### PR TITLE
[BugFix][Benchmark] Materialize same-spec artifacts and harden runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to vllm-hust-benchmark will be documented in this file.
+
+The format is based on Keep a Changelog, and this project aims to keep
+Unreleased entries concise and workflow-focused.
+
+## [Unreleased]
+
+### Added
+- Added a shared same-spec resolver in `src/vllm_hust_benchmark/same_spec.py` so
+  official baseline runs and current runs now materialize server/client
+  parameters from the same benchmark spec instead of duplicating shell-side
+  resolution logic.
+- Added `scripts/run-current-ascend-same-spec.sh` to run the current
+  `vllm-hust` plus `vllm-ascend-hust` stack against the official Ascend Jan 2026
+  benchmark spec while preferring the `vllm-hust-dev` environment Python and the
+  local workspace source trees.
+
+### Changed
+- Updated `scripts/run-official-ascend-goal-baseline.sh` to resolve runtime
+  parameters through the shared same-spec payload before launching the official
+  `v0.11.0` baseline.
+- Hardened the official and current same-spec runners with managed server
+  lifecycle state, startup lock files, and stale-server reclamation so reruns
+  can stop their own leftover benchmark services before restarting, while still
+  refusing to kill unrelated listeners.
+- Extended leaderboard export to persist same-spec metadata
+  (`spec_id` / `resolved_spec_hash` / resolved runtime parameters) together with
+  runtime provenance for both the engine repo and the Ascend plugin repo, so
+  exported artifacts remain auditable after publication.
+- Added regression coverage for same-spec resolution, artifact export metadata,
+  and runtime provenance propagation.

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -47,6 +47,24 @@ run_with_ascend_env() {
   "$@"
 }
 
