### PR TITLE
feat: harden official ascend baseline runner flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Current baseline target:
 
 Files:
 
+- `scripts/prepare-official-ascend-baseline-env.sh`
 - `scripts/run-official-ascend-goal-baseline.sh`
 - `docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json`
 - `docs/official-baselines/official-ascend-constraints.stub.json`
@@ -182,10 +183,23 @@ Files:
 Example:
 
 ```bash
+export ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110
+bash scripts/prepare-official-ascend-baseline-env.sh
+
 export GOAL_BASELINE_ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110
 bash scripts/run-official-ascend-goal-baseline.sh \
 	docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
 ```
+
+Notes:
+
+- `prepare-official-ascend-baseline-env.sh` creates or repairs a dedicated conda env for the fixed official baseline only.
+- `prepare-official-ascend-baseline-env.sh` also owns the benchmark admission preflight: it proactively cleans residual `api_server` / `bench serve` / `EngineCore_DP0` processes and clears the benchmark port before a new run is allowed to start.
+- The baseline runtime is pinned to `reference-repos/vllm@v0.11.0` and `reference-repos/vllm-ascend@v0.11.0` worktrees.
+- The prepare script intentionally does not install `vllm-hust` or `vllm-ascend-hust` into the official env, to avoid plugin-entry-point contamination.
+- The runner executes against the pinned worktrees through `PYTHONPATH` and defaults `VLLM_CACHE_ROOT` to `.cache/official-ascend-goal-baseline/` in this repository.
+- The runner calls the same prepare script in admission-only mode immediately before benchmark startup, so residual-process cleanup is a hard precondition rather than a manual step.
+- The runner prefers a locally cached Hugging Face snapshot for the target model when one already exists. You can also force a specific local model directory with `OFFICIAL_MODEL_PATH=/abs/model/path`.
 
 This produces:
 

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
@@ -20,6 +20,7 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",
     "disable_log_requests": "",

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
+
+ENV_PREFIX=${ENV_PREFIX:-"/root/miniconda3/envs/vllm-ascend-official-v0110"}
+PYTHON_VERSION=${PYTHON_VERSION:-"3.11"}
+OFFICIAL_VLLM_REPO=${OFFICIAL_VLLM_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm"}
+OFFICIAL_VLLM_ASCEND_REPO=${OFFICIAL_VLLM_ASCEND_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm-ascend"}
+OFFICIAL_VLLM_WORKTREE=${OFFICIAL_VLLM_WORKTREE:-"/tmp/vllm-v0110"}
+OFFICIAL_VLLM_ASCEND_WORKTREE=${OFFICIAL_VLLM_ASCEND_WORKTREE:-"/tmp/vllm-ascend-v0110"}
+OFFICIAL_VLLM_REF=${OFFICIAL_VLLM_REF:-"v0.11.0"}
+OFFICIAL_VLLM_ASCEND_REF=${OFFICIAL_VLLM_ASCEND_REF:-"v0.11.0"}
+BENCHMARK_SERVER_PORT=${BENCHMARK_SERVER_PORT:-"8000"}
+PREPARE_BENCHMARK_ADMISSION_ONLY=${PREPARE_BENCHMARK_ADMISSION_ONLY:-"0"}
+ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
+ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
+ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
+EXTRA_PYPI_INDEX=${EXTRA_PYPI_INDEX:-"https://mirrors.huaweicloud.com/ascend/repos/pypi"}
+
+export ENV_PREFIX
+
+ensure_worktree() {
+  local source_repo=$1
+  local target_dir=$2
+  local ref_name=$3
+  if [[ -f "$target_dir/pyproject.toml" ]]; then
+    return 0
+  fi
+  git -C "$source_repo" worktree add --detach "$target_dir" "$ref_name"
+}
+
+run_with_ascend_env() {
+  export ZSH_VERSION=""
+  if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
+    # shellcheck disable=SC1090
+    source "$ASCEND_TOOLKIT_SET_ENV"
+  fi
+  if [[ -f "$ASCEND_ATB_SET_ENV" ]]; then
+    set +u
+    # shellcheck disable=SC1090
+    source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
+    set -u
+  fi
+  "$@"
+}
+
+list_benchmark_residual_pids() {
+  ps -eo pid=,args= | awk '
+    /vllm\.entrypoints\.openai\.api_server|vllm\.entrypoints\.cli\.main bench serve|EngineCore_DP0/ && !/awk/ {
+      print $1
+    }
+  ' | sort -u
+}
+
+cleanup_benchmark_residual_processes() {
+  local pids
+  pids=$(list_benchmark_residual_pids)
+
+  if [[ -n "$pids" ]]; then
+    echo "[official-env] cleaning residual benchmark processes: $pids"
+    kill $pids 2>/dev/null || true
+
+    local pid
+    for pid in $pids; do
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+    done
+  fi
+
+  if command -v fuser >/dev/null 2>&1; then
+    local port_pids
+    port_pids=$(fuser "${BENCHMARK_SERVER_PORT}/tcp" 2>/dev/null || true)
+    if [[ -n "$port_pids" ]]; then
+      echo "[official-env] cleaning residual port ${BENCHMARK_SERVER_PORT} holders: $port_pids"
+      kill $port_pids 2>/dev/null || true
+      for pid in $port_pids; do
+        if kill -0 "$pid" 2>/dev/null; then
+          kill -9 "$pid" 2>/dev/null || true
+        fi
+      done
+    fi
+  fi
+
+  if command -v fuser >/dev/null 2>&1; then
+    if fuser "${BENCHMARK_SERVER_PORT}/tcp" >/dev/null 2>&1; then
+      echo "Port ${BENCHMARK_SERVER_PORT} is still occupied after cleanup" >&2
+      return 1
+    fi
+  fi
+
+  if [[ -n "$(list_benchmark_residual_pids)" ]]; then
+    echo "Residual benchmark processes still exist after cleanup" >&2
+    return 1
+  fi
+
+  echo "[official-env] benchmark admission preflight passed: no residual benchmark processes"
+}
+
+if ! command -v conda >/dev/null 2>&1; then
+  echo "conda is required" >&2
+  exit 2
+fi
+
+if [[ ! -d "$OFFICIAL_VLLM_REPO/.git" ]]; then
+  echo "Official vllm repo not found: $OFFICIAL_VLLM_REPO" >&2
+  exit 2
+fi
+
+if [[ ! -d "$OFFICIAL_VLLM_ASCEND_REPO/.git" ]]; then
+  echo "Official vllm-ascend repo not found: $OFFICIAL_VLLM_ASCEND_REPO" >&2
+  exit 2
+fi
+
+cleanup_benchmark_residual_processes
+
+if [[ "$PREPARE_BENCHMARK_ADMISSION_ONLY" == "1" ]]; then
+  echo "[official-env] admission-only mode completed"
+  exit 0
+fi
+
+ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_VLLM_REF"
+ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_VLLM_ASCEND_REF"
+
+if [[ ! -d "$ENV_PREFIX" ]]; then
+  conda create -y -p "$ENV_PREFIX" "python=$PYTHON_VERSION" pip
+fi
+
+run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip uninstall -y \
+  vllm \
+  vllm-ascend \
+  vllm_ascend \
+  vllm-hust \
+  vllm-ascend-hust \
+  torch \
+  torch-npu \
+  torch_npu \
+  torchvision \
+  torchaudio \
+  compressed-tensors \
+  depyf \
+  llguidance \
+  xgrammar \
+  fastapi \
+  numba || true
+
+run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall \
+  "setuptools>=77.0.3,<80.0.0"
+
+run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall \
+  --extra-index-url "$EXTRA_PYPI_INDEX" \
+  torch==2.7.1 \
+  torch-npu==2.7.1 \
+  torchvision==0.22.1 \
+  torchaudio==2.7.1
+
+run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall \
+  -r "$OFFICIAL_VLLM_WORKTREE/requirements/common.txt" \
+  -r "$OFFICIAL_VLLM_ASCEND_WORKTREE/requirements.txt" \
+  -r "$OFFICIAL_VLLM_ASCEND_WORKTREE/benchmarks/requirements-bench.txt" \
+  "setuptools>=77.0.3,<80.0.0" \
+  torch==2.7.1 \
+  torch-npu==2.7.1 \
+  torchvision==0.22.1 \
+  torchaudio==2.7.1 \
+  numpy==1.26.4 \
+  transformers==4.57.1 \
+  compressed-tensors==0.11.0 \
+  depyf==0.19.0 \
+  llguidance==0.7.30 \
+  xgrammar==0.1.25 \
+  fastapi==0.123.10 \
+  numba==0.61.2 \
+  opencv-python-headless==4.11.0.86
+
+run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall --no-deps \
+  "setuptools>=77.0.3,<80.0.0" \
+  torch==2.7.1 \
+  torch-npu==2.7.1 \
+  torchvision==0.22.1 \
+  torchaudio==2.7.1 \
+  numpy==1.26.4 \
+  transformers==4.57.1 \
+  compressed-tensors==0.11.0 \
+  depyf==0.19.0 \
+  llguidance==0.7.30 \
+  xgrammar==0.1.25 \
+  fastapi==0.123.10 \
+  numba==0.61.2
+
+PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE${PYTHONPATH:+:$PYTHONPATH}" \
+  run_with_ascend_env conda run -p "$ENV_PREFIX" python - <<'PY'
+import os
+from importlib import metadata
+from importlib.metadata import entry_points
+
+import torch
+import torch_npu
+import vllm
+import vllm_ascend
+
+print(f"env_prefix={os.environ['ENV_PREFIX']}")
+print(f"torch={torch.__version__}")
+print(f"torch_npu={torch_npu.__version__}")
+print(f"vllm_file={vllm.__file__}")
+print(f"vllm_ascend_file={vllm_ascend.__file__}")
+print(f"setuptools={metadata.version('setuptools')}")
+print(f"compressed_tensors={metadata.version('compressed-tensors')}")
+print(f"depyf={metadata.version('depyf')}")
+print(f"llguidance={metadata.version('llguidance')}")
+print(f"xgrammar={metadata.version('xgrammar')}")
+print(f"fastapi={metadata.version('fastapi')}")
+print(f"numba={metadata.version('numba')}")
+print(f"transformers={metadata.version('transformers')}")
+print(f"numpy={metadata.version('numpy')}")
+print("platform_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group='vllm.platform_plugins'))))
+print("general_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group='vllm.general_plugins'))))
+PY
+
+echo "Prepared official Ascend baseline env at $ENV_PREFIX"
+echo "Pinned runtime source refs: vllm=$OFFICIAL_VLLM_REF vllm-ascend=$OFFICIAL_VLLM_ASCEND_REF"
+echo "Use with: GOAL_BASELINE_ENV_PREFIX=$ENV_PREFIX bash $REPO_ROOT/scripts/run-official-ascend-goal-baseline.sh"

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+PREPARE_SCRIPT=${PREPARE_SCRIPT:-"$REPO_ROOT/scripts/prepare-official-ascend-baseline-env.sh"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
@@ -10,6 +11,12 @@ OFFICIAL_VLLM_REPO=${OFFICIAL_VLLM_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm"}
 OFFICIAL_VLLM_ASCEND_REPO=${OFFICIAL_VLLM_ASCEND_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm-ascend"}
 OFFICIAL_VLLM_WORKTREE=${OFFICIAL_VLLM_WORKTREE:-"/tmp/vllm-v0110"}
 OFFICIAL_VLLM_ASCEND_WORKTREE=${OFFICIAL_VLLM_ASCEND_WORKTREE:-"/tmp/vllm-ascend-v0110"}
+OFFICIAL_RUNTIME_CWD=${OFFICIAL_RUNTIME_CWD:-"/tmp"}
+OFFICIAL_VLLM_CACHE_ROOT=${OFFICIAL_VLLM_CACHE_ROOT:-"$REPO_ROOT/.cache/official-ascend-goal-baseline"}
+OFFICIAL_MODEL_PATH=${OFFICIAL_MODEL_PATH:-}
+ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
+ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
+ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
 GOAL_BASELINE_ENV_PREFIX=${GOAL_BASELINE_ENV_PREFIX:-}
 RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/official-ascend-goal-baseline"}
 RUN_ID=${RUN_ID:-"official-ascend-jan-2026-$(date -u +%Y%m%dT%H%M%SZ)"}
@@ -34,6 +41,64 @@ if [[ ! -d "$REPO_ROOT/src" ]]; then
   exit 2
 fi
 
+if [[ ! -f "$PREPARE_SCRIPT" ]]; then
+  echo "Prepare script not found: $PREPARE_SCRIPT" >&2
+  exit 2
+fi
+
+run_in_official_runtime() {
+  local pythonpath_prefix=$1
+  shift
+  (
+    cd "$OFFICIAL_RUNTIME_CWD"
+    export ZSH_VERSION=""
+    if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
+      # shellcheck disable=SC1090
+      source "$ASCEND_TOOLKIT_SET_ENV"
+    fi
+    if [[ -f "$ASCEND_ATB_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
+      set -u
+    fi
+    export VLLM_CACHE_ROOT="$OFFICIAL_VLLM_CACHE_ROOT"
+    PYTHONPATH="$pythonpath_prefix${PYTHONPATH:+:$PYTHONPATH}" \
+      conda run -p "$GOAL_BASELINE_ENV_PREFIX" "$@"
+  )
+}
+
+run_server_command() {
+  (
+    cd "$OFFICIAL_RUNTIME_CWD"
+    export ZSH_VERSION=""
+    if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
+      # shellcheck disable=SC1090
+      source "$ASCEND_TOOLKIT_SET_ENV"
+    fi
+    if [[ -f "$ASCEND_ATB_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
+      set -u
+    fi
+    export VLLM_CACHE_ROOT="$OFFICIAL_VLLM_CACHE_ROOT"
+    PYTHONUNBUFFERED=1 \
+      PYTHONPATH="$OFFICIAL_RUNTIME_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
+      conda run --no-capture-output -p "$GOAL_BASELINE_ENV_PREFIX" \
+      python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS
+  )
+}
+
+run_client_command() {
+  run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
+    python -m vllm.entrypoints.cli.main bench serve \
+    --save-result \
+    --result-dir "$RESULT_DIR" \
+    --result-filename "$(basename "$RAW_RESULT_FILE")" \
+    $CLIENT_ARGS
+}
+
 ensure_worktree() {
   local source_repo=$1
   local target_dir=$2
@@ -53,6 +118,18 @@ json2args() {
   '
 }
 
+resolve_runtime_model() {
+  if [[ -n "$OFFICIAL_MODEL_PATH" ]]; then
+    echo "$OFFICIAL_MODEL_PATH"
+    return 0
+  fi
+
+  run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
+    env MODEL_ID="$MODEL" \
+    python -c "import os; from huggingface_hub import snapshot_download; print(snapshot_download(os.environ['MODEL_ID'], local_files_only=True))" \
+    2>/dev/null || return 1
+}
+
 wait_for_server() {
   local host=$1
   local port=$2
@@ -64,7 +141,7 @@ wait_for_server() {
       return 0
     fi
     sleep 1
-    ((waited++))
+    ((waited += 1))
   done
 
   echo "Timed out waiting for official baseline server at ${host}:${port}" >&2
@@ -83,7 +160,10 @@ trap kill_server EXIT
 ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "v0.11.0"
 ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "v0.11.0"
 
+OFFICIAL_RUNTIME_PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE"
+
 mkdir -p "$RESULT_DIR"
+mkdir -p "$OFFICIAL_VLLM_CACHE_ROOT"
 
 SCENARIO=$(jq -r '.scenario' "$SPEC_FILE")
 MODEL=$(jq -r '.model' "$SPEC_FILE")
@@ -108,27 +188,77 @@ CLIENT_PORT=$(jq -r '.client_parameters.port' "$SPEC_FILE")
 INPUT_LEN=$(jq -r '.client_parameters.input_len' "$SPEC_FILE")
 OUTPUT_LEN=$(jq -r '.client_parameters.output_len' "$SPEC_FILE")
 
-SERVER_ARGS=$(json2args "$(jq -c --arg model "$MODEL" '.server_parameters + {model: $model}' "$SPEC_FILE")")
-CLIENT_ARGS=$(json2args "$(jq -c --arg model "$MODEL" '.client_parameters + {model: $model}' "$SPEC_FILE")")
+BENCHMARK_SERVER_PORT="$SERVER_PORT" \
+PREPARE_BENCHMARK_ADMISSION_ONLY=1 \
+ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
+VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
+bash "$PREPARE_SCRIPT"
+
+RUNTIME_MODEL="$MODEL"
+if cached_model_path=$(resolve_runtime_model); then
+  RUNTIME_MODEL="$cached_model_path"
+fi
+
+SERVER_ARGS=$(json2args "$(jq -c --arg model "$RUNTIME_MODEL" '
+  .server_parameters + {model: $model}
+  | if has("enforce_eager") then . else . + {enforce_eager: ""} end
+' "$SPEC_FILE")")
+CLIENT_ARGS=$(json2args "$(jq -c --arg model "$RUNTIME_MODEL" '
+  .client_parameters + {model: $model}
+  | if .dataset_name == "random" then
+      (if has("input_len") then . + {random_input_len: .input_len} | del(.input_len) else . end)
+      | (if has("output_len") then . + {random_output_len: .output_len} | del(.output_len) else . end)
+    else
+      .
+    end
+' "$SPEC_FILE")")
 
 RAW_RESULT_FILE="$RESULT_DIR/raw_benchmark_result.json"
 ARTIFACT_DIR="$RESULT_DIR/submission"
 
-SERVER_COMMAND="conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.openai.api_server $SERVER_ARGS"
-CLIENT_COMMAND="conda run -p $GOAL_BASELINE_ENV_PREFIX vllm bench serve --save-result --result-dir $RESULT_DIR --result-filename $(basename "$RAW_RESULT_FILE") $CLIENT_ARGS"
+SERVER_COMMAND="PYTHONUNBUFFERED=1 PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run --no-capture-output -p $GOAL_BASELINE_ENV_PREFIX python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS"
+CLIENT_COMMAND="PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.cli.main bench serve --save-result --result-dir $RESULT_DIR --result-filename $(basename "$RAW_RESULT_FILE") $CLIENT_ARGS"
 
 echo "[goal-baseline] using worktrees: $OFFICIAL_VLLM_WORKTREE and $OFFICIAL_VLLM_ASCEND_WORKTREE"
+echo "[goal-baseline] neutral cwd: $OFFICIAL_RUNTIME_CWD"
+echo "[goal-baseline] vllm cache root: $OFFICIAL_VLLM_CACHE_ROOT"
+echo "[goal-baseline] export model id: $MODEL"
+echo "[goal-baseline] runtime model source: $RUNTIME_MODEL"
+run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" python - <<'PY'
+from importlib import metadata
+
+import vllm
+import vllm_ascend
+
+
+def dist_version(*names: str) -> str:
+  for name in names:
+    try:
+      return metadata.version(name)
+    except metadata.PackageNotFoundError:
+      continue
+  return "not-installed"
+
+
+print(f"[goal-baseline] vllm module: {vllm.__file__}")
+print(f"[goal-baseline] vllm version: {getattr(vllm, '__version__', 'unknown')} (dist={dist_version('vllm')})")
+print(f"[goal-baseline] vllm_ascend module: {vllm_ascend.__file__}")
+print(
+  "[goal-baseline] vllm_ascend version: "
+  f"{getattr(vllm_ascend, '__version__', 'unknown')} "
+  f"(dist={dist_version('vllm-ascend', 'vllm_ascend')})"
+)
+PY
 echo "[goal-baseline] server command: $SERVER_COMMAND"
-bash -lc "$SERVER_COMMAND" &
+run_server_command &
 SERVER_PID=$!
 
 wait_for_server "$CLIENT_HOST" "$CLIENT_PORT"
 
 echo "[goal-baseline] client command: $CLIENT_COMMAND"
-bash -lc "$CLIENT_COMMAND"
+run_client_command
 
-PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
-conda run -p "$GOAL_BASELINE_ENV_PREFIX" \
+run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" \
 python -m vllm_hust_benchmark.cli export-leaderboard-artifact \
   "$SCENARIO" \
   --benchmark-result-file "$RAW_RESULT_FILE" \

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -160,6 +160,24 @@ def build_vllm_command(
     return [sys.executable, "-m", "vllm.entrypoints.cli.main", *command_args]
 
 
+def _resolve_flag_discovery_cwd(
+    layout: RepoLayout,
+    *,
+    runtime_engine: str = DEFAULT_RUNTIME_ENGINE,
+    runtime_repo: str | None = None,
+) -> Path:
+    candidate = (
+        Path(runtime_repo).resolve()
+        if runtime_repo
+        else resolve_runtime_repo(layout, runtime_engine)
+    )
+    if candidate.is_dir():
+        return candidate
+    if layout.benchmark_repo.is_dir():
+        return layout.benchmark_repo
+    return Path.cwd().resolve()
+
+
 @lru_cache(maxsize=8)
 def discover_vllm_flags(
     *command_parts: str,
@@ -171,7 +189,11 @@ def discover_vllm_flags(
         runtime_engine=runtime_engine,
     )
     layout = resolve_repo_layout()
-    cwd = Path(runtime_repo).resolve() if runtime_repo else resolve_runtime_repo(layout, runtime_engine)
+    cwd = _resolve_flag_discovery_cwd(
+        layout,
+        runtime_engine=runtime_engine,
+        runtime_repo=runtime_repo,
+    )
     completed = subprocess.run(
         help_command,
         check=False,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,6 +145,45 @@ def test_discover_vllm_flags_falls_back_for_bench_serve(monkeypatch) -> None:
     integration.discover_vllm_flags.cache_clear()
 
 
+def test_discover_vllm_flags_falls_back_to_benchmark_repo_cwd(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    benchmark_repo = tmp_path / "vllm-hust-benchmark"
+    benchmark_repo.mkdir()
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=benchmark_repo,
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=tmp_path / "vllm-hust-website",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["cwd"] = kwargs["cwd"]
+        captured["env"] = kwargs["env"]
+
+        class Result:
+            returncode = 0
+            stdout = "  --dataset-name DATASET_NAME\n  --num-prompts NUM_PROMPTS\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(integration, "resolve_repo_layout", lambda: layout)
+    monkeypatch.setattr(integration.shutil, "which", lambda name: None)
+    monkeypatch.setattr(integration.subprocess, "run", fake_run)
+    integration.discover_vllm_flags.cache_clear()
+
+    flags = integration.discover_vllm_flags("bench", "serve")
+
+    assert flags == frozenset({"dataset_name", "num_prompts"})
+    assert captured["cwd"] == benchmark_repo
+    assert str(benchmark_repo) in str(captured["env"]["PYTHONPATH"])
+    integration.discover_vllm_flags.cache_clear()
+
+
 def test_build_performance_suite_command(tmp_path: Path) -> None:
     layout = RepoLayout(
         workspace_root=tmp_path,


### PR DESCRIPTION
## Summary
- add a repository-owned `prepare-official-ascend-baseline-env.sh` script for the fixed official Ascend baseline environment
- harden the official benchmark runner to use pinned `vllm@v0.11.0` and `vllm-ascend@v0.11.0` worktrees, a repository-local cache root, and locally cached model snapshot reuse
- make residual `api_server` / `bench serve` / `EngineCore_DP0` cleanup a hard benchmark admission preflight before startup
- update the official baseline spec and README to reflect the validated flow

## Repository Scope
- [ ] `vllm-hust`
- [ ] `vllm-ascend-hust`
- [ ] `ascend-runtime-manager`
- [ ] `vllm-hust-dev-hub`
- [x] `vllm-hust-benchmark`
- [ ] `vllm-hust-website`
- [ ] `vllm-hust-workstation`
- [ ] `vllm-hust-docs`
- [ ] `EvoScientist`
- [ ] other

## Validation
- `bash -n scripts/prepare-official-ascend-baseline-env.sh && bash -n scripts/run-official-ascend-goal-baseline.sh`
- `PREPARE_BENCHMARK_ADMISSION_ONLY=1 ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110-fresh BENCHMARK_SERVER_PORT=8000 bash scripts/prepare-official-ascend-baseline-env.sh`
- `ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110-fresh bash scripts/prepare-official-ascend-baseline-env.sh`
- `ASCEND_RT_VISIBLE_DEVICES=2 GOAL_BASELINE_ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110-fresh RESULT_DIR=/workspace/vllm-hust-benchmark/.benchmarks/official-ascend-goal-baseline-fresh-20260507T-run4 bash scripts/run-official-ascend-goal-baseline.sh docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json`
- validated exported outputs under `/workspace/vllm-hust-benchmark/.benchmarks/official-ascend-goal-baseline-fresh-20260507T-run4/`

## Risks
- depends on local Hugging Face model cache or `OFFICIAL_MODEL_PATH` when external network is unavailable
- requires Ascend toolkit and ATB environment scripts plus a free benchmark device/port
- repository-local `.cache/` state is intentionally not part of this PR

## Checklist
- [x] I removed or redacted secrets, tokens, and private endpoints.
- [x] I updated docs if user-facing behavior changed.
- [x] I noted the tests I ran, or clearly stated what I could not run.