### PR TITLE
fix(ci): respect org PR policy for snapshot sync

### DIFF
--- a/.github/workflows/auto-merge-github-snapshot-pr.yml
+++ b/.github/workflows/auto-merge-github-snapshot-pr.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Merge eligible snapshot PR
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: vLLM-HUST/vllm-hust-benchmark
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           if [[ "$HEAD_BRANCH" != "bot/leaderboard-snapshot-sync" ]]; then
@@ -28,6 +29,7 @@ jobs:
           fi
 
           pr_number=$(gh pr list \
+            -R "$REPO_SLUG" \
             --base main \
             --head "$HEAD_BRANCH" \
             --state open \
@@ -39,4 +41,4 @@ jobs:
             exit 0
           fi
 
-          gh pr merge "$pr_number" --squash --delete-branch=false
+          gh pr merge -R "$REPO_SLUG" "$pr_number" --squash --delete-branch=false

--- a/.github/workflows/sync-github-snapshot-pr.yml
+++ b/.github/workflows/sync-github-snapshot-pr.yml
@@ -40,9 +40,15 @@ jobs:
 
       - name: Create or update snapshot PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.VLLM_HUST_BENCHMARK_GH_TOKEN }}
           SNAPSHOT_MARKER: ${{ steps.marker.outputs.value }}
         run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "Skipping snapshot PR creation because this organization blocks GitHub Actions from creating pull requests with github.token." >> "$GITHUB_STEP_SUMMARY"
+            echo "Create the PR from the trusted vllm-hust runner instead, or configure VLLM_HUST_BENCHMARK_GH_TOKEN for this repository." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           title="chore(data): sync leaderboard snapshots"
           if [[ -n "$SNAPSHOT_MARKER" ]]; then
             title="$title ($SNAPSHOT_MARKER)"

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For cross-repository CI, `sync-submission-to-hf` is the preferred publish entryp
 Because the production website currently prioritizes `github -> hf -> local`, a successful HF upload alone is not sufficient to refresh the live site. The production chain therefore has two stages:
 
 1. `vllm-hust` benchmark CI publishes refreshed snapshots to the HF dataset.
-2. The same CI mirrors those four snapshot files into `leaderboard-data/snapshots/` on a dedicated benchmark-repo bot branch, and this repository auto-opens and auto-merges a PR back to `main` after `CI` passes.
+2. The same trusted-runner CI mirrors those four snapshot files into `leaderboard-data/snapshots/` on a dedicated benchmark-repo bot branch, opens or updates the PR back to `main`, and this repository auto-merges that PR after `CI` passes.
 
 This keeps the HF dataset as the canonical aggregated source while still satisfying the website's GitHub-first loader.
 

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -458,6 +458,14 @@ probe_server_ready() {
   return 1
 }
 
+server_log_indicates_node_env_failure() {
+  local log_file=$1
+
+  [[ -f "$log_file" ]] || return 1
+
+  grep -Eq "DrvMngGetConsoleLogLevel failed|dcmi model initialized failed|ret is -8020|drvRet=87|drvRetCode=87|ErrCode=507899|error code is 507899|rtGetDeviceCount|Can't get ascend_hal device count|driver error:internal error|Resource_Busy\(EL0005\)|The resources are busy|ERR99999 UNKNOWN applicaiton exception|ERR99999 UNKNOWN application exception|Engine core initialization failed" "$log_file"
+}
+
 wait_for_server() {
   local host=$1
   local port=$2
@@ -475,6 +483,10 @@ wait_for_server() {
       echo "Current same-spec server exited before becoming ready" >&2
       if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
         tail -n 40 "$SERVER_STDOUT_LOG" >&2
+        if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
+          echo "Detected Ascend node-level runtime failure during current same-spec startup" >&2
+          return 86
+        fi
       fi
       return 1
     fi
@@ -498,6 +510,10 @@ wait_for_server() {
   echo "Timed out waiting for current same-spec server at ${host}:${port}" >&2
   if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
     tail -n 40 "$SERVER_STDOUT_LOG" >&2
+    if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
+      echo "Detected Ascend node-level runtime failure while waiting for current same-spec startup" >&2
+      return 86
+    fi
   fi
   return 1
 }


### PR DESCRIPTION
This follow-up fixes the remaining publication-chain regressions after #8 and #9.

Organization policy blocks GitHub Actions from creating pull requests with `github.token`, so the benchmark-repo-side snapshot PR workflow must skip cleanly unless a dedicated non-Actions token is configured. This branch also fixes the auto-merge workflow to pass `-R vLLM-HUST/vllm-hust-benchmark` to gh so it can merge snapshot PRs without a checked-out git repository.