### PR TITLE
fix(export): validate leaderboard constraint placeholders

### DIFF
--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -38,6 +38,28 @@ REQUIRED_CONSTRAINT_METRIC_KEYS = (
 )
 
 
+def _validate_constraints_metrics(constraints_metrics: dict[str, Any]) -> dict[str, Any]:
+    long_context_length = constraints_metrics.get("long_context_length")
+    if long_context_length is None:
+        return constraints_metrics
+
+    try:
+        normalized_length = int(long_context_length)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "constraints_metrics.long_context_length must be null or an integer >= 1"
+        ) from exc
+
+    if normalized_length < 1:
+        raise ValueError(
+            "constraints_metrics.long_context_length must be null or >= 1 "
+            "for website leaderboard compatibility"
+        )
+
+    constraints_metrics["long_context_length"] = normalized_length
+    return constraints_metrics
+
+
 def _load_metrics_payload(metrics_file: Path) -> dict[str, Any]:
     payload = json.loads(metrics_file.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -63,6 +85,8 @@ def _load_metrics_payload(metrics_file: Path) -> dict[str, Any]:
             + ", ".join(missing_constraints)
         )
 
+    _validate_constraints_metrics(constraints_metrics)
+
     return payload
 
 
@@ -79,7 +103,7 @@ def _load_constraints_metrics(constraints_file: Path) -> dict[str, Any]:
         raise ValueError(
             "constraints_metrics missing required keys: " + ", ".join(missing_constraints)
         )
-    return dict(constraints_metrics)
+    return _validate_constraints_metrics(dict(constraints_metrics))
 
 
 def _safe_float(value: Any) -> float | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -452,6 +452,78 @@ def test_export_leaderboard_artifact_from_raw_benchmark_result(tmp_path) -> None
     assert artifact["metadata"]["github_user"] == "benchmark-bot"
 
 
+def test_export_leaderboard_artifact_rejects_zero_long_context_length(
+    tmp_path: Path, capsys
+) -> None:
+    benchmark_result = tmp_path / "serve_result.json"
+    benchmark_result.write_text(
+        """
+{
+    "completed": 2,
+    "failed": 0,
+    "output_throughput": 10.0,
+    "mean_ttft_ms": 42.0
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    constraints_file = tmp_path / "constraints.json"
+    constraints_file.write_text(
+        """
+{
+    "single_chip_effective_utilization_pct": null,
+    "typical_throughput_ratio_vs_baseline": null,
+    "typical_ttft_reduction_pct_vs_baseline": null,
+    "typical_tpot_reduction_pct_vs_baseline": null,
+    "long_context_length": 0,
+    "long_context_throughput_stable": null,
+    "long_context_ttft_p95_ms": null,
+    "long_context_ttft_p99_ms": null,
+    "long_context_tpot_p95_ms": null,
+    "long_context_tpot_p99_ms": null,
+    "long_context_ttft_p95_stable": null,
+    "long_context_ttft_p99_stable": null,
+    "long_context_tpot_p95_stable": null,
+    "long_context_tpot_p99_stable": null,
+    "unit_token_cost_reduction_pct": null,
+    "multi_tenant_high_utilization": null
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "export-leaderboard-artifact",
+            "random-online",
+            "--benchmark-result-file",
+            str(benchmark_result),
+            "--constraints-file",
+            str(constraints_file),
+            "--output-dir",
+            str(tmp_path / "export_invalid"),
+            "--run-id",
+            "bad-run-1",
+            "--engine",
+            "vllm-ascend-hust",
+            "--engine-version",
+            "28568c22",
+            "--model-name",
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            "--hardware-chip-model",
+            "910B3",
+            "--submitter",
+            "ci",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "constraints_metrics.long_context_length must be null or >= 1" in captured.err
+
+
 
 def test_build_vllm_bench_command_prefers_console_script():
     with patch("vllm_hust_benchmark.integration.shutil.which", return_value="/fake/bin/vllm"):


### PR DESCRIPTION
Reject invalid long_context_length placeholder values before exporting leaderboard artifacts and add a regression test covering the old zero-value failure path.

## Summary

Describe what changed and why.

## Repository Scope

- [ ] `vllm-hust`
- [ ] `vllm-ascend-hust`
- [ ] `ascend-runtime-manager`
- [ ] `vllm-hust-dev-hub`
- [ ] `vllm-hust-benchmark`
- [ ] `vllm-hust-website`
- [ ] `vllm-hust-workstation`
- [ ] `vllm-hust-docs`
- [ ] `EvoScientist`
- [ ] other

## Validation

List the exact commands, workflows, smoke tests, or manual checks you ran.

## Risks

Call out any mergeability, hardware, deployment, CI, or compatibility risks.

## Checklist

- [ ] I removed or redacted secrets, tokens, and private endpoints.
- [ ] I updated docs if user-facing behavior changed.
- [ ] I noted the tests I ran, or clearly stated what I could not run.