+list_port_listener_pids() {
+  local port=$1
+
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>/dev/null | grep -E ":${port}[[:space:]]" | grep -o 'pid=[0-9]*' | cut -d= -f2 | sort -u || true
+    return 0
+  fi
+
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti tcp:"$port" -sTCP:LISTEN 2>/dev/null | sort -u || true
+    return 0
+  fi
+
+  if command -v fuser >/dev/null 2>&1; then
+    fuser "${port}/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u || true
+  fi
+}
+
 list_benchmark_residual_pids() {
   ps -eo pid=,args= | awk '
     /vllm\.entrypoints\.openai\.api_server|vllm\.entrypoints\.cli\.main bench serve|EngineCore_DP0/ && !/awk/ {
@@ -56,6 +74,23 @@ list_benchmark_residual_pids() {
 }
 
 cleanup_benchmark_residual_processes() {
+  if [[ "$PREPARE_BENCHMARK_ADMISSION_ONLY" == "1" ]]; then
+    local port_pids
+    port_pids=$(list_port_listener_pids "$BENCHMARK_SERVER_PORT")
+    if [[ -n "$port_pids" ]]; then
+      echo "Port ${BENCHMARK_SERVER_PORT} is already occupied by listening processes: $port_pids" >&2
+      return 1
+    fi
+
+    if [[ -n "$(list_benchmark_residual_pids)" ]]; then
+      echo "Residual benchmark processes still exist during admission check" >&2
+      return 1
+    fi
+
+    echo "[official-env] benchmark admission preflight passed: no residual benchmark processes"
+    return 0
+  fi
+
   local pids
   pids=$(list_benchmark_residual_pids)
 
@@ -71,25 +106,11 @@ cleanup_benchmark_residual_processes() {
     done
   fi
 
-  if command -v fuser >/dev/null 2>&1; then
-    local port_pids
-    port_pids=$(fuser "${BENCHMARK_SERVER_PORT}/tcp" 2>/dev/null || true)
-    if [[ -n "$port_pids" ]]; then
-      echo "[official-env] cleaning residual port ${BENCHMARK_SERVER_PORT} holders: $port_pids"
-      kill $port_pids 2>/dev/null || true
-      for pid in $port_pids; do
-        if kill -0 "$pid" 2>/dev/null; then
-          kill -9 "$pid" 2>/dev/null || true
-        fi
-      done
-    fi
-  fi
-
-  if command -v fuser >/dev/null 2>&1; then
-    if fuser "${BENCHMARK_SERVER_PORT}/tcp" >/dev/null 2>&1; then
-      echo "Port ${BENCHMARK_SERVER_PORT} is still occupied after cleanup" >&2
-      return 1
-    fi
+  local port_pids
+  port_pids=$(list_port_listener_pids "$BENCHMARK_SERVER_PORT")
+  if [[ -n "$port_pids" ]]; then
+    echo "Port ${BENCHMARK_SERVER_PORT} is already occupied by listening processes: $port_pids" >&2
+    return 1
   fi
 
   if [[ -n "$(list_benchmark_residual_pids)" ]]; then

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -3,32 +3,50 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
-PREPARE_SCRIPT=${PREPARE_SCRIPT:-"$REPO_ROOT/scripts/prepare-official-ascend-baseline-env.sh"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
-OFFICIAL_VLLM_REPO=${OFFICIAL_VLLM_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm"}
-OFFICIAL_VLLM_ASCEND_REPO=${OFFICIAL_VLLM_ASCEND_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm-ascend"}
-OFFICIAL_VLLM_WORKTREE=${OFFICIAL_VLLM_WORKTREE:-"/tmp/vllm-v0110"}
-OFFICIAL_VLLM_ASCEND_WORKTREE=${OFFICIAL_VLLM_ASCEND_WORKTREE:-"/tmp/vllm-ascend-v0110"}
-OFFICIAL_RUNTIME_CWD=${OFFICIAL_RUNTIME_CWD:-"/tmp"}
-OFFICIAL_VLLM_CACHE_ROOT=${OFFICIAL_VLLM_CACHE_ROOT:-"$REPO_ROOT/.cache/official-ascend-goal-baseline"}
-OFFICIAL_MODEL_PATH=${OFFICIAL_MODEL_PATH:-}
-OFFICIAL_SERVER_HOST=${OFFICIAL_SERVER_HOST:-}
-OFFICIAL_SERVER_PORT=${OFFICIAL_SERVER_PORT:-"8000"}
-OFFICIAL_CLIENT_HOST=${OFFICIAL_CLIENT_HOST:-}
-OFFICIAL_CLIENT_PORT=${OFFICIAL_CLIENT_PORT:-$OFFICIAL_SERVER_PORT}
+CURRENT_RUNTIME_CWD=${CURRENT_RUNTIME_CWD:-"/tmp"}
+CURRENT_VLLM_HUST_REPO=${CURRENT_VLLM_HUST_REPO:-"$WORKSPACE_ROOT/vllm-hust"}
+CURRENT_VLLM_ASCEND_HUST_REPO=${CURRENT_VLLM_ASCEND_HUST_REPO:-"$WORKSPACE_ROOT/vllm-ascend-hust"}
+CURRENT_RUNTIME_PYTHONPATH=${CURRENT_RUNTIME_PYTHONPATH:-}
+CURRENT_ENV_PREFIX=${CURRENT_ENV_PREFIX:-"/root/miniconda3/envs/vllm-hust-dev"}
+CURRENT_RUNTIME_PYTHON=${CURRENT_RUNTIME_PYTHON:-"$CURRENT_ENV_PREFIX/bin/python"}
+CURRENT_VLLM_CACHE_ROOT=${CURRENT_VLLM_CACHE_ROOT:-"$REPO_ROOT/.cache/current-ascend-same-spec"}
+CURRENT_MODEL_PATH=${CURRENT_MODEL_PATH:-}
+CURRENT_SERVER_HOST=${CURRENT_SERVER_HOST:-}
+CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-"8001"}
+CURRENT_CLIENT_HOST=${CURRENT_CLIENT_HOST:-}
+CURRENT_CLIENT_PORT=${CURRENT_CLIENT_PORT:-$CURRENT_SERVER_PORT}
+CURRENT_ENGINE=${CURRENT_ENGINE:-"vllm-hust"}
+CURRENT_ENGINE_VERSION=${CURRENT_ENGINE_VERSION:-}
+CURRENT_SUBMITTER=${CURRENT_SUBMITTER:-"same-spec-current"}
+CURRENT_BASELINE_ENGINE=${CURRENT_BASELINE_ENGINE:-"vllm"}
+CURRENT_DATA_SOURCE=${CURRENT_DATA_SOURCE:-"vllm-hust-benchmark"}
+CURRENT_GITHUB_REPOSITORY=${CURRENT_GITHUB_REPOSITORY:-"vLLM-HUST/vllm-hust"}
+CURRENT_GITHUB_REF=${CURRENT_GITHUB_REF:-$(git -C "$CURRENT_VLLM_HUST_REPO" branch --show-current 2>/dev/null || echo main)}
+CURRENT_GIT_COMMIT=${CURRENT_GIT_COMMIT:-$(git -C "$CURRENT_VLLM_HUST_REPO" rev-parse HEAD 2>/dev/null || true)}
+CURRENT_PLUGIN_ENGINE=${CURRENT_PLUGIN_ENGINE:-"vllm-ascend-hust"}
+CURRENT_PLUGIN_GITHUB_REPOSITORY=${CURRENT_PLUGIN_GITHUB_REPOSITORY:-"vLLM-HUST/vllm-ascend-hust"}
+CURRENT_PLUGIN_GITHUB_REF=${CURRENT_PLUGIN_GITHUB_REF:-$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" branch --show-current 2>/dev/null || echo main)}
+CURRENT_PLUGIN_GIT_COMMIT=${CURRENT_PLUGIN_GIT_COMMIT:-$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" rev-parse HEAD 2>/dev/null || true)}
 ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
 ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
 ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
-GOAL_BASELINE_ENV_PREFIX=${GOAL_BASELINE_ENV_PREFIX:-}
-RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/official-ascend-goal-baseline"}
-RUN_ID=${RUN_ID:-"official-ascend-jan-2026-$(date -u +%Y%m%dT%H%M%SZ)"}
+RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/current-ascend-same-spec"}
+RUN_ID=${RUN_ID:-"current-ascend-same-spec-$(date -u +%Y%m%dT%H%M%SZ)"}
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
-if [[ -z "$GOAL_BASELINE_ENV_PREFIX" ]]; then
-  echo "GOAL_BASELINE_ENV_PREFIX is required" >&2
+CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_ASCEND_HUST_REPO:$CURRENT_VLLM_HUST_REPO"
+if [[ -n "$CURRENT_RUNTIME_PYTHONPATH" ]]; then
+  CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH:$CURRENT_RUNTIME_PYTHONPATH"
+else
+  CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH"
+fi
+
+if [[ ! -x "$CURRENT_RUNTIME_PYTHON" ]]; then
+  echo "CURRENT_RUNTIME_PYTHON is not executable: $CURRENT_RUNTIME_PYTHON" >&2
   exit 2
 fi
 
@@ -39,16 +57,6 @@ fi
 
 if [[ ! -f "$CONSTRAINTS_FILE" ]]; then
   echo "Constraints stub not found: $CONSTRAINTS_FILE" >&2
-  exit 2
-fi
-
-if [[ ! -d "$REPO_ROOT/src" ]]; then
-  echo "Benchmark repo not found: $REPO_ROOT" >&2
-  exit 2
-fi
-
-if [[ ! -f "$PREPARE_SCRIPT" ]]; then
-  echo "Prepare script not found: $PREPARE_SCRIPT" >&2
   exit 2
 fi
 
@@ -125,7 +133,7 @@ terminate_pid_tree() {
   [[ -z "$tree_pids" ]] && return 0
   tree_list=$(echo "$tree_pids" | tr '\n' ' ')
 
-  echo "[goal-baseline] stopping ${description}: ${tree_list}"
+  echo "[same-spec-current] stopping ${description}: ${tree_list}"
   kill $tree_list 2>/dev/null || true
 
   for attempt in $(seq 1 10); do
@@ -151,7 +159,7 @@ acquire_runner_lock() {
   mkdir -p "$RUNNER_STATE_DIR"
   exec {RUNNER_LOCK_FD}>"$RUNNER_LOCK_FILE"
   if ! flock -n "$RUNNER_LOCK_FD"; then
-    echo "Another official baseline run is already active for $RESULT_DIR" >&2
+    echo "Another current same-spec benchmark run is already active for $RESULT_DIR" >&2
     exit 1
   fi
 }
@@ -194,9 +202,9 @@ cleanup_managed_server() {
     while IFS= read -r pid; do
       [[ -z "$pid" ]] && continue
       if [[ -n "$managed_port" ]] && is_server_process_for_port "$pid" "$managed_port"; then
-        terminate_pid_tree "$pid" "managed official baseline server"
+        terminate_pid_tree "$pid" "managed current same-spec server"
       elif is_managed_wrapper_process "$pid"; then
-        terminate_pid_tree "$pid" "managed official baseline wrapper"
+        terminate_pid_tree "$pid" "managed current same-spec wrapper"
       fi
     done <<< "$candidate_pids"
   fi
@@ -207,17 +215,17 @@ cleanup_managed_server() {
     local remaining_pids
     remaining_pids=$(list_port_listener_pids "$managed_port")
     if [[ -n "$remaining_pids" ]]; then
-      echo "Managed official baseline port ${managed_port} is still occupied after cleanup: $remaining_pids" >&2
+      echo "Managed current same-spec port ${managed_port} is still occupied after cleanup: $remaining_pids" >&2
       return 1
     fi
   fi
 }
 
-run_in_official_runtime() {
+run_in_current_runtime() {
   local pythonpath_prefix=$1
   shift
   (
-    cd "$OFFICIAL_RUNTIME_CWD"
+    cd "$CURRENT_RUNTIME_CWD"
     export ZSH_VERSION=""
     if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
       # shellcheck disable=SC1090
@@ -229,15 +237,15 @@ run_in_official_runtime() {
       source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
       set -u
     fi
-    export VLLM_CACHE_ROOT="$OFFICIAL_VLLM_CACHE_ROOT"
+    export VLLM_CACHE_ROOT="$CURRENT_VLLM_CACHE_ROOT"
     PYTHONPATH="$pythonpath_prefix${PYTHONPATH:+:$PYTHONPATH}" \
-      conda run -p "$GOAL_BASELINE_ENV_PREFIX" "$@"
+      "$@"
   )
 }
 
 run_server_command() {
   (
-    cd "$OFFICIAL_RUNTIME_CWD"
+    cd "$CURRENT_RUNTIME_CWD"
     export ZSH_VERSION=""
     if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
       # shellcheck disable=SC1090
@@ -249,41 +257,61 @@ run_server_command() {
       source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
       set -u
     fi
-    export VLLM_CACHE_ROOT="$OFFICIAL_VLLM_CACHE_ROOT"
+    export VLLM_CACHE_ROOT="$CURRENT_VLLM_CACHE_ROOT"
     PYTHONUNBUFFERED=1 \
-      PYTHONPATH="$OFFICIAL_RUNTIME_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
-      conda run --no-capture-output -p "$GOAL_BASELINE_ENV_PREFIX" \
-      python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS
+      PYTHONPATH="$CURRENT_RUNTIME_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
+      "$CURRENT_RUNTIME_PYTHON" -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS
   )
 }
 
 run_client_command() {
-  run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
-    python -m vllm.entrypoints.cli.main bench serve \
+  run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" -m vllm.entrypoints.cli.main bench serve \
     --save-result \
     --result-dir "$RESULT_DIR" \
     --result-filename "$(basename "$RAW_RESULT_FILE")" \
     $CLIENT_ARGS
 }
 
+json2args() {
+  local json_string=$1
+  echo "$json_string" | jq -r '
+    to_entries |
+    map(if (.value | tostring) == "" then "--" + (.key | gsub("_"; "-")) else "--" + (.key | gsub("_"; "-")) + " " + (.value | tostring) end) |
+    join(" ")
+  '
+}
+
+resolve_runtime_model() {
+  if [[ -n "$CURRENT_MODEL_PATH" ]]; then
+    echo "$CURRENT_MODEL_PATH"
+    return 0
+  fi
+
+  run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    env MODEL_ID="$MODEL" \
+    "$CURRENT_RUNTIME_PYTHON" -c "import os; from huggingface_hub import snapshot_download; print(snapshot_download(os.environ['MODEL_ID'], local_files_only=True))" \
+    2>/dev/null || return 1
+}
+
 resolve_same_spec() {
   local resolve_args=(
-    python -m vllm_hust_benchmark.same_spec resolve
+    "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.same_spec resolve
     --spec-file "$SPEC_FILE"
     --output-file "$SAME_SPEC_FILE"
     --runtime-model "$RUNTIME_MODEL"
-    --server-port "$OFFICIAL_SERVER_PORT"
-    --client-port "$OFFICIAL_CLIENT_PORT"
+    --server-port "$CURRENT_SERVER_PORT"
+    --client-port "$CURRENT_CLIENT_PORT"
   )
 
-  if [[ -n "$OFFICIAL_SERVER_HOST" ]]; then
-    resolve_args+=(--server-host "$OFFICIAL_SERVER_HOST")
+  if [[ -n "$CURRENT_SERVER_HOST" ]]; then
+    resolve_args+=(--server-host "$CURRENT_SERVER_HOST")
   fi
-  if [[ -n "$OFFICIAL_CLIENT_HOST" ]]; then
-    resolve_args+=(--client-host "$OFFICIAL_CLIENT_HOST")
+  if [[ -n "$CURRENT_CLIENT_HOST" ]]; then
+    resolve_args+=(--client-host "$CURRENT_CLIENT_HOST")
   fi
 
-  run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${resolve_args[@]}"
+  run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" "${resolve_args[@]}"
 }
 
 port_has_listener() {
@@ -323,37 +351,6 @@ assert_target_port_available() {
   fi
 }
 
-ensure_worktree() {
-  local source_repo=$1
-  local target_dir=$2
-  local ref_name=$3
-  if [[ -f "$target_dir/pyproject.toml" ]]; then
-    return 0
-  fi
-  git -C "$source_repo" worktree add --detach "$target_dir" "$ref_name"
-}
-
-json2args() {
-  local json_string=$1
-  echo "$json_string" | jq -r '
-    to_entries |
-    map(if (.value | tostring) == "" then "--" + (.key | gsub("_"; "-")) else "--" + (.key | gsub("_"; "-")) + " " + (.value | tostring) end) |
-    join(" ")
-  '
-}
-
-resolve_runtime_model() {
-  if [[ -n "$OFFICIAL_MODEL_PATH" ]]; then
-    echo "$OFFICIAL_MODEL_PATH"
-    return 0
-  fi
-
-  run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
-    env MODEL_ID="$MODEL" \
-    python -c "import os; from huggingface_hub import snapshot_download; print(snapshot_download(os.environ['MODEL_ID'], local_files_only=True))" \
-    2>/dev/null || return 1
-}
-
 wait_for_server() {
   local host=$1
   local port=$2
@@ -361,6 +358,10 @@ wait_for_server() {
   local timeout_sec=${READY_TIMEOUT_SECONDS:-300}
 
   while (( waited < timeout_sec )); do
+    if [[ -n "${SERVER_PID:-}" ]] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "Current same-spec server exited before becoming ready" >&2
+      return 1
+    fi
     if curl -fsS "http://${host}:${port}/health" >/dev/null; then
       return 0
     fi
@@ -368,7 +369,7 @@ wait_for_server() {
     ((waited += 1))
   done
 
-  echo "Timed out waiting for official baseline server at ${host}:${port}" >&2
+  echo "Timed out waiting for current same-spec server at ${host}:${port}" >&2
   return 1
 }
 
@@ -378,13 +379,8 @@ kill_server() {
 
 trap kill_server EXIT
 
-ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "v0.11.0"
-ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "v0.11.0"
-
-OFFICIAL_RUNTIME_PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE"
-
 mkdir -p "$RESULT_DIR"
-mkdir -p "$OFFICIAL_VLLM_CACHE_ROOT"
+mkdir -p "$CURRENT_VLLM_CACHE_ROOT"
 RUNNER_STATE_DIR="$RESULT_DIR/.runtime-state"
 RUNNER_LOCK_FILE="$RUNNER_STATE_DIR/runner.lock"
 MANAGED_SERVER_PORT_FILE="$RUNNER_STATE_DIR/server.port"
@@ -394,7 +390,6 @@ MANAGED_SERVER_LISTENER_PIDS_FILE="$RUNNER_STATE_DIR/server.listener.pids"
 acquire_runner_lock
 cleanup_managed_server
 
-SCENARIO=$(jq -r '.scenario' "$SPEC_FILE")
 MODEL=$(jq -r '.model' "$SPEC_FILE")
 MODEL_PARAMETERS=$(jq -r '.model_parameters' "$SPEC_FILE")
 MODEL_PRECISION=$(jq -r '.model_precision' "$SPEC_FILE")
@@ -402,16 +397,17 @@ HARDWARE_VENDOR=$(jq -r '.hardware_vendor' "$SPEC_FILE")
 HARDWARE_CHIP_MODEL=$(jq -r '.hardware_chip_model' "$SPEC_FILE")
 CHIP_COUNT=$(jq -r '.chip_count' "$SPEC_FILE")
 NODE_COUNT=$(jq -r '.node_count' "$SPEC_FILE")
-ENGINE=$(jq -r '.export.engine' "$SPEC_FILE")
-ENGINE_VERSION=$(jq -r '.export.engine_version' "$SPEC_FILE")
-SUBMITTER=$(jq -r '.export.submitter' "$SPEC_FILE")
-BASELINE_ENGINE=$(jq -r '.export.baseline_engine' "$SPEC_FILE")
-GITHUB_REPOSITORY=$(jq -r '.export.github_repository' "$SPEC_FILE")
-GITHUB_REF=$(jq -r '.export.github_ref' "$SPEC_FILE")
-GIT_COMMIT=$(jq -r '.export.git_commit' "$SPEC_FILE")
-DATA_SOURCE=$(jq -r '.export.data_source' "$SPEC_FILE")
+SCENARIO=$(jq -r '.scenario' "$SPEC_FILE")
 INPUT_LEN=$(jq -r '.client_parameters.input_len' "$SPEC_FILE")
 OUTPUT_LEN=$(jq -r '.client_parameters.output_len' "$SPEC_FILE")
+
+if [[ -z "$CURRENT_ENGINE_VERSION" ]]; then
+  CURRENT_ENGINE_VERSION=$(run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" "$CURRENT_RUNTIME_PYTHON" - <<'PY'
+import vllm
+print(getattr(vllm, '__version__', 'unknown'))
+PY
+)
+fi
 
 RUNTIME_MODEL="$MODEL"
 if cached_model_path=$(resolve_runtime_model); then
@@ -426,75 +422,38 @@ SERVER_PORT=$(jq -r '.resolved_server_parameters.port' "$SAME_SPEC_FILE")
 CLIENT_HOST=$(jq -r '.resolved_client_parameters.host' "$SAME_SPEC_FILE")
 CLIENT_PORT=$(jq -r '.resolved_client_parameters.port' "$SAME_SPEC_FILE")
 
-BENCHMARK_SERVER_PORT="$SERVER_PORT" \
-PREPARE_BENCHMARK_ADMISSION_ONLY=1 \
-ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
-VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
-bash "$PREPARE_SCRIPT"
+assert_target_port_available "Current same-spec benchmark" "$CLIENT_HOST" "$CLIENT_PORT"
 
-assert_target_port_available "Official baseline" "$CLIENT_HOST" "$CLIENT_PORT"
-
-SERVER_ARGS=$(json2args "$(jq -c '.resolved_server_parameters' "$SAME_SPEC_FILE")")
+SERVER_ARGS=$(json2args "$(jq -c '.resolved_server_parameters | del(.disable_log_requests)' "$SAME_SPEC_FILE")")
 CLIENT_ARGS=$(json2args "$(jq -c '.resolved_client_parameters' "$SAME_SPEC_FILE")")
 
 RAW_RESULT_FILE="$RESULT_DIR/raw_benchmark_result.json"
 ARTIFACT_DIR="$RESULT_DIR/submission"
+SERVER_STDOUT_LOG="$RESULT_DIR/server.stdout.log"
 
-SERVER_COMMAND="PYTHONUNBUFFERED=1 PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run --no-capture-output -p $GOAL_BASELINE_ENV_PREFIX python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS"
-CLIENT_COMMAND="PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.cli.main bench serve --save-result --result-dir $RESULT_DIR --result-filename $(basename "$RAW_RESULT_FILE") $CLIENT_ARGS"
-
-echo "[goal-baseline] using worktrees: $OFFICIAL_VLLM_WORKTREE and $OFFICIAL_VLLM_ASCEND_WORKTREE"
-echo "[goal-baseline] neutral cwd: $OFFICIAL_RUNTIME_CWD"
-echo "[goal-baseline] vllm cache root: $OFFICIAL_VLLM_CACHE_ROOT"
-echo "[goal-baseline] export model id: $MODEL"
-echo "[goal-baseline] runtime model source: $RUNTIME_MODEL"
-echo "[goal-baseline] benchmark endpoint: ${CLIENT_HOST}:${CLIENT_PORT}"
-run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" python - <<'PY'
-from importlib import metadata
-
-import vllm
-import vllm_ascend
-
-
-def dist_version(*names: str) -> str:
-  for name in names:
-    try:
-      return metadata.version(name)
-    except metadata.PackageNotFoundError:
-      continue
-  return "not-installed"
-
-
-print(f"[goal-baseline] vllm module: {vllm.__file__}")
-print(f"[goal-baseline] vllm version: {getattr(vllm, '__version__', 'unknown')} (dist={dist_version('vllm')})")
-print(f"[goal-baseline] vllm_ascend module: {vllm_ascend.__file__}")
-print(
-  "[goal-baseline] vllm_ascend version: "
-  f"{getattr(vllm_ascend, '__version__', 'unknown')} "
-  f"(dist={dist_version('vllm-ascend', 'vllm_ascend')})"
-)
-PY
-echo "[goal-baseline] server command: $SERVER_COMMAND"
-run_server_command &
+echo "[same-spec-current] neutral cwd: $CURRENT_RUNTIME_CWD"
+echo "[same-spec-current] vllm cache root: $CURRENT_VLLM_CACHE_ROOT"
+echo "[same-spec-current] runtime model source: $RUNTIME_MODEL"
+echo "[same-spec-current] resolved spec file: $SAME_SPEC_FILE"
+echo "[same-spec-current] benchmark endpoint: ${CLIENT_HOST}:${CLIENT_PORT}"
+run_server_command >"$SERVER_STDOUT_LOG" 2>&1 &
 SERVER_PID=$!
 persist_managed_server_state
 
 wait_for_server "$CLIENT_HOST" "$CLIENT_PORT"
 persist_managed_server_state
-
-echo "[goal-baseline] client command: $CLIENT_COMMAND"
 run_client_command
 
-run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" \
-python -m vllm_hust_benchmark.cli export-leaderboard-artifact \
+run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" \
+"$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.cli export-leaderboard-artifact \
   "$SCENARIO" \
   --benchmark-result-file "$RAW_RESULT_FILE" \
   --constraints-file "$CONSTRAINTS_FILE" \
   --same-spec-file "$SAME_SPEC_FILE" \
   --output-dir "$ARTIFACT_DIR" \
   --run-id "$RUN_ID" \
-  --engine "$ENGINE" \
-  --engine-version "$ENGINE_VERSION" \
+  --engine "$CURRENT_ENGINE" \
+  --engine-version "$CURRENT_ENGINE_VERSION" \
   --model-name "$MODEL" \
   --model-parameters "$MODEL_PARAMETERS" \
   --model-precision "$MODEL_PRECISION" \
@@ -502,13 +461,21 @@ python -m vllm_hust_benchmark.cli export-leaderboard-artifact \
   --hardware-chip-model "$HARDWARE_CHIP_MODEL" \
   --chip-count "$CHIP_COUNT" \
   --node-count "$NODE_COUNT" \
-  --submitter "$SUBMITTER" \
-  --baseline-engine "$BASELINE_ENGINE" \
-  --data-source "$DATA_SOURCE" \
+  --submitter "$CURRENT_SUBMITTER" \
+  --baseline-engine "$CURRENT_BASELINE_ENGINE" \
+  --data-source "$CURRENT_DATA_SOURCE" \
   --input-length "$INPUT_LEN" \
   --output-length "$OUTPUT_LEN" \
-  --git-commit "$GIT_COMMIT" \
-  --github-repository "$GITHUB_REPOSITORY" \
-  --github-ref "$GITHUB_REF"
+  --git-commit "$CURRENT_GIT_COMMIT" \
+  --github-repository "$CURRENT_GITHUB_REPOSITORY" \
+  --github-ref "$CURRENT_GITHUB_REF" \
+  --runtime-python "$CURRENT_RUNTIME_PYTHON" \
+  --engine-source-repository "$CURRENT_GITHUB_REPOSITORY" \
+  --engine-source-ref "$CURRENT_GITHUB_REF" \
+  --engine-source-commit "$CURRENT_GIT_COMMIT" \
+  --plugin-source-engine "$CURRENT_PLUGIN_ENGINE" \
+  --plugin-source-repository "$CURRENT_PLUGIN_GITHUB_REPOSITORY" \
+  --plugin-source-ref "$CURRENT_PLUGIN_GITHUB_REF" \
+  --plugin-source-commit "$CURRENT_PLUGIN_GIT_COMMIT"
 
-echo "[goal-baseline] exported leaderboard artifact to $ARTIFACT_DIR"
+echo "[same-spec-current] exported leaderboard artifact to $ARTIFACT_DIR"

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -296,6 +296,7 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--metrics-file")
     export_parser.add_argument("--benchmark-result-file")
     export_parser.add_argument("--constraints-file")
+    export_parser.add_argument("--same-spec-file")
     export_parser.add_argument("--output-dir", required=True)
     export_parser.add_argument("--artifact-name", default="run_leaderboard.json")
     export_parser.add_argument("--run-id", required=True)
@@ -329,6 +330,14 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--github-event-name")
     export_parser.add_argument("--github-pr-number", type=int)
     export_parser.add_argument("--github-pr-url")
+    export_parser.add_argument("--runtime-python")
+    export_parser.add_argument("--engine-source-repository")
+    export_parser.add_argument("--engine-source-ref")
+    export_parser.add_argument("--engine-source-commit")
+    export_parser.add_argument("--plugin-source-engine")
+    export_parser.add_argument("--plugin-source-repository")
+    export_parser.add_argument("--plugin-source-ref")
+    export_parser.add_argument("--plugin-source-commit")
     export_parser.add_argument("--publish-website", action="store_true")
     export_parser.add_argument("--website-output-dir")
     export_parser.add_argument("--execute", action="store_true")
@@ -666,12 +675,16 @@ def main(argv: list[str] | None = None) -> int:
         constraints_file = (
             Path(args.constraints_file).resolve() if args.constraints_file else None
         )
+        same_spec_file = (
+            Path(args.same_spec_file).resolve() if args.same_spec_file else None
+        )
         try:
             artifact_path, manifest_path = export_leaderboard_artifacts(
                 scenario=scenario,
                 metrics_file=metrics_file,
                 benchmark_result_file=benchmark_result_file,
                 constraints_file=constraints_file,
+                same_spec_file=same_spec_file,
                 output_dir=Path(args.output_dir),
                 artifact_name=args.artifact_name,
                 run_id=args.run_id,
@@ -705,6 +718,14 @@ def main(argv: list[str] | None = None) -> int:
                 github_event_name=github_metadata["github_event_name"],
                 github_pr_number=github_metadata["github_pr_number"],
                 github_pr_url=github_metadata["github_pr_url"],
+                runtime_python=args.runtime_python,
+                engine_source_repository=args.engine_source_repository,
+                engine_source_ref=args.engine_source_ref,
+                engine_source_commit=args.engine_source_commit,
+                plugin_source_engine=args.plugin_source_engine,
+                plugin_source_repository=args.plugin_source_repository,
+                plugin_source_ref=args.plugin_source_ref,
+                plugin_source_commit=args.plugin_source_commit,
             )
         except (OSError, ValueError) as error:
             print(str(error), file=sys.stderr)

--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -37,6 +37,14 @@ REQUIRED_CONSTRAINT_METRIC_KEYS = (
     "multi_tenant_high_utilization",
 )
 
+REQUIRED_SAME_SPEC_KEYS = (
+    "schema_version",
+    "spec_id",
+    "resolved_spec_hash",
+    "resolved_server_parameters",
+    "resolved_client_parameters",
+)
+
 
 def _validate_constraints_metrics(constraints_metrics: dict[str, Any]) -> dict[str, Any]:
     long_context_length = constraints_metrics.get("long_context_length")
@@ -104,6 +112,23 @@ def _load_constraints_metrics(constraints_file: Path) -> dict[str, Any]:
             "constraints_metrics missing required keys: " + ", ".join(missing_constraints)
         )
     return _validate_constraints_metrics(dict(constraints_metrics))
+
+
+def _load_same_spec_payload(same_spec_file: Path) -> dict[str, Any]:
+    payload = json.loads(same_spec_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("same spec file must be a JSON object")
+
+    missing_keys = [key for key in REQUIRED_SAME_SPEC_KEYS if key not in payload]
+    if missing_keys:
+        raise ValueError(
+            "same spec payload missing required keys: " + ", ".join(missing_keys)
+        )
+    if not isinstance(payload.get("resolved_server_parameters"), dict):
+        raise ValueError("same spec resolved_server_parameters must be an object")
+    if not isinstance(payload.get("resolved_client_parameters"), dict):
+        raise ValueError("same spec resolved_client_parameters must be an object")
+    return payload
 
 
 def _safe_float(value: Any) -> float | None:
@@ -246,6 +271,7 @@ def export_leaderboard_artifacts(
     metrics_file: Path | None,
     benchmark_result_file: Path | None,
     constraints_file: Path | None,
+    same_spec_file: Path | None,
     output_dir: Path,
     artifact_name: str,
     run_id: str,
@@ -279,6 +305,14 @@ def export_leaderboard_artifacts(
     github_event_name: str | None,
     github_pr_number: int | None,
     github_pr_url: str | None,
+    runtime_python: str | None,
+    engine_source_repository: str | None,
+    engine_source_ref: str | None,
+    engine_source_commit: str | None,
+    plugin_source_engine: str | None,
+    plugin_source_repository: str | None,
+    plugin_source_ref: str | None,
+    plugin_source_commit: str | None,
 ) -> tuple[Path, Path]:
     payload = load_export_payload(
         metrics_file=metrics_file,
@@ -288,6 +322,9 @@ def export_leaderboard_artifacts(
     )
     metrics = dict(payload["metrics"])
     constraints_metrics = dict(payload["constraints_metrics"])
+    same_spec_payload = (
+        _load_same_spec_payload(same_spec_file) if same_spec_file is not None else None
+    )
 
     submitted_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     config_type = _infer_config_type(
@@ -399,8 +436,24 @@ def export_leaderboard_artifacts(
             "verified": None,
             "idempotency_key": idempotency_key,
             "manifest_source": f"generated-by-vllm-hust-benchmark/{benchmark_version}",
+            "runtime_provenance": {
+                "python": runtime_python,
+                "engine": {
+                    "repository": engine_source_repository,
+                    "ref": engine_source_ref,
+                    "commit": engine_source_commit,
+                },
+                "plugin": {
+                    "engine": plugin_source_engine,
+                    "repository": plugin_source_repository,
+                    "ref": plugin_source_ref,
+                    "commit": plugin_source_commit,
+                },
+            },
         },
     }
+    if same_spec_payload is not None:
+        artifact["same_spec"] = same_spec_payload
 
     output_dir.mkdir(parents=True, exist_ok=True)
     artifact_path = output_dir / artifact_name

--- a/src/vllm_hust_benchmark/same_spec.py
+++ b/src/vllm_hust_benchmark/same_spec.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+PRECISION_TO_DTYPE = {
+    "FP32": "float32",
+    "FP16": "float16",
+    "BF16": "bfloat16",
+    "fp32": "float32",
+    "fp16": "float16",
+    "bf16": "bfloat16",
+}
+
+NON_SEMANTIC_SERVER_KEYS = {"host", "port", "model"}
+NON_SEMANTIC_CLIENT_KEYS = {"host", "port", "model"}
+
+
+def load_benchmark_spec(spec_file: Path) -> dict[str, Any]:
+    payload = json.loads(spec_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{spec_file}: benchmark spec must be a JSON object")
+    return payload
+
+
+def _require_string(payload: dict[str, Any], key: str) -> str:
+    value = str(payload.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"benchmark spec is missing required field: {key}")
+    return value
+
+
+def _require_dict(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"benchmark spec field must be an object: {key}")
+    return dict(value)
+
+
+def precision_to_runtime_dtype(model_precision: str) -> str:
+    dtype = PRECISION_TO_DTYPE.get(model_precision)
+    if dtype is None:
+        raise ValueError(
+            "benchmark spec model_precision is not mappable to a runtime dtype: "
+            f"{model_precision!r}"
+        )
+    return dtype
+
+
+def resolve_server_parameters(
+    spec: dict[str, Any],
+    *,
+    runtime_model: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+) -> dict[str, Any]:
+    resolved = _require_dict(spec, "server_parameters")
+    resolved["model"] = runtime_model or _require_string(spec, "model")
+    if host is not None:
+        resolved["host"] = host
+    if port is not None:
+        resolved["port"] = port
+    if "dtype" not in resolved:
+        resolved["dtype"] = precision_to_runtime_dtype(_require_string(spec, "model_precision"))
+    if "enforce_eager" not in resolved:
+        resolved["enforce_eager"] = ""
+    return resolved
+
+
+def resolve_client_parameters(
+    spec: dict[str, Any],
+    *,
+    runtime_model: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+) -> dict[str, Any]:
+    resolved = _require_dict(spec, "client_parameters")
+    resolved["model"] = runtime_model or _require_string(spec, "model")
+    if host is not None:
+        resolved["host"] = host
+    if port is not None:
+        resolved["port"] = port
+
+    if resolved.get("dataset_name") == "random":
+        if "input_len" in resolved and "random_input_len" not in resolved:
+            resolved["random_input_len"] = resolved.pop("input_len")
+        if "output_len" in resolved and "random_output_len" not in resolved:
+            resolved["random_output_len"] = resolved.pop("output_len")
+    return resolved
+
+
+def _normalize_for_hash(
+    parameters: dict[str, Any], *, drop_keys: set[str]
+) -> dict[str, Any]:
+    return {key: value for key, value in parameters.items() if key not in drop_keys}
+
+
+def build_same_spec_payload(
+    spec: dict[str, Any],
+    *,
+    spec_source: Path | None = None,
+    runtime_model: str | None = None,
+    server_host: str | None = None,
+    server_port: int | None = None,
+    client_host: str | None = None,
+    client_port: int | None = None,
+) -> dict[str, Any]:
+    spec_id = _require_string(spec, "id")
+    canonical_model = _require_string(spec, "model")
+    resolved_server_parameters = resolve_server_parameters(
+        spec,
+        runtime_model=runtime_model or canonical_model,
+        host=server_host,
+        port=server_port,
+    )
+    resolved_client_parameters = resolve_client_parameters(
+        spec,
+        runtime_model=runtime_model or canonical_model,
+        host=client_host,
+        port=client_port,
+    )
+    hash_basis = {
+        "schema_version": "benchmark-same-spec/v1",
+        "spec_id": spec_id,
+        "scenario": _require_string(spec, "scenario"),
+        "model": canonical_model,
+        "model_parameters": _require_string(spec, "model_parameters"),
+        "model_precision": _require_string(spec, "model_precision"),
+        "hardware_vendor": _require_string(spec, "hardware_vendor"),
+        "hardware_chip_model": _require_string(spec, "hardware_chip_model"),
+        "chip_count": int(spec.get("chip_count") or 0),
+        "node_count": int(spec.get("node_count") or 0),
+        "resolved_server_parameters": _normalize_for_hash(
+            resolve_server_parameters(
+                spec,
+                runtime_model=canonical_model,
+                host=server_host,
+                port=server_port,
+            ),
+            drop_keys=NON_SEMANTIC_SERVER_KEYS,
+        ),
+        "resolved_client_parameters": _normalize_for_hash(
+            resolve_client_parameters(
+                spec,
+                runtime_model=canonical_model,
+                host=client_host,
+                port=client_port,
+            ),
+            drop_keys=NON_SEMANTIC_CLIENT_KEYS,
+        ),
+    }
+    hash_input = json.dumps(
+        hash_basis,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    resolved_spec_hash = hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
+
+    return {
+        "schema_version": "benchmark-same-spec/v1",
+        "spec_id": spec_id,
+        "spec_label": str(spec.get("label") or ""),
+        "spec_source": str(spec_source.resolve()) if spec_source is not None else None,
+        "scenario": _require_string(spec, "scenario"),
+        "model": canonical_model,
+        "model_parameters": _require_string(spec, "model_parameters"),
+        "model_precision": _require_string(spec, "model_precision"),
+        "hardware_vendor": _require_string(spec, "hardware_vendor"),
+        "hardware_chip_model": _require_string(spec, "hardware_chip_model"),
+        "chip_count": int(spec.get("chip_count") or 0),
+        "node_count": int(spec.get("node_count") or 0),
+        "resolved_spec_hash": resolved_spec_hash,
+        "resolved_server_parameters": resolved_server_parameters,
+        "resolved_client_parameters": resolved_client_parameters,
+    }
+
+
+def write_same_spec_payload(
+    *,
+    spec_file: Path,
+    output_file: Path,
+    runtime_model: str | None = None,
+    server_host: str | None = None,
+    server_port: int | None = None,
+    client_host: str | None = None,
+    client_port: int | None = None,
+) -> Path:
+    payload = build_same_spec_payload(
+        load_benchmark_spec(spec_file),
+        spec_source=spec_file,
+        runtime_model=runtime_model,
+        server_host=server_host,
+        server_port=server_port,
+        client_host=client_host,
+        client_port=client_port,
+    )
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return output_file
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve a benchmark same-spec payload for runtime and export.",
+    )
+    parser.add_argument("resolve", nargs="?")
+    parser.add_argument("--spec-file", required=True, type=Path)
+    parser.add_argument("--output-file", required=True, type=Path)
+    parser.add_argument("--runtime-model")
+    return parser.parse_args()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a benchmark same-spec payload for runtime and export.",
+    )
+    parser.add_argument("command", choices=["resolve"])
+    parser.add_argument("--spec-file", required=True, type=Path)
+    parser.add_argument("--output-file", required=True, type=Path)
+    parser.add_argument("--runtime-model")
+    parser.add_argument("--server-host")
+    parser.add_argument("--server-port", type=int)
+    parser.add_argument("--client-host")
+    parser.add_argument("--client-port", type=int)
+    args = parser.parse_args(argv)
+
+    try:
+        output_file = write_same_spec_payload(
+            spec_file=args.spec_file.resolve(),
+            output_file=args.output_file.resolve(),
+            runtime_model=args.runtime_model,
+            server_host=args.server_host,
+            server_port=args.server_port,
+            client_host=args.client_host,
+            client_port=args.client_port,
+        )
+    except (OSError, ValueError) as error:
+        print(str(error))
+        return 2
+
+    print(output_file)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -645,6 +645,112 @@ def test_export_leaderboard_artifact_from_raw_benchmark_result(tmp_path) -> None
     assert artifact["metadata"]["github_user"] == "benchmark-bot"
 
 
+def test_export_leaderboard_artifact_embeds_same_spec_payload(tmp_path: Path) -> None:
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text(
+        """
+{
+    "metrics": {
+        "ttft_ms": 150.0,
+        "throughput_tps": 98.5,
+        "peak_mem_mb": 2048,
+        "error_rate": 0.0
+    },
+    "constraints_metrics": {
+        "single_chip_effective_utilization_pct": 91.0,
+        "typical_throughput_ratio_vs_baseline": 2.1,
+        "typical_ttft_reduction_pct_vs_baseline": 22.0,
+        "typical_tpot_reduction_pct_vs_baseline": 21.0,
+        "long_context_length": 32768,
+        "long_context_throughput_stable": true,
+        "long_context_ttft_p95_ms": 100.0,
+        "long_context_ttft_p99_ms": 120.0,
+        "long_context_tpot_p95_ms": 15.0,
+        "long_context_tpot_p99_ms": 18.0,
+        "long_context_ttft_p95_stable": true,
+        "long_context_ttft_p99_stable": true,
+        "long_context_tpot_p95_stable": true,
+        "long_context_tpot_p99_stable": true,
+        "unit_token_cost_reduction_pct": 30.0,
+        "multi_tenant_high_utilization": true
+    }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    same_spec_file = tmp_path / "same_spec.json"
+    same_spec_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "benchmark-same-spec/v1",
+                "spec_id": "spec-1",
+                "resolved_spec_hash": "abc123",
+                "resolved_server_parameters": {"dtype": "float16"},
+                "resolved_client_parameters": {"dataset_name": "random"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "export_same_spec"
+    exit_code = main(
+        [
+            "export-leaderboard-artifact",
+            "sharegpt-online",
+            "--metrics-file",
+            str(metrics_file),
+            "--same-spec-file",
+            str(same_spec_file),
+            "--output-dir",
+            str(output_dir),
+            "--run-id",
+            "same-spec-run-1",
+            "--engine",
+            "vllm-hust",
+            "--engine-version",
+            "0.7.3",
+            "--model-name",
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "--hardware-chip-model",
+            "Ascend-910B",
+            "--submitter",
+            "ci",
+            "--runtime-python",
+            "/root/miniconda3/envs/vllm-hust-dev/bin/python",
+            "--engine-source-repository",
+            "vLLM-HUST/vllm-hust",
+            "--engine-source-ref",
+            "main",
+            "--engine-source-commit",
+            "abc123def456",
+            "--plugin-source-engine",
+            "vllm-ascend-hust",
+            "--plugin-source-repository",
+            "vLLM-HUST/vllm-ascend-hust",
+            "--plugin-source-ref",
+            "ws/fix/same_spec_current_artifact",
+            "--plugin-source-commit",
+            "fedcba654321",
+        ]
+    )
+
+    assert exit_code == 0
+    artifact = json.loads((output_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
+    assert artifact["same_spec"]["spec_id"] == "spec-1"
+    assert artifact["same_spec"]["resolved_spec_hash"] == "abc123"
+    assert artifact["metadata"]["runtime_provenance"]["python"] == (
+        "/root/miniconda3/envs/vllm-hust-dev/bin/python"
+    )
+    assert artifact["metadata"]["runtime_provenance"]["engine"]["repository"] == (
+        "vLLM-HUST/vllm-hust"
+    )
+    assert artifact["metadata"]["runtime_provenance"]["plugin"]["repository"] == (
+        "vLLM-HUST/vllm-ascend-hust"
+    )
+
+
 def test_export_leaderboard_artifact_rejects_zero_long_context_length(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_same_spec.py
+++ b/tests/test_same_spec.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+
+from vllm_hust_benchmark.same_spec import build_same_spec_payload
+from vllm_hust_benchmark.same_spec import write_same_spec_payload
+
+
+def _spec() -> dict:
+    return {
+        "id": "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
+        "label": "Official Ascend Jan 2026 baseline for vllm-hust goal tracking",
+        "scenario": "random-online",
+        "model": "Qwen/Qwen2.5-14B-Instruct",
+        "model_parameters": "14B",
+        "model_precision": "FP16",
+        "hardware_vendor": "Huawei",
+        "hardware_chip_model": "910B3",
+        "chip_count": 1,
+        "node_count": 1,
+        "server_parameters": {
+            "tensor_parallel_size": 1,
+            "enforce_eager": "",
+            "trust_remote_code": "",
+            "disable_log_stats": "",
+            "host": "0.0.0.0",
+            "port": 8000,
+        },
+        "client_parameters": {
+            "backend": "vllm",
+            "endpoint": "/v1/completions",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "input_len": 1024,
+            "output_len": 256,
+            "request_rate": 1,
+            "host": "127.0.0.1",
+            "port": 8000,
+        },
+    }
+
+
+def test_build_same_spec_payload_injects_dtype() -> None:
+    payload = build_same_spec_payload(_spec())
+
+    assert payload["resolved_server_parameters"]["dtype"] == "float16"
+    assert payload["resolved_client_parameters"]["random_input_len"] == 1024
+    assert payload["resolved_client_parameters"]["random_output_len"] == 256
+    assert "input_len" not in payload["resolved_client_parameters"]
+    assert "output_len" not in payload["resolved_client_parameters"]
+
+
+def test_same_spec_hash_ignores_runtime_model_path() -> None:
+    left = build_same_spec_payload(_spec(), runtime_model="Qwen/Qwen2.5-14B-Instruct")
+    right = build_same_spec_payload(
+        _spec(),
+        runtime_model="/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-14B-Instruct/snapshots/abc",
+    )
+
+    assert left["resolved_server_parameters"]["model"] != right["resolved_server_parameters"]["model"]
+    assert left["resolved_spec_hash"] == right["resolved_spec_hash"]
+
+
+def test_same_spec_hash_ignores_host_and_port_overrides() -> None:
+    baseline = build_same_spec_payload(_spec())
+    overridden = build_same_spec_payload(
+        _spec(),
+        server_port=8001,
+        client_port=8001,
+        client_host="127.0.0.1",
+    )
+
+    assert overridden["resolved_server_parameters"]["port"] == 8001
+    assert overridden["resolved_client_parameters"]["port"] == 8001
+    assert overridden["resolved_client_parameters"]["host"] == "127.0.0.1"
+    assert baseline["resolved_spec_hash"] == overridden["resolved_spec_hash"]
+
+
+def test_write_same_spec_payload(tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(json.dumps(_spec()), encoding="utf-8")
+    output_file = tmp_path / "resolved.json"
+
+    write_same_spec_payload(
+        spec_file=spec_file,
+        output_file=output_file,
+        runtime_model="Qwen/Qwen2.5-14B-Instruct",
+    )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["spec_id"] == _spec()["id"]
+    assert payload["resolved_spec_hash"]


### PR DESCRIPTION
## Summary
- resolve official and current benchmark runs from a shared same-spec payload so exported artifacts carry the same benchmark contract
- export same-spec metadata and runtime provenance into leaderboard artifacts for downstream website validation
- harden official and current runner scripts with managed port isolation, lifecycle cleanup, and a current-run convenience entrypoint

## Tests
- cd /workspace/vllm-hust-benchmark && /root/miniconda3/envs/vllm-hust-dev/bin/python -m pytest tests/test_cli.py tests/test_same_spec.py -q
- cd /workspace/vllm-hust-benchmark && bash -n scripts/run-official-ascend-goal-baseline.sh scripts/run-current-ascend-same-spec.sh scripts/prepare-official-ascend-baseline-env.sh

## Notes
- benchmark outputs in .cache/ and pytest-results.xml were intentionally left out of the commit