### PR TITLE
fix: export and backfill leaderboard versions

### DIFF
--- a/leaderboard-data/snapshots/leaderboard_multi.json
+++ b/leaderboard-data/snapshots/leaderboard_multi.json
@@ -267,8 +267,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1.dev2743+g7f888566e",
+      "core": "0.17.2rc1.dev450+g289b51ab2.d20260417",
       "benchmark": "0.1.0"
     },
     "environment": {

--- a/leaderboard-data/snapshots/leaderboard_single.json
+++ b/leaderboard-data/snapshots/leaderboard_single.json
@@ -218,8 +218,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -371,8 +371,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -524,8 +524,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -677,8 +677,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -830,8 +830,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -983,8 +983,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -1136,8 +1136,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -1289,8 +1289,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.18.0.post1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -1442,8 +1442,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.18.0.post1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -1595,8 +1595,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.18.0.post1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -1748,8 +1748,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.18.0.post1",
+      "core": "0.17.2.post1",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -2305,7 +2305,7 @@
     "versions": {
       "protocol": "N/A",
       "backend": "0.1.dev2743+g7f888566e",
-      "core": "N/A",
+      "core": "0.17.2rc1.dev450+g289b51ab2.d20260417",
       "benchmark": "0.1.0"
     },
     "environment": {
@@ -2402,8 +2402,8 @@
     "cluster": null,
     "versions": {
       "protocol": "N/A",
-      "backend": "N/A",
-      "core": "N/A",
+      "backend": "0.1.dev2743+g7f888566e",
+      "core": "0.17.2rc1.dev450+g289b51ab2.d20260417",
       "benchmark": "0.1.0"
     },
     "environment": {

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -20,6 +20,8 @@ CURRENT_CLIENT_HOST=${CURRENT_CLIENT_HOST:-}
 CURRENT_CLIENT_PORT=${CURRENT_CLIENT_PORT:-$CURRENT_SERVER_PORT}
 CURRENT_ENGINE=${CURRENT_ENGINE:-"vllm-hust"}
 CURRENT_ENGINE_VERSION=${CURRENT_ENGINE_VERSION:-}
+CURRENT_CORE_VERSION=${CURRENT_CORE_VERSION:-}
+CURRENT_BACKEND_VERSION=${CURRENT_BACKEND_VERSION:-}
 CURRENT_SUBMITTER=${CURRENT_SUBMITTER:-"same-spec-current"}
 CURRENT_BASELINE_ENGINE=${CURRENT_BASELINE_ENGINE:-"vllm"}
 CURRENT_DATA_SOURCE=${CURRENT_DATA_SOURCE:-"vllm-hust-benchmark"}
@@ -127,6 +129,70 @@ PY
   fi
 
   fallback=$(resolve_current_engine_version_from_git)
+  if is_valid_engine_version "$fallback"; then
+    printf '%s' "$fallback"
+    return 0
+  fi
+
+  printf '%s' "unknown"
+}
+
+resolve_current_backend_version_from_git() {
+  local described=""
+
+  if [[ -n "$CURRENT_PLUGIN_GIT_COMMIT" ]]; then
+    described=$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" describe --tags --always "$CURRENT_PLUGIN_GIT_COMMIT" 2>/dev/null || true)
+    if [[ -n "$described" ]]; then
+      printf '%s' "$described"
+      return 0
+    fi
+  fi
+
+  described=$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" describe --tags --always HEAD 2>/dev/null || true)
+  if [[ -n "$described" ]]; then
+    printf '%s' "$described"
+    return 0
+  fi
+
+  git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" rev-parse --short HEAD 2>/dev/null || true
+}
+
+detect_current_backend_version() {
+  local raw_output=""
+  local detected=""
+  local fallback=""
+
+  raw_output=$(run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" "$CURRENT_RUNTIME_PYTHON" - <<'PY'
+from importlib import metadata
+
+version = None
+try:
+    import vllm_ascend
+    version = getattr(vllm_ascend, '__version__', None)
+except Exception:
+    version = None
+
+if not version:
+    for dist_name in ('vllm-ascend-hust', 'vllm-ascend'):
+        try:
+            version = metadata.version(dist_name)
+            break
+        except Exception:
+            continue
+
+print(f"__VLLM_HUST_BACKEND_VERSION__={version or ''}")
+PY
+)
+
+  detected=$(printf '%s\n' "$raw_output" | sed -n 's/^__VLLM_HUST_BACKEND_VERSION__=//p' | tail -n 1)
+  detected=$(printf '%s' "$detected" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')
+
+  if is_valid_engine_version "$detected"; then
+    printf '%s' "$detected"
+    return 0
+  fi
+
+  fallback=$(resolve_current_backend_version_from_git)
   if is_valid_engine_version "$fallback"; then
     printf '%s' "$fallback"
     return 0
@@ -550,6 +616,14 @@ if [[ -z "$CURRENT_ENGINE_VERSION" ]]; then
   CURRENT_ENGINE_VERSION=$(detect_current_engine_version)
 fi
 
+if [[ -z "$CURRENT_CORE_VERSION" ]]; then
+  CURRENT_CORE_VERSION="$CURRENT_ENGINE_VERSION"
+fi
+
+if [[ -z "$CURRENT_BACKEND_VERSION" ]]; then
+  CURRENT_BACKEND_VERSION=$(detect_current_backend_version)
+fi
+
 RUNTIME_MODEL="$MODEL"
 if cached_model_path=$(resolve_runtime_model); then
   if [[ -n "$CURRENT_MODEL_PATH" ]] || local_runtime_model_has_required_artifacts "$cached_model_path"; then
@@ -609,6 +683,8 @@ run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RU
   --run-id "$RUN_ID" \
   --engine "$CURRENT_ENGINE" \
   --engine-version "$CURRENT_ENGINE_VERSION" \
+  --core-version "$CURRENT_CORE_VERSION" \
+  --backend-version "$CURRENT_BACKEND_VERSION" \
   --model-name "$MODEL" \
   --model-parameters "$MODEL_PARAMETERS" \
   --model-precision "$MODEL_PRECISION" \

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -18,6 +18,8 @@ OFFICIAL_SERVER_HOST=${OFFICIAL_SERVER_HOST:-}
 OFFICIAL_SERVER_PORT=${OFFICIAL_SERVER_PORT:-"8000"}
 OFFICIAL_CLIENT_HOST=${OFFICIAL_CLIENT_HOST:-}
 OFFICIAL_CLIENT_PORT=${OFFICIAL_CLIENT_PORT:-$OFFICIAL_SERVER_PORT}
+OFFICIAL_CORE_VERSION=${OFFICIAL_CORE_VERSION:-}
+OFFICIAL_BACKEND_VERSION=${OFFICIAL_BACKEND_VERSION:-}
 ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
 ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
 ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
@@ -368,6 +370,97 @@ raise SystemExit(
     0 if runtime_model_path_has_required_artifacts(os.environ["RUNTIME_MODEL_CANDIDATE"]) else 1
 )
 PY
+
+is_valid_engine_version() {
+  local version=${1:-}
+  [[ -n "$version" ]] && [[ "$version" != "unknown" ]] && [[ "$version" != "not-installed" ]] && [[ "$version" != "N/A" ]]
+}
+
+detect_official_core_version() {
+  local raw_output=""
+  local detected=""
+  local fallback=""
+
+  raw_output=$(run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" python - <<'PY'
+from importlib import metadata
+
+version = None
+try:
+    import vllm
+    version = getattr(vllm, '__version__', None)
+except Exception:
+    version = None
+
+if not version:
+    try:
+        version = metadata.version('vllm')
+    except Exception:
+        version = None
+
+print(f"__VLLM_HUST_CORE_VERSION__={version or ''}")
+PY
+)
+
+  detected=$(printf '%s\n' "$raw_output" | sed -n 's/^__VLLM_HUST_CORE_VERSION__=//p' | tail -n 1)
+  detected=$(printf '%s' "$detected" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')
+
+  if is_valid_engine_version "$detected"; then
+    printf '%s' "$detected"
+    return 0
+  fi
+
+  fallback=$(git -C "$OFFICIAL_VLLM_WORKTREE" describe --tags --always HEAD 2>/dev/null || true)
+  if is_valid_engine_version "$fallback"; then
+    printf '%s' "$fallback"
+    return 0
+  fi
+
+  printf '%s' "unknown"
+}
+
+detect_official_backend_version() {
+  local raw_output=""
+  local detected=""
+  local fallback=""
+
+  raw_output=$(run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" python - <<'PY'
+from importlib import metadata
+
+version = None
+try:
+    import vllm_ascend
+    version = getattr(vllm_ascend, '__version__', None)
+except Exception:
+    version = None
+
+if not version:
+    for dist_name in ('vllm-ascend', 'vllm_ascend'):
+        try:
+            version = metadata.version(dist_name)
+            break
+        except Exception:
+            continue
+
+print(f"__VLLM_HUST_BACKEND_VERSION__={version or ''}")
+PY
+)
+
+  detected=$(printf '%s\n' "$raw_output" | sed -n 's/^__VLLM_HUST_BACKEND_VERSION__=//p' | tail -n 1)
+  detected=$(printf '%s' "$detected" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')
+
+  if is_valid_engine_version "$detected"; then
+    printf '%s' "$detected"
+    return 0
+  fi
+
+  fallback=$(git -C "$OFFICIAL_VLLM_ASCEND_WORKTREE" describe --tags --always HEAD 2>/dev/null || true)
+  if is_valid_engine_version "$fallback"; then
+    printf '%s' "$fallback"
+    return 0
+  fi
+
+  printf '%s' "unknown"
+}
 }
 
 wait_for_server() {
@@ -428,6 +521,20 @@ GIT_COMMIT=$(jq -r '.export.git_commit' "$SPEC_FILE")
 DATA_SOURCE=$(jq -r '.export.data_source' "$SPEC_FILE")
 INPUT_LEN=$(jq -r '.client_parameters.input_len' "$SPEC_FILE")
 OUTPUT_LEN=$(jq -r '.client_parameters.output_len' "$SPEC_FILE")
+
+if [[ -z "$OFFICIAL_CORE_VERSION" ]]; then
+  OFFICIAL_CORE_VERSION=$(detect_official_core_version)
+fi
+if ! is_valid_engine_version "$OFFICIAL_CORE_VERSION"; then
+  OFFICIAL_CORE_VERSION="$ENGINE_VERSION"
+fi
+
+if [[ -z "$OFFICIAL_BACKEND_VERSION" ]]; then
+  OFFICIAL_BACKEND_VERSION=$(detect_official_backend_version)
+fi
+if ! is_valid_engine_version "$OFFICIAL_BACKEND_VERSION"; then
+  OFFICIAL_BACKEND_VERSION="$ENGINE_VERSION"
+fi
 
 RUNTIME_MODEL="$MODEL"
 if cached_model_path=$(resolve_runtime_model); then
@@ -515,6 +622,8 @@ python -m vllm_hust_benchmark.cli export-leaderboard-artifact \
   --run-id "$RUN_ID" \
   --engine "$ENGINE" \
   --engine-version "$ENGINE_VERSION" \
+  --core-version "$OFFICIAL_CORE_VERSION" \
+  --backend-version "$OFFICIAL_BACKEND_VERSION" \
   --model-name "$MODEL" \
   --model-parameters "$MODEL_PARAMETERS" \
   --model-precision "$MODEL_PRECISION" \


### PR DESCRIPTION
## Summary
- pass explicit core/backend versions through the same-spec export path so new snapshots stop emitting `N/A` for the stack versions
- backfill the safe historical snapshot rows whose core/backend versions can be recovered from runtime provenance or the same April 17 benchmark batch
- leave the official reference baseline untouched because its snapshot still lacks enough provenance to backfill safely

## Validation
- bash -n scripts/run-current-ascend-same-spec.sh
- python3 JSON parse/coverage checks for leaderboard-data/snapshots/leaderboard_single.json and leaderboard_multi.json
- git diff --check
