### PR TITLE
[Feat][Benchmark] Add official Ascend baseline workflow

### DIFF
--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -1,0 +1,194 @@
+name: Run Official Ascend Baselines
+
+'on':
+  workflow_dispatch:
+    inputs:
+      spec_paths:
+        description: Optional newline-separated spec files or directories. Defaults to docs/official-baselines.
+        required: false
+        type: string
+        default: ""
+      repeat_count:
+        description: Repeat count for specs that do not yet have a canonical run.
+        required: false
+        type: number
+        default: 3
+      force_run_existing:
+        description: Re-run even when canonical submissions already exist. Existing canonical submissions are preserved.
+        required: false
+        type: boolean
+        default: false
+      prepare_official_env:
+        description: Prepare or repair the pinned official baseline conda env before running.
+        required: false
+        type: boolean
+        default: true
+      publish_website:
+        description: Rebuild website data from submissions after the batch.
+        required: false
+        type: boolean
+        default: false
+      force_repair_official_env:
+        description: Skip the prepare-script health check and force a full repair/reinstall of the official env.
+        required: false
+        type: boolean
+        default: false
+      website_ref:
+        description: Optional vllm-hust-website ref to use when publish_website is enabled.
+        required: false
+        type: string
+        default: main
+      goal_baseline_env_prefix:
+        description: Optional conda env prefix for the official v0.11.0 baseline runtime. Leave blank to resolve from conda info --base on the runner.
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run-official-baselines:
+    runs-on:
+      - self-hosted
+      - linux-aarch64-a2b3-0
+      - docker
+    timeout-minutes: 360
+    env:
+      HF_HUB_DISABLE_TELEMETRY: "1"
+      HF_ENDPOINT: ${{ vars.HF_ENDPOINT || 'https://hf-mirror.com' }}
+      HF_HOME: ${{ github.workspace }}/../.hf-cache
+      HUGGINGFACE_HUB_CACHE: ${{ github.workspace }}/../.hf-cache/hub
+      TRANSFORMERS_CACHE: ${{ github.workspace }}/../.hf-cache/transformers
+      MATRIX_RUN_ID: official-ascend-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+      MATRIX_RESULT_ROOT: ${{ github.workspace }}/.benchmarks/official-ascend-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+      MATRIX_SUMMARY_FILE: ${{ github.workspace }}/artifacts/official-baseline/summary.md
+      REPEAT_COUNT: ${{ github.event.inputs.repeat_count || 3 }}
+      FORCE_RUN_EXISTING: ${{ github.event.inputs.force_run_existing == 'true' && '1' || '0' }}
+      PREPARE_OFFICIAL_ENV: ${{ github.event.inputs.prepare_official_env == 'false' && '0' || '1' }}
+      FORCE_REPAIR_OFFICIAL_ENV: ${{ github.event.inputs.force_repair_official_env == 'true' && '1' || '0' }}
+      PUBLISH_WEBSITE: ${{ github.event.inputs.publish_website == 'true' && '1' || '0' }}
+      VLLM_HUST_WEBSITE_REF: ${{ github.event.inputs.website_ref || 'main' }}
+    steps:
+      - name: Pre-clean generated directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$GITHUB_WORKSPACE/reference-repos" \
+                 "$GITHUB_WORKSPACE/vllm-hust-website" \
+                 "$GITHUB_WORKSPACE/.benchmarks" \
+                 "$GITHUB_WORKSPACE/artifacts"
+          mkdir -p "$GITHUB_WORKSPACE/artifacts/official-baseline"
+
+      - name: Checkout benchmark repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout upstream vllm reference repo
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm
+          path: reference-repos/vllm
+          fetch-depth: 0
+
+      - name: Checkout upstream vllm-ascend reference repo
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm-ascend
+          path: reference-repos/vllm-ascend
+          fetch-depth: 0
+
+      - name: Checkout website repo
+        if: ${{ inputs.publish_website }}
+        uses: actions/checkout@v4
+        with:
+          repository: vLLM-HUST/vllm-hust-website
+          ref: ${{ env.VLLM_HUST_WEBSITE_REF }}
+          path: vllm-hust-website
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve official env prefix
+        shell: bash
+        env:
+          GOAL_BASELINE_ENV_PREFIX_INPUT: ${{ github.event.inputs.goal_baseline_env_prefix || '' }}
+        run: |
+          set -euo pipefail
+          env_prefix="${GOAL_BASELINE_ENV_PREFIX_INPUT}"
+          if [[ -z "${env_prefix//[[:space:]]/}" ]]; then
+            env_prefix="$(conda info --base)/envs/vllm-ascend-official-v0110"
+          fi
+
+          printf 'GOAL_BASELINE_ENV_PREFIX=%s\n' "$env_prefix" >> "$GITHUB_ENV"
+          echo "Resolved GOAL_BASELINE_ENV_PREFIX=$env_prefix"
+          echo "FORCE_REPAIR_OFFICIAL_ENV=$FORCE_REPAIR_OFFICIAL_ENV"
+
+      - name: Resolve spec arguments
+        id: resolve-specs
+        shell: bash
+        env:
+          SPEC_PATHS_INPUT: ${{ github.event.inputs.spec_paths || '' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SPEC_PATHS_INPUT//[[:space:]]/}" ]]; then
+            {
+              echo 'args<<EOF'
+              echo 'docs/official-baselines'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo 'args<<EOF'
+            while IFS= read -r line; do
+              [[ -z "${line//[[:space:]]/}" ]] && continue
+              printf '%s\n' "$line"
+            done <<< "$SPEC_PATHS_INPUT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run official baseline matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          spec_args=()
+          while IFS= read -r item; do
+            [[ -z "$item" ]] && continue
+            spec_args+=("$item")
+          done <<< "${{ steps.resolve-specs.outputs.args }}"
+
+          if [[ ${#spec_args[@]} -eq 0 ]]; then
+            spec_args+=("docs/official-baselines")
+          fi
+
+          bash scripts/run-official-ascend-goal-baseline-matrix.sh "${spec_args[@]}"
+
+      - name: Upload official baseline summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: official-baseline-summary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/official-baseline/summary.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload official baseline results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: official-baseline-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .benchmarks/official-ascend-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+            submissions/official-ascend-*
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ Current baseline target:
 
 - official `vllm v0.11.0`
 - official `vllm-ascend v0.11.0`
-- scenario `random-online`
-- model `Qwen/Qwen2.5-14B-Instruct`
-- hardware `Huawei 910B3`
+- canonical spec set under `docs/official-baselines/*.json`
+- current hardware target `Huawei 910B3`
+
+The official baseline set is no longer a single `random-online` spec. The canonical spec files under `docs/official-baselines/` are the source of truth for all official scenarios that need a baseline under the pinned January 2026 `v0.11.0` runtime pair.
 
 Files:
 
@@ -230,23 +231,48 @@ Files:
 Example:
 
 ```bash
-export ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110
+export ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
 bash scripts/prepare-official-ascend-baseline-env.sh
 
-export GOAL_BASELINE_ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110
+export GOAL_BASELINE_ENV_PREFIX="$ENV_PREFIX"
 bash scripts/run-official-ascend-goal-baseline.sh \
 	docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+```
+
+Batch trigger for all official specs:
+
+```bash
+export GOAL_BASELINE_ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+bash scripts/run-official-ascend-goal-baseline-matrix.sh
+```
+
+Batch trigger with repeated candidate selection for missing canonical specs:
+
+```bash
+export GOAL_BASELINE_ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+REPEAT_COUNT=3 bash scripts/run-official-ascend-goal-baseline-matrix.sh
 ```
 
 Notes:
 
 - `prepare-official-ascend-baseline-env.sh` creates or repairs a dedicated conda env for the fixed official baseline only.
+- `prepare-official-ascend-baseline-env.sh` now starts with a health check. If the existing env already matches the pinned official baseline, it skips the heavy uninstall/reinstall path and reuses the env as-is.
+- If `ENV_PREFIX` is unset, the prepare script now defaults it to `$(conda info --base)/envs/vllm-ascend-official-v0110` instead of assuming `/root/miniconda3/...`.
 - `prepare-official-ascend-baseline-env.sh` also owns the benchmark admission preflight: it proactively cleans residual `api_server` / `bench serve` / `EngineCore_DP0` processes and clears the benchmark port before a new run is allowed to start.
 - The baseline runtime is pinned to `reference-repos/vllm@v0.11.0` and `reference-repos/vllm-ascend@v0.11.0` worktrees.
 - The prepare script intentionally does not install `vllm-hust` or `vllm-ascend-hust` into the official env, to avoid plugin-entry-point contamination.
+- The prepare script now defaults `PYTORCH_CPU_INDEX_URL` to `https://download.pytorch.org/whl/cpu` in addition to the Ascend mirror, so `torch==...+cpu` dependencies from `torch-npu` metadata can resolve.
+- The torch family package pins are configurable with `OFFICIAL_TORCH_VERSION`, `OFFICIAL_TORCH_NPU_VERSION`, `OFFICIAL_TORCHVISION_VERSION`, and `OFFICIAL_TORCHAUDIO_VERSION`.
+- For the default official version set on `Python 3.11`, the prepare script now auto-selects built-in archived wheel URLs for both `x86_64` and `aarch64`, based on the local machine architecture.
+- You can bypass drifting package indexes with explicit wheel URLs: `OFFICIAL_TORCH_WHEEL_URL`, `OFFICIAL_TORCH_NPU_WHEEL_URL`, `OFFICIAL_TORCHVISION_WHEEL_URL`, and `OFFICIAL_TORCHAUDIO_WHEEL_URL`.
+- If you override the default torch-family versions or use a different Python ABI, the script falls back to index-based resolution unless you also provide explicit wheel URLs.
 - The runner executes against the pinned worktrees through `PYTHONPATH` and defaults `VLLM_CACHE_ROOT` to `.cache/official-ascend-goal-baseline/` in this repository.
 - The runner calls the same prepare script in admission-only mode immediately before benchmark startup, so residual-process cleanup is a hard precondition rather than a manual step.
 - The runner prefers a locally cached Hugging Face snapshot for the target model when one already exists. You can also force a specific local model directory with `OFFICIAL_MODEL_PATH=/abs/model/path`.
+- `run-official-ascend-goal-baseline-matrix.sh` is the batch trigger for official baseline establishment. It skips specs that already have canonical submissions under `submissions/<spec-id>/` and prints a hint instead of re-running them.
+- When a spec has no canonical submission yet, `run-official-ascend-goal-baseline-matrix.sh` repeats it `REPEAT_COUNT` times (default `3`), chooses the run whose primary metric is closest to the median candidate, and promotes only that run into `submissions/<spec-id>/`.
+- Set `FORCE_RUN_EXISTING=1` only when you intentionally want a review-only rerun. The matrix runner preserves the current canonical submission and leaves the new result under `.benchmarks/` for manual comparison instead of auto-replacing it.
+- For official baseline workflow dispatch in GitHub Actions, use `.github/workflows/run-official-ascend-baselines.yml`. It runs the same matrix trigger on the self-hosted Ascend runner and uploads the summary plus generated result directories as artifacts, but it does not auto-commit canonical updates.
 
 This produces:
 
@@ -254,6 +280,111 @@ This produces:
 - a website-compatible leaderboard artifact under `.benchmarks/official-ascend-goal-baseline/submission/`
 
 The exported artifact can then be aggregated into `vllm-hust-website` with `publish-website` or `vllm-hust-website/scripts/aggregate_results.py`.
+
+### Triggering Locally
+
+Recommended first establishment run for all missing official specs:
+
+```bash
+cd /path/to/vllm-hust-benchmark
+export GOAL_BASELINE_ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+REPEAT_COUNT=3 bash scripts/run-official-ascend-goal-baseline-matrix.sh
+```
+
+Run only one spec file:
+
+```bash
+cd /path/to/vllm-hust-benchmark
+export GOAL_BASELINE_ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+REPEAT_COUNT=3 bash scripts/run-official-ascend-goal-baseline-matrix.sh \
+	docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
+```
+
+Run a review-only rerun for a spec that already has canonical data:
+
+```bash
+cd /path/to/vllm-hust-benchmark
+export GOAL_BASELINE_ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+FORCE_RUN_EXISTING=1 REPEAT_COUNT=3 bash scripts/run-official-ascend-goal-baseline-matrix.sh \
+	docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+```
+
+Useful local switches:
+
+- `PREPARE_OFFICIAL_ENV=1` (default): create or repair the pinned official env before the batch.
+- `FORCE_REPAIR_OFFICIAL_ENV=1`: bypass the prepare script health check and force a full reinstall/repair of the official env.
+- `REPEAT_COUNT=3`: recommended default for establishing a missing canonical spec.
+- `FORCE_RUN_EXISTING=1`: rerun even if canonical data already exists, but do not overwrite canonical automatically.
+- `PUBLISH_WEBSITE=1`: rebuild `vllm-hust-website/data` from the full `submissions/` tree after the batch.
+- `PYTORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu`: default CPU wheel index used by the prepare script for torch-family dependency resolution.
+- `OFFICIAL_TORCH_NPU_WHEEL_URL=<exact-wheel-url>`: preferred escape hatch when the historical `torch-npu` build has disappeared from the live mirror.
+
+Outputs:
+
+- Per-run artifacts go to `.benchmarks/<matrix-run-id>/...`
+- Promoted canonical submissions go to `submissions/<spec-id>/`
+- The batch summary goes to `.benchmarks/<matrix-run-id>/summary.md` unless `MATRIX_SUMMARY_FILE` is overridden.
+
+### Triggering The Workflow
+
+The manual workflow entrypoint is `.github/workflows/run-official-ascend-baselines.yml` and is intended for a self-hosted Ascend runner.
+
+Recommended `workflow_dispatch` inputs for the first full establishment run:
+
+- `spec_paths`: leave blank to cover `docs/official-baselines`
+- `repeat_count`: `3`
+- `force_run_existing`: `false`
+- `prepare_official_env`: `true`
+- `force_repair_official_env`: `false`
+- `publish_website`: `false`
+- `website_ref`: `main`
+- `goal_baseline_env_prefix`: leave blank unless the runner must use a non-default conda base; blank resolves to `$(conda info --base)/envs/vllm-ascend-official-v0110` on the runner
+
+Workflow visibility note:
+
+- GitHub can only dispatch workflows that already exist on the remote repository. Before using `gh workflow run`, commit and push `.github/workflows/run-official-ascend-baselines.yml` to the branch you want to dispatch.
+- If you are validating from a feature branch before merge, pass `--ref <branch>` so GitHub dispatches the workflow definition from that remote branch.
+
+Trigger from GitHub UI:
+
+1. Open the Actions page for this repository.
+2. Select `Run Official Ascend Baselines`.
+3. Click `Run workflow`.
+4. Fill `spec_paths` only when you want a subset. Leave it blank for the full official set.
+
+Trigger from `gh` CLI:
+
+```bash
+cd /path/to/vllm-hust-benchmark
+gh workflow run run-official-ascend-baselines.yml \
+	--ref ws/run-official-baseline \
+	-f repeat_count=3 \
+	-f force_run_existing=false \
+	-f prepare_official_env=true \
+	-f force_repair_official_env=false \
+	-f publish_website=false \
+	-f website_ref=main
+```
+
+Trigger a subset from `gh` CLI by passing newline-separated `spec_paths`:
+
+```bash
+cd /path/to/vllm-hust-benchmark
+gh workflow run run-official-ascend-baselines.yml \
+	--ref ws/run-official-baseline \
+	-f spec_paths='docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
+docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-throughput-qwen25-14b-910b3.json' \
+	-f repeat_count=3 \
+	-f force_repair_official_env=false \
+	-f force_run_existing=false
+```
+
+Workflow artifacts:
+
+- `official-baseline-summary-<run_id>-<attempt>`: the batch summary markdown.
+- `official-baseline-results-<run_id>-<attempt>`: `.benchmarks/...` results and any promoted `submissions/official-ascend-*` directories.
+
+The workflow does not auto-commit promoted canonical submissions back to the repository. Review the uploaded artifacts or the self-hosted runner workspace first, then decide whether to commit the promoted `submissions/<spec-id>/` directories.
 
 ## Batch Same-Spec Matrices
 

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-instructcoder-online-qwen25-coder-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-instructcoder-online-qwen25-coder-14b-910b3.json
@@ -1,0 +1,50 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-instructcoder-online-qwen25-coder-14b-910b3",
+  "label": "Official Ascend Jan 2026 InstructCoder online baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "instructcoder-online",
+  "model": "Qwen/Qwen2.5-Coder-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "hf",
+    "dataset_path": "likaixin/InstructCoder",
+    "num_prompts": 2048,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-prefix-repetition-online-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-prefix-repetition-online-qwen25-14b-910b3.json
@@ -1,0 +1,51 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-prefix-repetition-online-qwen25-14b-910b3",
+  "label": "Official Ascend Jan 2026 prefix repetition online baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "prefix-repetition-online",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "prefix_repetition",
+    "num_prompts": 200,
+    "input_len": 4096,
+    "output_len": 256,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-random-latency-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-random-latency-qwen25-14b-910b3.json
@@ -1,0 +1,44 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-random-latency-qwen25-14b-910b3",
+  "label": "Official Ascend Jan 2026 random latency baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "random-latency",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": ""
+  },
+  "client_parameters": {
+    "input_len": 1024,
+    "output_len": 128,
+    "batch_size": 8,
+    "num_iters_warmup": 10,
+    "num_iters": 30
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
@@ -1,0 +1,50 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-sharegpt-online-qwen25-14b-910b3",
+  "label": "Official Ascend Jan 2026 ShareGPT online baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "sharegpt-online",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "sharegpt",
+    "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+    "num_prompts": 200,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-throughput-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-throughput-qwen25-14b-910b3.json
@@ -1,0 +1,44 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-sharegpt-throughput-qwen25-14b-910b3",
+  "label": "Official Ascend Jan 2026 ShareGPT throughput baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "sharegpt-throughput",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": ""
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "dataset_name": "sharegpt",
+    "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+    "num_prompts": 200,
+    "num_warmups": 0
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-sonnet-throughput-qwen25-14b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-sonnet-throughput-qwen25-14b-910b3.json
@@ -1,0 +1,44 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-sonnet-throughput-qwen25-14b-910b3",
+  "label": "Official Ascend Jan 2026 sonnet throughput baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "sonnet-throughput",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": ""
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "dataset_name": "sonnet",
+    "dataset_path": "benchmarks/sonnet.txt",
+    "num_prompts": 200,
+    "num_warmups": 0
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0110-visionarena-online-qwen25-vl-7b-910b3.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0110-visionarena-online-qwen25-vl-7b-910b3.json
@@ -1,0 +1,52 @@
+{
+  "id": "official-ascend-jan-2026-v0.11.0-visionarena-online-qwen25-vl-7b-910b3",
+  "label": "Official Ascend Jan 2026 VisionArena online baseline for vllm-hust goal tracking",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.11.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.11.0",
+    "vllm_ascend_ref": "v0.11.0"
+  },
+  "scenario": "visionarena-online",
+  "model": "Qwen/Qwen2.5-VL-7B-Instruct",
+  "model_parameters": "7B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B3",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "limit_mm_per_prompt": "image=1",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "openai-chat",
+    "endpoint": "/v1/chat/completions",
+    "dataset_name": "hf",
+    "dataset_path": "lmarena-ai/VisionArena-Chat",
+    "hf_split": "train",
+    "num_prompts": 1000,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.11.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.11.0",
+    "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
 
-ENV_PREFIX=${ENV_PREFIX:-"/root/miniconda3/envs/vllm-ascend-official-v0110"}
+ENV_PREFIX=${ENV_PREFIX:-""}
 PYTHON_VERSION=${PYTHON_VERSION:-"3.11"}
 OFFICIAL_VLLM_REPO=${OFFICIAL_VLLM_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm"}
 OFFICIAL_VLLM_ASCEND_REPO=${OFFICIAL_VLLM_ASCEND_REPO:-"$WORKSPACE_ROOT/reference-repos/vllm-ascend"}
@@ -19,8 +19,20 @@ ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolk
 ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
 ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
 EXTRA_PYPI_INDEX=${EXTRA_PYPI_INDEX:-"https://mirrors.huaweicloud.com/ascend/repos/pypi"}
-
-export ENV_PREFIX
+PYTORCH_CPU_INDEX_URL=${PYTORCH_CPU_INDEX_URL:-"https://download.pytorch.org/whl/cpu"}
+DEFAULT_OFFICIAL_TORCH_VERSION="2.7.1"
+DEFAULT_OFFICIAL_TORCH_NPU_VERSION="2.7.1.post1"
+DEFAULT_OFFICIAL_TORCHVISION_VERSION="0.22.1"
+DEFAULT_OFFICIAL_TORCHAUDIO_VERSION="2.7.1"
+OFFICIAL_TORCH_VERSION=${OFFICIAL_TORCH_VERSION:-"$DEFAULT_OFFICIAL_TORCH_VERSION"}
+OFFICIAL_TORCH_NPU_VERSION=${OFFICIAL_TORCH_NPU_VERSION:-"$DEFAULT_OFFICIAL_TORCH_NPU_VERSION"}
+OFFICIAL_TORCHVISION_VERSION=${OFFICIAL_TORCHVISION_VERSION:-"$DEFAULT_OFFICIAL_TORCHVISION_VERSION"}
+OFFICIAL_TORCHAUDIO_VERSION=${OFFICIAL_TORCHAUDIO_VERSION:-"$DEFAULT_OFFICIAL_TORCHAUDIO_VERSION"}
+OFFICIAL_TORCH_WHEEL_URL=${OFFICIAL_TORCH_WHEEL_URL:-""}
+OFFICIAL_TORCH_NPU_WHEEL_URL=${OFFICIAL_TORCH_NPU_WHEEL_URL:-""}
+OFFICIAL_TORCHVISION_WHEEL_URL=${OFFICIAL_TORCHVISION_WHEEL_URL:-""}
+OFFICIAL_TORCHAUDIO_WHEEL_URL=${OFFICIAL_TORCHAUDIO_WHEEL_URL:-""}
+FORCE_REPAIR_OFFICIAL_ENV=${FORCE_REPAIR_OFFICIAL_ENV:-"0"}
 
 ensure_worktree() {
   local source_repo=$1
@@ -45,6 +57,282 @@ run_with_ascend_env() {
     set -u
   fi
   "$@"
+}
+
+normalize_arch() {
+  case "$1" in
+    x86_64|amd64)
+      printf '%s\n' "x86_64"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "aarch64"
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
+resolve_python_abi_tag() {
+  printf '%s\n' "$1" | sed -E 's/^([0-9]+)\.([0-9]+).*$/cp\1\2/'
+}
+
+add_pip_extra_index_arg() {
+  local index_url=$1
+  if [[ -n "$index_url" ]]; then
+    PIP_EXTRA_INDEX_ARGS+=(--extra-index-url "$index_url")
+  fi
+}
+
+resolve_default_package_version() {
+  case "$1" in
+    torch)
+      printf '%s\n' "$DEFAULT_OFFICIAL_TORCH_VERSION"
+      ;;
+    torch-npu)
+      printf '%s\n' "$DEFAULT_OFFICIAL_TORCH_NPU_VERSION"
+      ;;
+    torchvision)
+      printf '%s\n' "$DEFAULT_OFFICIAL_TORCHVISION_VERSION"
+      ;;
+    torchaudio)
+      printf '%s\n' "$DEFAULT_OFFICIAL_TORCHAUDIO_VERSION"
+      ;;
+    *)
+      printf '%s\n' ""
+      ;;
+  esac
+}
+
+resolve_default_archived_wheel_url() {
+  local package_name=$1
+  local python_abi_tag=$2
+  local runtime_arch=$3
+
+  case "$package_name:$python_abi_tag:$runtime_arch" in
+    torch:cp311:x86_64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torch-2.7.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl"
+      ;;
+    torch:cp311:aarch64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torch-2.7.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl"
+      ;;
+    torch-npu:cp311:x86_64)
+      printf '%s\n' "https://mirrors.huaweicloud.com/ascend/repos/pypi/torch-npu/torch_npu-2.7.1.post1-cp311-cp311-manylinux_2_28_x86_64.whl"
+      ;;
+    torch-npu:cp311:aarch64)
+      printf '%s\n' "https://mirrors.huaweicloud.com/ascend/repos/pypi/torch-npu/torch_npu-2.7.1.post1-cp311-cp311-manylinux_2_28_aarch64.whl"
+      ;;
+    torchvision:cp311:x86_64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torchvision-0.22.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl"
+      ;;
+    torchvision:cp311:aarch64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torchvision-0.22.1-cp311-cp311-manylinux_2_28_aarch64.whl"
+      ;;
+    torchaudio:cp311:x86_64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.7.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl"
+      ;;
+    torchaudio:cp311:aarch64)
+      printf '%s\n' "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl"
+      ;;
+    *)
+      printf '%s\n' ""
+      ;;
+  esac
+}
+
+create_filtered_requirements_file() {
+  local source_file=$1
+  local target_file=$2
+
+  awk '
+    /^[[:space:]]*(torch|torch-npu|torch_npu|torchvision|torchaudio)([[:space:]]|[<>=!~].*)?$/ {
+      next
+    }
+    {
+      print
+    }
+  ' "$source_file" > "$target_file"
+}
+
+resolve_package_install_target() {
+  local package_name=$1
+  local package_version=$2
+  local wheel_url=$3
+  local default_package_version
+  local default_archived_wheel_url
+
+  if [[ -n "$wheel_url" ]]; then
+    printf '%s\n' "$wheel_url"
+    return 0
+  fi
+
+  default_package_version=$(resolve_default_package_version "$package_name")
+  if [[ -n "$default_package_version" ]] && [[ "$package_version" == "$default_package_version" ]]; then
+    default_archived_wheel_url=$(resolve_default_archived_wheel_url "$package_name" "$OFFICIAL_PYTHON_ABI_TAG" "$OFFICIAL_RUNTIME_ARCH")
+    if [[ -n "$default_archived_wheel_url" ]]; then
+      printf '%s\n' "$default_archived_wheel_url"
+      return 0
+    fi
+  fi
+
+  printf '%s==%s\n' "$package_name" "$package_version"
+}
+
+emit_prepared_env_summary() {
+  echo "Prepared official Ascend baseline env at $ENV_PREFIX"
+  echo "Pinned runtime source refs: vllm=$OFFICIAL_VLLM_REF vllm-ascend=$OFFICIAL_VLLM_ASCEND_REF"
+  echo "Resolved runtime arch: $OFFICIAL_RUNTIME_ARCH"
+  echo "Resolved python ABI tag: $OFFICIAL_PYTHON_ABI_TAG"
+  echo "Resolved package targets: torch=$OFFICIAL_TORCH_INSTALL_TARGET torch-npu=$OFFICIAL_TORCH_NPU_INSTALL_TARGET torchvision=$OFFICIAL_TORCHVISION_INSTALL_TARGET torchaudio=$OFFICIAL_TORCHAUDIO_INSTALL_TARGET"
+  echo "Use with: GOAL_BASELINE_ENV_PREFIX=$ENV_PREFIX bash $REPO_ROOT/scripts/run-official-ascend-goal-baseline.sh"
+}
+
+verify_official_env() {
+  PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE${PYTHONPATH:+:$PYTHONPATH}" \
+  run_with_ascend_env conda run -p "$ENV_PREFIX" env \
+    OFFICIAL_EXPECTED_PYTHON_VERSION="$PYTHON_VERSION" \
+    OFFICIAL_EXPECTED_SETUPTOOLS_SPEC=">=77.0.3,<80.0.0" \
+    OFFICIAL_EXPECTED_VLLM_WORKTREE="$OFFICIAL_VLLM_WORKTREE" \
+    OFFICIAL_EXPECTED_VLLM_ASCEND_WORKTREE="$OFFICIAL_VLLM_ASCEND_WORKTREE" \
+    OFFICIAL_EXPECTED_TORCH_TARGET="$OFFICIAL_TORCH_INSTALL_TARGET" \
+    OFFICIAL_EXPECTED_TORCH_NPU_TARGET="$OFFICIAL_TORCH_NPU_INSTALL_TARGET" \
+    OFFICIAL_EXPECTED_TORCHVISION_TARGET="$OFFICIAL_TORCHVISION_INSTALL_TARGET" \
+    OFFICIAL_EXPECTED_TORCHAUDIO_TARGET="$OFFICIAL_TORCHAUDIO_INSTALL_TARGET" \
+    OFFICIAL_EXPECTED_NUMPY_VERSION="1.26.4" \
+    OFFICIAL_EXPECTED_TRANSFORMERS_VERSION="4.57.1" \
+    OFFICIAL_EXPECTED_COMPRESSED_TENSORS_VERSION="0.11.0" \
+    OFFICIAL_EXPECTED_DEPYF_VERSION="0.19.0" \
+    OFFICIAL_EXPECTED_LLGUIDANCE_VERSION="0.7.30" \
+    OFFICIAL_EXPECTED_XGRAMMAR_VERSION="0.1.25" \
+    OFFICIAL_EXPECTED_FASTAPI_VERSION="0.123.10" \
+    OFFICIAL_EXPECTED_NUMBA_VERSION="0.61.2" \
+    OFFICIAL_EXPECTED_OPENCV_VERSION="4.11.0.86" \
+    python - <<'PY'
+import os
+import sys
+from importlib import metadata
+from importlib.metadata import entry_points
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+def fail(message: str) -> None:
+  print(f"[official-env] health check failed: {message}", file=sys.stderr)
+  raise SystemExit(1)
+
+
+def dist_version(*names: str) -> str:
+  for name in names:
+    try:
+      return metadata.version(name)
+    except metadata.PackageNotFoundError:
+      continue
+  joined = ", ".join(names)
+  raise metadata.PackageNotFoundError(f"No package metadata was found for {joined}")
+
+
+def ensure_absent(*names: str) -> None:
+  for name in names:
+    try:
+      version = metadata.version(name)
+    except metadata.PackageNotFoundError:
+      continue
+    fail(f"unexpected installed distribution {name}=={version}")
+
+
+def expected_version_from_target(target: str) -> str:
+  if not target:
+    fail("empty package target")
+
+  if "://" not in target and "==" in target:
+    return target.split("==", 1)[1].strip()
+
+  filename = unquote(Path(urlparse(target).path).name)
+  if not filename.endswith(".whl"):
+    fail(f"cannot parse expected version from target: {target}")
+
+  parts = filename[:-4].split("-")
+  if len(parts) < 5:
+    fail(f"unexpected wheel filename format: {filename}")
+
+  return parts[1]
+
+
+def assert_loaded_from(path_value: str, expected_root: str, label: str) -> None:
+  resolved_path = str(Path(path_value).resolve())
+  resolved_root = str(Path(expected_root).resolve())
+  if resolved_path != resolved_root and not resolved_path.startswith(resolved_root + os.sep):
+    fail(f"{label} loaded from {resolved_path}, expected under {resolved_root}")
+
+
+try:
+  from packaging.specifiers import SpecifierSet
+  from packaging.version import Version
+except Exception as exc:  # pragma: no cover - repair path handles this.
+  fail(f"required health-check dependency packaging is unavailable: {exc}")
+
+expected_python_version = os.environ["OFFICIAL_EXPECTED_PYTHON_VERSION"]
+actual_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+if actual_python_version != expected_python_version:
+  fail(f"python version is {actual_python_version}, expected {expected_python_version}")
+
+import torch
+import torch_npu
+import vllm
+import vllm_ascend
+
+assert_loaded_from(vllm.__file__, os.environ["OFFICIAL_EXPECTED_VLLM_WORKTREE"], "vllm")
+assert_loaded_from(vllm_ascend.__file__, os.environ["OFFICIAL_EXPECTED_VLLM_ASCEND_WORKTREE"], "vllm_ascend")
+
+expected_versions = (
+  (("torch",), expected_version_from_target(os.environ["OFFICIAL_EXPECTED_TORCH_TARGET"])),
+  (("torch-npu", "torch_npu"), expected_version_from_target(os.environ["OFFICIAL_EXPECTED_TORCH_NPU_TARGET"])),
+  (("torchvision",), expected_version_from_target(os.environ["OFFICIAL_EXPECTED_TORCHVISION_TARGET"])),
+  (("torchaudio",), expected_version_from_target(os.environ["OFFICIAL_EXPECTED_TORCHAUDIO_TARGET"])),
+  (("numpy",), os.environ["OFFICIAL_EXPECTED_NUMPY_VERSION"]),
+  (("transformers",), os.environ["OFFICIAL_EXPECTED_TRANSFORMERS_VERSION"]),
+  (("compressed-tensors",), os.environ["OFFICIAL_EXPECTED_COMPRESSED_TENSORS_VERSION"]),
+  (("depyf",), os.environ["OFFICIAL_EXPECTED_DEPYF_VERSION"]),
+  (("llguidance",), os.environ["OFFICIAL_EXPECTED_LLGUIDANCE_VERSION"]),
+  (("xgrammar",), os.environ["OFFICIAL_EXPECTED_XGRAMMAR_VERSION"]),
+  (("fastapi",), os.environ["OFFICIAL_EXPECTED_FASTAPI_VERSION"]),
+  (("numba",), os.environ["OFFICIAL_EXPECTED_NUMBA_VERSION"]),
+  (("opencv-python-headless",), os.environ["OFFICIAL_EXPECTED_OPENCV_VERSION"]),
+)
+
+for names, expected_version in expected_versions:
+  actual_version = dist_version(*names)
+  if actual_version != expected_version:
+    fail(f"{names[0]} version is {actual_version}, expected {expected_version}")
+
+setuptools_version = dist_version("setuptools")
+setuptools_spec = SpecifierSet(os.environ["OFFICIAL_EXPECTED_SETUPTOOLS_SPEC"])
+if Version(setuptools_version) not in setuptools_spec:
+  fail(
+    f"setuptools version is {setuptools_version}, expected {os.environ['OFFICIAL_EXPECTED_SETUPTOOLS_SPEC']}"
+  )
+
+ensure_absent("vllm", "vllm-hust", "vllm_hust")
+ensure_absent("vllm-ascend", "vllm_ascend", "vllm-ascend-hust", "vllm_ascend_hust")
+
+print(f"env_prefix={os.environ['ENV_PREFIX']}")
+print(f"torch={torch.__version__}")
+print(f"torch_npu={torch_npu.__version__}")
+print(f"vllm_file={vllm.__file__}")
+print(f"vllm_ascend_file={vllm_ascend.__file__}")
+print(f"setuptools={setuptools_version}")
+print(f"compressed_tensors={dist_version('compressed-tensors')}")
+print(f"depyf={dist_version('depyf')}")
+print(f"llguidance={dist_version('llguidance')}")
+print(f"xgrammar={dist_version('xgrammar')}")
+print(f"fastapi={dist_version('fastapi')}")
+print(f"numba={dist_version('numba')}")
+print(f"transformers={dist_version('transformers')}")
+print(f"numpy={dist_version('numpy')}")
+print(f"opencv_python_headless={dist_version('opencv-python-headless')}")
+print("platform_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group="vllm.platform_plugins"))))
+print("general_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group="vllm.general_plugins"))))
+PY
 }
 
 list_port_listener_pids() {
@@ -126,6 +414,19 @@ if ! command -v conda >/dev/null 2>&1; then
   exit 2
 fi
 
+if [[ -z "$ENV_PREFIX" ]]; then
+  ENV_PREFIX="$(conda info --base)/envs/vllm-ascend-official-v0110"
+fi
+
+ENV_PREFIX_PARENT=$(dirname "$ENV_PREFIX")
+if [[ ! -d "$ENV_PREFIX" ]] && [[ ! -d "$ENV_PREFIX_PARENT" || ! -w "$ENV_PREFIX_PARENT" ]]; then
+  echo "ENV_PREFIX parent directory is not writable: $ENV_PREFIX_PARENT" >&2
+  echo "Set ENV_PREFIX to a writable conda env path before running this script." >&2
+  exit 2
+fi
+
+export ENV_PREFIX
+
 if [[ ! -d "$OFFICIAL_VLLM_REPO/.git" ]]; then
   echo "Official vllm repo not found: $OFFICIAL_VLLM_REPO" >&2
   exit 2
@@ -150,6 +451,40 @@ if [[ ! -d "$ENV_PREFIX" ]]; then
   conda create -y -p "$ENV_PREFIX" "python=$PYTHON_VERSION" pip
 fi
 
+OFFICIAL_RUNTIME_ARCH=$(normalize_arch "$(uname -m)")
+OFFICIAL_PYTHON_ABI_TAG=$(resolve_python_abi_tag "$PYTHON_VERSION")
+PIP_EXTRA_INDEX_ARGS=()
+add_pip_extra_index_arg "$EXTRA_PYPI_INDEX"
+add_pip_extra_index_arg "$PYTORCH_CPU_INDEX_URL"
+
+OFFICIAL_TORCH_INSTALL_TARGET=$(resolve_package_install_target torch "$OFFICIAL_TORCH_VERSION" "$OFFICIAL_TORCH_WHEEL_URL")
+OFFICIAL_TORCH_NPU_INSTALL_TARGET=$(resolve_package_install_target torch-npu "$OFFICIAL_TORCH_NPU_VERSION" "$OFFICIAL_TORCH_NPU_WHEEL_URL")
+OFFICIAL_TORCHVISION_INSTALL_TARGET=$(resolve_package_install_target torchvision "$OFFICIAL_TORCHVISION_VERSION" "$OFFICIAL_TORCHVISION_WHEEL_URL")
+OFFICIAL_TORCHAUDIO_INSTALL_TARGET=$(resolve_package_install_target torchaudio "$OFFICIAL_TORCHAUDIO_VERSION" "$OFFICIAL_TORCHAUDIO_WHEEL_URL")
+
+if [[ "$FORCE_REPAIR_OFFICIAL_ENV" != "1" ]]; then
+  if health_check_output=$(verify_official_env 2>&1); then
+    echo "[official-env] health check passed; existing env matches pinned official baseline"
+    printf '%s\n' "$health_check_output"
+    emit_prepared_env_summary
+    exit 0
+  fi
+
+  printf '%s\n' "$health_check_output" >&2
+  echo "[official-env] repairing env to match pinned official baseline"
+else
+  echo "[official-env] FORCE_REPAIR_OFFICIAL_ENV=1; skipping health check"
+fi
+
+FILTERED_REQUIREMENTS_DIR=$(mktemp -d)
+trap 'rm -rf "$FILTERED_REQUIREMENTS_DIR"' EXIT
+FILTERED_COMMON_REQUIREMENTS_FILE="$FILTERED_REQUIREMENTS_DIR/common.txt"
+FILTERED_ASCEND_REQUIREMENTS_FILE="$FILTERED_REQUIREMENTS_DIR/requirements.txt"
+FILTERED_BENCH_REQUIREMENTS_FILE="$FILTERED_REQUIREMENTS_DIR/requirements-bench.txt"
+create_filtered_requirements_file "$OFFICIAL_VLLM_WORKTREE/requirements/common.txt" "$FILTERED_COMMON_REQUIREMENTS_FILE"
+create_filtered_requirements_file "$OFFICIAL_VLLM_ASCEND_WORKTREE/requirements.txt" "$FILTERED_ASCEND_REQUIREMENTS_FILE"
+create_filtered_requirements_file "$OFFICIAL_VLLM_ASCEND_WORKTREE/benchmarks/requirements-bench.txt" "$FILTERED_BENCH_REQUIREMENTS_FILE"
+
 run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip uninstall -y \
   vllm \
   vllm-ascend \
@@ -172,21 +507,22 @@ run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade -
   "setuptools>=77.0.3,<80.0.0"
 
 run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall \
-  --extra-index-url "$EXTRA_PYPI_INDEX" \
-  torch==2.7.1 \
-  torch-npu==2.7.1 \
-  torchvision==0.22.1 \
-  torchaudio==2.7.1
+  "${PIP_EXTRA_INDEX_ARGS[@]}" \
+  "$OFFICIAL_TORCH_INSTALL_TARGET" \
+  "$OFFICIAL_TORCH_NPU_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHVISION_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHAUDIO_INSTALL_TARGET"
 
 run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall \
-  -r "$OFFICIAL_VLLM_WORKTREE/requirements/common.txt" \
-  -r "$OFFICIAL_VLLM_ASCEND_WORKTREE/requirements.txt" \
-  -r "$OFFICIAL_VLLM_ASCEND_WORKTREE/benchmarks/requirements-bench.txt" \
+  "${PIP_EXTRA_INDEX_ARGS[@]}" \
+  -r "$FILTERED_COMMON_REQUIREMENTS_FILE" \
+  -r "$FILTERED_ASCEND_REQUIREMENTS_FILE" \
+  -r "$FILTERED_BENCH_REQUIREMENTS_FILE" \
   "setuptools>=77.0.3,<80.0.0" \
-  torch==2.7.1 \
-  torch-npu==2.7.1 \
-  torchvision==0.22.1 \
-  torchaudio==2.7.1 \
+  "$OFFICIAL_TORCH_INSTALL_TARGET" \
+  "$OFFICIAL_TORCH_NPU_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHVISION_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHAUDIO_INSTALL_TARGET" \
   numpy==1.26.4 \
   transformers==4.57.1 \
   compressed-tensors==0.11.0 \
@@ -198,11 +534,12 @@ run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade -
   opencv-python-headless==4.11.0.86
 
 run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade --force-reinstall --no-deps \
+  "${PIP_EXTRA_INDEX_ARGS[@]}" \
   "setuptools>=77.0.3,<80.0.0" \
-  torch==2.7.1 \
-  torch-npu==2.7.1 \
-  torchvision==0.22.1 \
-  torchaudio==2.7.1 \
+  "$OFFICIAL_TORCH_INSTALL_TARGET" \
+  "$OFFICIAL_TORCH_NPU_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHVISION_INSTALL_TARGET" \
+  "$OFFICIAL_TORCHAUDIO_INSTALL_TARGET" \
   numpy==1.26.4 \
   transformers==4.57.1 \
   compressed-tensors==0.11.0 \
@@ -213,34 +550,6 @@ run_with_ascend_env conda run -p "$ENV_PREFIX" python -m pip install --upgrade -
   numba==0.61.2
 
 PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE${PYTHONPATH:+:$PYTHONPATH}" \
-  run_with_ascend_env conda run -p "$ENV_PREFIX" python - <<'PY'
-import os
-from importlib import metadata
-from importlib.metadata import entry_points
+  verify_official_env
 
-import torch
-import torch_npu
-import vllm
-import vllm_ascend
-
-print(f"env_prefix={os.environ['ENV_PREFIX']}")
-print(f"torch={torch.__version__}")
-print(f"torch_npu={torch_npu.__version__}")
-print(f"vllm_file={vllm.__file__}")
-print(f"vllm_ascend_file={vllm_ascend.__file__}")
-print(f"setuptools={metadata.version('setuptools')}")
-print(f"compressed_tensors={metadata.version('compressed-tensors')}")
-print(f"depyf={metadata.version('depyf')}")
-print(f"llguidance={metadata.version('llguidance')}")
-print(f"xgrammar={metadata.version('xgrammar')}")
-print(f"fastapi={metadata.version('fastapi')}")
-print(f"numba={metadata.version('numba')}")
-print(f"transformers={metadata.version('transformers')}")
-print(f"numpy={metadata.version('numpy')}")
-print("platform_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group='vllm.platform_plugins'))))
-print("general_plugins=" + ",".join(sorted(ep.name for ep in entry_points(group='vllm.general_plugins'))))
-PY
-
-echo "Prepared official Ascend baseline env at $ENV_PREFIX"
-echo "Pinned runtime source refs: vllm=$OFFICIAL_VLLM_REF vllm-ascend=$OFFICIAL_VLLM_ASCEND_REF"
-echo "Use with: GOAL_BASELINE_ENV_PREFIX=$ENV_PREFIX bash $REPO_ROOT/scripts/run-official-ascend-goal-baseline.sh"
+emit_prepared_env_summary

--- a/scripts/run-official-ascend-goal-baseline-matrix.sh
+++ b/scripts/run-official-ascend-goal-baseline-matrix.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
+PREPARE_SCRIPT=${PREPARE_SCRIPT:-"$SCRIPT_DIR/prepare-official-ascend-baseline-env.sh"}
+SINGLE_RUNNER=${SINGLE_RUNNER:-"$SCRIPT_DIR/run-official-ascend-goal-baseline.sh"}
+MATRIX_RUN_ID=${MATRIX_RUN_ID:-"official-ascend-goal-baseline-matrix-$(date -u +%Y%m%dT%H%M%SZ)"}
+MATRIX_RESULT_ROOT=${MATRIX_RESULT_ROOT:-"$REPO_ROOT/.benchmarks/$MATRIX_RUN_ID"}
+CANONICAL_SUBMISSIONS_ROOT=${CANONICAL_SUBMISSIONS_ROOT:-"$REPO_ROOT/submissions"}
+PUBLISH_WEBSITE=${PUBLISH_WEBSITE:-0}
+WEBSITE_OUTPUT_DIR=${WEBSITE_OUTPUT_DIR:-"$WORKSPACE_ROOT/vllm-hust-website/data"}
+FORCE_RUN_EXISTING=${FORCE_RUN_EXISTING:-0}
+REPEAT_COUNT=${REPEAT_COUNT:-3}
+PREPARE_OFFICIAL_ENV=${PREPARE_OFFICIAL_ENV:-1}
+SUMMARY_FILE=${MATRIX_SUMMARY_FILE:-"$MATRIX_RESULT_ROOT/summary.md"}
+PYTHON_BIN=${PYTHON_BIN:-$(command -v python3 || true)}
+PREPARED_ENV=0
+SKIPPED_COUNT=0
+RUN_COUNT=0
+PROMOTED_COUNT=0
+REVIEW_COUNT=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/run-official-ascend-goal-baseline-matrix.sh [<spec-file-or-dir> ...]
+
+Behavior:
+  - Defaults to docs/official-baselines when no path is provided
+  - Skips specs that already have canonical submissions under submissions/<spec-id>/
+  - Runs specs without canonical submissions through scripts/run-official-ascend-goal-baseline.sh
+  - Repeats missing-canonical specs REPEAT_COUNT times (default: 3)
+  - Chooses the repeat whose primary metric is closest to the median run and promotes only that candidate into canonical submissions/<spec-id>/
+  - Set FORCE_RUN_EXISTING=1 to run specs even when a canonical submission already exists
+    Existing canonical submissions are preserved and the new run is left in .benchmarks/ for manual review
+  - Set PUBLISH_WEBSITE=1 to rebuild website data from the full submissions/ tree after the batch
+
+Examples:
+  export GOAL_BASELINE_ENV_PREFIX=/root/miniconda3/envs/vllm-ascend-official-v0110
+  bash scripts/run-official-ascend-goal-baseline-matrix.sh
+
+  REPEAT_COUNT=5 bash scripts/run-official-ascend-goal-baseline-matrix.sh \
+    docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
+
+  FORCE_RUN_EXISTING=1 bash scripts/run-official-ascend-goal-baseline-matrix.sh \
+    docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+EOF
+}
+
+if [[ ! -x "$SINGLE_RUNNER" ]]; then
+  echo "Single official baseline runner is not executable: $SINGLE_RUNNER" >&2
+  exit 2
+fi
+
+if [[ ! -f "$PREPARE_SCRIPT" ]]; then
+  echo "Prepare script not found: $PREPARE_SCRIPT" >&2
+  exit 2
+fi
+
+if [[ -z "$PYTHON_BIN" ]] || [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "python3 is required for official baseline matrix orchestration" >&2
+  exit 2
+fi
+
+if [[ -z "${GOAL_BASELINE_ENV_PREFIX:-}" ]]; then
+  echo "GOAL_BASELINE_ENV_PREFIX is required" >&2
+  exit 2
+fi
+
+slugify() {
+  local value=$1
+  value=$(basename "$value")
+  value=${value%.json}
+  value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+  value=$(printf '%s' "$value" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+  printf '%s\n' "${value:-spec}"
+}
+
+collect_specs() {
+  local input_path=$1
+  if [[ -d "$input_path" ]]; then
+    find "$(realpath "$input_path")" -maxdepth 1 -type f -name '*.json' \
+      ! -name '*.stub.json' \
+      ! -name '*constraints*' | sort
+    return 0
+  fi
+
+  if [[ -f "$input_path" ]]; then
+    realpath "$input_path"
+    return 0
+  fi
+
+  echo "Spec path not found: $input_path" >&2
+  return 1
+}
+
+resolve_spec_id() {
+  local spec_file=$1
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$spec_file"
+from pathlib import Path
+import sys
+
+from vllm_hust_benchmark.official_baselines import get_official_baseline_spec_id
+from vllm_hust_benchmark.official_baselines import load_official_baseline_spec
+
+print(get_official_baseline_spec_id(load_official_baseline_spec(Path(sys.argv[1]))))
+PY
+}
+
+resolve_canonical_dir() {
+  local spec_file=$1
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$spec_file" "$CANONICAL_SUBMISSIONS_ROOT"
+from pathlib import Path
+import sys
+
+from vllm_hust_benchmark.official_baselines import get_canonical_submission_dir
+from vllm_hust_benchmark.official_baselines import load_official_baseline_spec
+
+spec = load_official_baseline_spec(Path(sys.argv[1]))
+print(get_canonical_submission_dir(spec, submissions_root=Path(sys.argv[2])).resolve())
+PY
+}
+
+has_canonical_run() {
+  local spec_file=$1
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$spec_file" "$CANONICAL_SUBMISSIONS_ROOT"
+from pathlib import Path
+import sys
+
+from vllm_hust_benchmark.official_baselines import has_canonical_run
+from vllm_hust_benchmark.official_baselines import load_official_baseline_spec
+
+spec = load_official_baseline_spec(Path(sys.argv[1]))
+raise SystemExit(0 if has_canonical_run(spec, submissions_root=Path(sys.argv[2])) else 1)
+PY
+}
+
+prepare_official_env_once() {
+  if [[ "$PREPARED_ENV" == "1" ]] || [[ "$PREPARE_OFFICIAL_ENV" != "1" ]]; then
+    return 0
+  fi
+
+  echo "[official-baseline-matrix] preparing official baseline environment: $GOAL_BASELINE_ENV_PREFIX"
+  ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
+  VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
+  bash "$PREPARE_SCRIPT"
+  PREPARED_ENV=1
+}
+
+promote_submission_to_canonical() {
+  local result_dir=$1
+  local canonical_dir=$2
+  local spec_id=$3
+  local submission_dir="$result_dir/submission"
+  local backup_dir
+
+  if [[ ! -f "$submission_dir/run_leaderboard.json" ]] || [[ ! -f "$submission_dir/leaderboard_manifest.json" ]]; then
+    echo "Canonical promotion source is incomplete for $spec_id: $submission_dir" >&2
+    return 1
+  fi
+
+  if [[ -e "$canonical_dir" ]]; then
+    backup_dir="${canonical_dir}.backup-$(date -u +%Y%m%dT%H%M%SZ)"
+    mv "$canonical_dir" "$backup_dir"
+    echo "[official-baseline-matrix] moved pre-existing non-canonical path aside: $backup_dir"
+  fi
+
+  mkdir -p "$(dirname "$canonical_dir")"
+  cp -a "$submission_dir" "$canonical_dir"
+  echo "[official-baseline-matrix] promoted canonical submission: $spec_id -> $canonical_dir"
+}
+
+append_summary() {
+  printf '%s\n' "$1" >> "$SUMMARY_FILE"
+}
+
+resolve_benchmark_type() {
+  local spec_file=$1
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$spec_file"
+from pathlib import Path
+import sys
+
+from vllm_hust_benchmark.official_baselines import get_official_baseline_benchmark_type
+from vllm_hust_benchmark.official_baselines import load_official_baseline_spec
+
+spec = load_official_baseline_spec(Path(sys.argv[1]))
+print(get_official_baseline_benchmark_type(spec))
+PY
+}
+
+select_canonical_candidate() {
+  local benchmark_type=$1
+  shift
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$benchmark_type" "$@"
+from pathlib import Path
+import json
+import sys
+
+from vllm_hust_benchmark.official_baselines import select_canonical_candidate
+
+benchmark_type = sys.argv[1]
+result_dirs = [Path(item) for item in sys.argv[2:]]
+payload = select_canonical_candidate(result_dirs, benchmark_type=benchmark_type)
+print(json.dumps(payload))
+PY
+}
+
+if [[ $# -lt 1 ]]; then
+  set -- "$REPO_ROOT/docs/official-baselines"
+fi
+
+mkdir -p "$MATRIX_RESULT_ROOT"
+mkdir -p "$(dirname "$SUMMARY_FILE")"
+: > "$SUMMARY_FILE"
+
+mapfile -t SPEC_FILES < <(
+  for path in "$@"; do
+    collect_specs "$path"
+  done | awk 'NF' | sort -u
+)
+
+if [[ ${#SPEC_FILES[@]} -eq 0 ]]; then
+  echo "No official baseline spec files resolved from input arguments." >&2
+  exit 2
+fi
+
+echo "[official-baseline-matrix] result root: $MATRIX_RESULT_ROOT"
+echo "[official-baseline-matrix] canonical submissions root: $CANONICAL_SUBMISSIONS_ROOT"
+echo "[official-baseline-matrix] resolved ${#SPEC_FILES[@]} spec file(s)"
+append_summary "## Official Baseline Matrix"
+append_summary "- Result root: $MATRIX_RESULT_ROOT"
+append_summary "- Canonical submissions root: $CANONICAL_SUBMISSIONS_ROOT"
+append_summary "- Force rerun existing canonical: $FORCE_RUN_EXISTING"
+append_summary "- Repeat count for missing canonical specs: $REPEAT_COUNT"
+
+for spec_file in "${SPEC_FILES[@]}"; do
+  spec_slug=$(slugify "$spec_file")
+  spec_id=$(resolve_spec_id "$spec_file")
+  canonical_dir=$(resolve_canonical_dir "$spec_file")
+  benchmark_type=$(resolve_benchmark_type "$spec_file")
+
+  echo
+  echo "[official-baseline-matrix] spec: $spec_file"
+  echo "[official-baseline-matrix] spec id: $spec_id"
+  echo "[official-baseline-matrix] benchmark type: $benchmark_type"
+
+  if has_canonical_run "$spec_file"; then
+    if [[ "$FORCE_RUN_EXISTING" != "1" ]]; then
+      echo "[official-baseline-matrix] skip: canonical run already exists at $canonical_dir"
+      append_summary "- Skip existing canonical: $spec_id -> $canonical_dir"
+      ((SKIPPED_COUNT+=1))
+      continue
+    fi
+
+    echo "[official-baseline-matrix] canonical run already exists; re-running for manual review only"
+    append_summary "- Re-run for review only: $spec_id (canonical preserved at $canonical_dir)"
+    should_promote=0
+  else
+    echo "[official-baseline-matrix] no canonical run found; executing and promoting on success"
+    append_summary "- Missing canonical, will run: $spec_id"
+    should_promote=1
+  fi
+
+  prepare_official_env_once
+
+  repeat_total=1
+  if [[ "$should_promote" == "1" ]]; then
+    repeat_total="$REPEAT_COUNT"
+  fi
+
+  repeat_result_dirs=()
+  for repeat_index in $(seq 1 "$repeat_total"); do
+    repeat_label=$(printf 'repeat-%02d' "$repeat_index")
+    result_dir="$MATRIX_RESULT_ROOT/$spec_slug/$repeat_label"
+    run_id="$MATRIX_RUN_ID-$spec_slug-$repeat_label"
+
+    echo "[official-baseline-matrix] running $repeat_label for $spec_id"
+    append_summary "  - Executing $repeat_label for $spec_id -> $result_dir"
+
+    RESULT_DIR="$result_dir" \
+    RUN_ID="$run_id" \
+    GOAL_BASELINE_ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
+    VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
+    bash "$SINGLE_RUNNER" "$spec_file"
+
+    repeat_result_dirs+=("$result_dir")
+    ((RUN_COUNT+=1))
+  done
+
+  selection_json=$(select_canonical_candidate "$benchmark_type" "${repeat_result_dirs[@]}")
+  selected_result_dir=$(printf '%s' "$selection_json" | jq -r '.selected_result_dir')
+  primary_metric_name=$(printf '%s' "$selection_json" | jq -r '.primary_metric_name')
+  median_value=$(printf '%s' "$selection_json" | jq -r '.median_value')
+  append_summary "  - Candidate selection for $spec_id uses $primary_metric_name median=$median_value"
+  while IFS= read -r candidate_line; do
+    [[ -z "$candidate_line" ]] && continue
+    append_summary "    - $candidate_line"
+  done < <(printf '%s' "$selection_json" | jq -r '.candidates[] | (.result_dir + " | metric=" + (.primary_metric_value|tostring) + " | error_rate=" + (.error_rate|tostring) + " | distance_to_median=" + (.distance_to_median|tostring))')
+
+  if [[ "$should_promote" == "1" ]]; then
+    promote_submission_to_canonical "$selected_result_dir" "$canonical_dir" "$spec_id"
+    append_summary "  - Selected canonical candidate: $selected_result_dir"
+    ((PROMOTED_COUNT+=1))
+  else
+    echo "[official-baseline-matrix] review hint: selected rerun candidate is $selected_result_dir; canonical remains $canonical_dir"
+    append_summary "  - Review hint: selected rerun candidate is $selected_result_dir; canonical remains $canonical_dir"
+    ((REVIEW_COUNT+=1))
+  fi
+done
+
+if [[ "$PUBLISH_WEBSITE" == "1" ]]; then
+  echo
+  echo "[official-baseline-matrix] rebuilding website data from full submissions tree"
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m vllm_hust_benchmark.cli publish-website \
+    --source-dir "$CANONICAL_SUBMISSIONS_ROOT" \
+    --output-dir "$WEBSITE_OUTPUT_DIR" \
+    --execute
+  append_summary "- Website data rebuilt at: $WEBSITE_OUTPUT_DIR"
+fi
+
+append_summary "- Skipped existing canonical runs: $SKIPPED_COUNT"
+append_summary "- Executed runs: $RUN_COUNT"
+append_summary "- Promoted new canonical runs: $PROMOTED_COUNT"
+append_summary "- Review-only reruns: $REVIEW_COUNT"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo
+echo "[official-baseline-matrix] skipped existing canonical runs: $SKIPPED_COUNT"
+echo "[official-baseline-matrix] executed runs: $RUN_COUNT"
+echo "[official-baseline-matrix] promoted new canonical runs: $PROMOTED_COUNT"
+echo "[official-baseline-matrix] review-only reruns: $REVIEW_COUNT"
+echo "[official-baseline-matrix] summary: $SUMMARY_FILE"

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -23,6 +23,7 @@ OFFICIAL_BACKEND_VERSION=${OFFICIAL_BACKEND_VERSION:-}
 ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
 ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
 ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
+HOST_PYTHON_BIN=${HOST_PYTHON_BIN:-$(command -v python3 || command -v python || true)}
 GOAL_BASELINE_ENV_PREFIX=${GOAL_BASELINE_ENV_PREFIX:-}
 RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/official-ascend-goal-baseline"}
 RUN_ID=${RUN_ID:-"official-ascend-jan-2026-$(date -u +%Y%m%dT%H%M%SZ)"}
@@ -53,6 +54,16 @@ if [[ ! -f "$PREPARE_SCRIPT" ]]; then
   echo "Prepare script not found: $PREPARE_SCRIPT" >&2
   exit 2
 fi
+
+if [[ -z "$HOST_PYTHON_BIN" ]] || [[ ! -x "$HOST_PYTHON_BIN" ]]; then
+  echo "python3 or python is required for benchmark repo utilities" >&2
+  exit 2
+fi
+
+SPEC_FILE=$(realpath "$SPEC_FILE")
+CONSTRAINTS_FILE=$(realpath "$CONSTRAINTS_FILE")
+RESULT_DIR=$(realpath -m "$RESULT_DIR")
+OFFICIAL_VLLM_CACHE_ROOT=$(realpath -m "$OFFICIAL_VLLM_CACHE_ROOT")
 
 SCRIPT_BASENAME=$(basename "$0")
 
@@ -260,32 +271,68 @@ run_server_command() {
 }
 
 run_client_command() {
-  run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
-    python -m vllm.entrypoints.cli.main bench serve \
-    --save-result \
-    --result-dir "$RESULT_DIR" \
-    --result-filename "$(basename "$RAW_RESULT_FILE")" \
-    $CLIENT_ARGS
+  case "$BENCHMARK_TYPE" in
+    serve)
+      run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
+        python -m vllm.entrypoints.cli.main bench serve \
+        --save-result \
+        --result-dir "$RESULT_DIR" \
+        --result-filename "$(basename "$RAW_RESULT_FILE")" \
+        $CLIENT_ARGS
+      ;;
+    throughput|latency)
+      run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" \
+        python -m vllm.entrypoints.cli.main bench "$BENCHMARK_TYPE" \
+        --output-json "$RAW_RESULT_FILE" \
+        $CLIENT_ARGS
+      ;;
+    *)
+      echo "Unsupported benchmark type for official baseline runner: $BENCHMARK_TYPE" >&2
+      return 2
+      ;;
+  esac
 }
 
 resolve_same_spec() {
   local resolve_args=(
-    python -m vllm_hust_benchmark.same_spec resolve
+    "$HOST_PYTHON_BIN" -m vllm_hust_benchmark.same_spec resolve
     --spec-file "$SPEC_FILE"
     --output-file "$SAME_SPEC_FILE"
     --runtime-model "$RUNTIME_MODEL"
-    --server-port "$OFFICIAL_SERVER_PORT"
-    --client-port "$OFFICIAL_CLIENT_PORT"
   )
 
-  if [[ -n "$OFFICIAL_SERVER_HOST" ]]; then
-    resolve_args+=(--server-host "$OFFICIAL_SERVER_HOST")
-  fi
-  if [[ -n "$OFFICIAL_CLIENT_HOST" ]]; then
-    resolve_args+=(--client-host "$OFFICIAL_CLIENT_HOST")
+  if [[ "$BENCHMARK_TYPE" == "serve" ]]; then
+    resolve_args+=(
+      --server-port "$OFFICIAL_SERVER_PORT"
+      --client-port "$OFFICIAL_CLIENT_PORT"
+    )
+
+    if [[ -n "$OFFICIAL_SERVER_HOST" ]]; then
+      resolve_args+=(--server-host "$OFFICIAL_SERVER_HOST")
+    fi
+    if [[ -n "$OFFICIAL_CLIENT_HOST" ]]; then
+      resolve_args+=(--client-host "$OFFICIAL_CLIENT_HOST")
+    fi
   fi
 
-  run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${resolve_args[@]}"
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "${resolve_args[@]}"
+}
+
+resolve_scenario_benchmark_type() {
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
+    env SCENARIO_NAME="$SCENARIO" \
+    "$HOST_PYTHON_BIN" -c "import os; from vllm_hust_benchmark.registry import get_scenario; print(get_scenario(os.environ['SCENARIO_NAME']).benchmark_type)"
+}
+
+append_export_arg_from_spec() {
+  local flag=$1
+  local jq_filter=$2
+  local value
+
+  value=$(jq -r "$jq_filter // empty" "$SPEC_FILE")
+  if [[ -n "$value" ]] && [[ "$value" != "null" ]]; then
+    EXPORT_ARGS+=("$flag" "$value")
+  fi
 }
 
 port_has_listener() {
@@ -370,6 +417,7 @@ raise SystemExit(
     0 if runtime_model_path_has_required_artifacts(os.environ["RUNTIME_MODEL_CANDIDATE"]) else 1
 )
 PY
+}
 
 is_valid_engine_version() {
   local version=${1:-}
@@ -461,7 +509,6 @@ PY
 
   printf '%s' "unknown"
 }
-}
 
 wait_for_server() {
   local host=$1
@@ -519,8 +566,7 @@ GITHUB_REPOSITORY=$(jq -r '.export.github_repository' "$SPEC_FILE")
 GITHUB_REF=$(jq -r '.export.github_ref' "$SPEC_FILE")
 GIT_COMMIT=$(jq -r '.export.git_commit' "$SPEC_FILE")
 DATA_SOURCE=$(jq -r '.export.data_source' "$SPEC_FILE")
-INPUT_LEN=$(jq -r '.client_parameters.input_len' "$SPEC_FILE")
-OUTPUT_LEN=$(jq -r '.client_parameters.output_len' "$SPEC_FILE")
+BENCHMARK_TYPE=$(resolve_scenario_benchmark_type)
 
 if [[ -z "$OFFICIAL_CORE_VERSION" ]]; then
   OFFICIAL_CORE_VERSION=$(detect_official_core_version)
@@ -548,34 +594,17 @@ fi
 SAME_SPEC_FILE="$RESULT_DIR/resolved_same_spec.json"
 resolve_same_spec
 
-SERVER_HOST=$(jq -r '.resolved_server_parameters.host' "$SAME_SPEC_FILE")
-SERVER_PORT=$(jq -r '.resolved_server_parameters.port' "$SAME_SPEC_FILE")
-CLIENT_HOST=$(jq -r '.resolved_client_parameters.host' "$SAME_SPEC_FILE")
-CLIENT_PORT=$(jq -r '.resolved_client_parameters.port' "$SAME_SPEC_FILE")
-
-BENCHMARK_SERVER_PORT="$SERVER_PORT" \
-PREPARE_BENCHMARK_ADMISSION_ONLY=1 \
-ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
-VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
-bash "$PREPARE_SCRIPT"
-
-assert_target_port_available "Official baseline" "$CLIENT_HOST" "$CLIENT_PORT"
-
-SERVER_ARGS=$(json2args "$(jq -c '.resolved_server_parameters' "$SAME_SPEC_FILE")")
 CLIENT_ARGS=$(json2args "$(jq -c '.resolved_client_parameters' "$SAME_SPEC_FILE")")
 
 RAW_RESULT_FILE="$RESULT_DIR/raw_benchmark_result.json"
 ARTIFACT_DIR="$RESULT_DIR/submission"
 
-SERVER_COMMAND="PYTHONUNBUFFERED=1 PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run --no-capture-output -p $GOAL_BASELINE_ENV_PREFIX python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS"
-CLIENT_COMMAND="PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.cli.main bench serve --save-result --result-dir $RESULT_DIR --result-filename $(basename "$RAW_RESULT_FILE") $CLIENT_ARGS"
-
 echo "[goal-baseline] using worktrees: $OFFICIAL_VLLM_WORKTREE and $OFFICIAL_VLLM_ASCEND_WORKTREE"
 echo "[goal-baseline] neutral cwd: $OFFICIAL_RUNTIME_CWD"
 echo "[goal-baseline] vllm cache root: $OFFICIAL_VLLM_CACHE_ROOT"
+echo "[goal-baseline] benchmark type: $BENCHMARK_TYPE"
 echo "[goal-baseline] export model id: $MODEL"
 echo "[goal-baseline] runtime model source: $RUNTIME_MODEL"
-echo "[goal-baseline] benchmark endpoint: ${CLIENT_HOST}:${CLIENT_PORT}"
 run_in_official_runtime "$OFFICIAL_RUNTIME_PYTHONPATH" python - <<'PY'
 from importlib import metadata
 
@@ -601,43 +630,78 @@ print(
   f"(dist={dist_version('vllm-ascend', 'vllm_ascend')})"
 )
 PY
-echo "[goal-baseline] server command: $SERVER_COMMAND"
-run_server_command &
-SERVER_PID=$!
-persist_managed_server_state
 
-wait_for_server "$CLIENT_HOST" "$CLIENT_PORT"
-persist_managed_server_state
+case "$BENCHMARK_TYPE" in
+  serve)
+    SERVER_HOST=$(jq -r '.resolved_server_parameters.host' "$SAME_SPEC_FILE")
+    SERVER_PORT=$(jq -r '.resolved_server_parameters.port' "$SAME_SPEC_FILE")
+    CLIENT_HOST=$(jq -r '.resolved_client_parameters.host' "$SAME_SPEC_FILE")
+    CLIENT_PORT=$(jq -r '.resolved_client_parameters.port' "$SAME_SPEC_FILE")
+    SERVER_ARGS=$(json2args "$(jq -c '.resolved_server_parameters' "$SAME_SPEC_FILE")")
+
+    BENCHMARK_SERVER_PORT="$SERVER_PORT" \
+    PREPARE_BENCHMARK_ADMISSION_ONLY=1 \
+    ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
+    VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
+    bash "$PREPARE_SCRIPT"
+
+    assert_target_port_available "Official baseline" "$CLIENT_HOST" "$CLIENT_PORT"
+
+    SERVER_COMMAND="PYTHONUNBUFFERED=1 PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run --no-capture-output -p $GOAL_BASELINE_ENV_PREFIX python -u -m vllm.entrypoints.openai.api_server $SERVER_ARGS"
+    CLIENT_COMMAND="PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.cli.main bench serve --save-result --result-dir $RESULT_DIR --result-filename $(basename "$RAW_RESULT_FILE") $CLIENT_ARGS"
+
+    echo "[goal-baseline] benchmark endpoint: ${CLIENT_HOST}:${CLIENT_PORT}"
+    echo "[goal-baseline] server command: $SERVER_COMMAND"
+    run_server_command &
+    SERVER_PID=$!
+    persist_managed_server_state
+
+    wait_for_server "$CLIENT_HOST" "$CLIENT_PORT"
+    persist_managed_server_state
+    ;;
+  throughput|latency)
+    CLIENT_COMMAND="PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} conda run -p $GOAL_BASELINE_ENV_PREFIX python -m vllm.entrypoints.cli.main bench $BENCHMARK_TYPE --output-json $RAW_RESULT_FILE $CLIENT_ARGS"
+    ;;
+  *)
+    echo "Unsupported benchmark type for official baseline runner: $BENCHMARK_TYPE" >&2
+    exit 2
+    ;;
+esac
 
 echo "[goal-baseline] client command: $CLIENT_COMMAND"
 run_client_command
 
-run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" \
-python -m vllm_hust_benchmark.cli export-leaderboard-artifact \
-  "$SCENARIO" \
-  --benchmark-result-file "$RAW_RESULT_FILE" \
-  --constraints-file "$CONSTRAINTS_FILE" \
-  --same-spec-file "$SAME_SPEC_FILE" \
-  --output-dir "$ARTIFACT_DIR" \
-  --run-id "$RUN_ID" \
-  --engine "$ENGINE" \
-  --engine-version "$ENGINE_VERSION" \
-  --core-version "$OFFICIAL_CORE_VERSION" \
-  --backend-version "$OFFICIAL_BACKEND_VERSION" \
-  --model-name "$MODEL" \
-  --model-parameters "$MODEL_PARAMETERS" \
-  --model-precision "$MODEL_PRECISION" \
-  --hardware-vendor "$HARDWARE_VENDOR" \
-  --hardware-chip-model "$HARDWARE_CHIP_MODEL" \
-  --chip-count "$CHIP_COUNT" \
-  --node-count "$NODE_COUNT" \
-  --submitter "$SUBMITTER" \
-  --baseline-engine "$BASELINE_ENGINE" \
-  --data-source "$DATA_SOURCE" \
-  --input-length "$INPUT_LEN" \
-  --output-length "$OUTPUT_LEN" \
-  --git-commit "$GIT_COMMIT" \
-  --github-repository "$GITHUB_REPOSITORY" \
+EXPORT_ARGS=(
+  python -m vllm_hust_benchmark.cli export-leaderboard-artifact
+  "$SCENARIO"
+  --benchmark-result-file "$RAW_RESULT_FILE"
+  --constraints-file "$CONSTRAINTS_FILE"
+  --same-spec-file "$SAME_SPEC_FILE"
+  --output-dir "$ARTIFACT_DIR"
+  --run-id "$RUN_ID"
+  --engine "$ENGINE"
+  --engine-version "$ENGINE_VERSION"
+  --core-version "$OFFICIAL_CORE_VERSION"
+  --backend-version "$OFFICIAL_BACKEND_VERSION"
+  --model-name "$MODEL"
+  --model-parameters "$MODEL_PARAMETERS"
+  --model-precision "$MODEL_PRECISION"
+  --hardware-vendor "$HARDWARE_VENDOR"
+  --hardware-chip-model "$HARDWARE_CHIP_MODEL"
+  --chip-count "$CHIP_COUNT"
+  --node-count "$NODE_COUNT"
+  --submitter "$SUBMITTER"
+  --baseline-engine "$BASELINE_ENGINE"
+  --data-source "$DATA_SOURCE"
+  --git-commit "$GIT_COMMIT"
+  --github-repository "$GITHUB_REPOSITORY"
   --github-ref "$GITHUB_REF"
+)
+
+append_export_arg_from_spec --input-length '.client_parameters.input_len'
+append_export_arg_from_spec --output-length '.client_parameters.output_len'
+append_export_arg_from_spec --batch-size '.client_parameters.batch_size'
+
+run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${EXPORT_ARGS[@]}"
 
 echo "[goal-baseline] exported leaderboard artifact to $ARTIFACT_DIR"

--- a/src/vllm_hust_benchmark/official_baselines.py
+++ b/src/vllm_hust_benchmark/official_baselines.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import median
+from typing import Any, Mapping
+
+from vllm_hust_benchmark.registry import get_scenario
+
+OFFICIAL_BASELINE_SUBMITTER = "official-ascend-baseline"
+
+PRIMARY_METRIC_BY_BENCHMARK_TYPE = {
+    "serve": "ttft_ms",
+    "latency": "ttft_ms",
+    "throughput": "throughput_tps",
+}
+
+
+def load_official_baseline_spec(spec_file: Path) -> dict[str, Any]:
+    payload = json.loads(spec_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{spec_file}: official baseline spec must be a JSON object")
+    return payload
+
+
+def get_official_baseline_spec_id(spec: Mapping[str, Any]) -> str:
+    spec_id = str(spec.get("id") or "").strip()
+    if not spec_id:
+        raise ValueError("official baseline spec is missing required field: id")
+    return spec_id
+
+
+def get_canonical_submission_dir(
+    spec: Mapping[str, Any], *, submissions_root: Path
+) -> Path:
+    return submissions_root / get_official_baseline_spec_id(spec)
+
+
+def _load_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def has_canonical_run(spec: Mapping[str, Any], *, submissions_root: Path) -> bool:
+    canonical_dir = get_canonical_submission_dir(spec, submissions_root=submissions_root)
+    run_file = canonical_dir / "run_leaderboard.json"
+    manifest_file = canonical_dir / "leaderboard_manifest.json"
+
+    run_payload = _load_json_object(run_file)
+    manifest_payload = _load_json_object(manifest_file)
+    if run_payload is None or manifest_payload is None:
+        return False
+
+    same_spec = run_payload.get("same_spec")
+    same_spec = same_spec if isinstance(same_spec, Mapping) else {}
+    metadata = run_payload.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    entries = manifest_payload.get("entries")
+    entries = entries if isinstance(entries, list) else []
+
+    spec_id = get_official_baseline_spec_id(spec)
+    if str(same_spec.get("spec_id") or "").strip() != spec_id:
+        return False
+    if str(metadata.get("submitter") or "").strip() != OFFICIAL_BASELINE_SUBMITTER:
+        return False
+    if not any(
+        isinstance(entry, Mapping)
+        and str(entry.get("leaderboard_artifact") or "").strip() == "run_leaderboard.json"
+        for entry in entries
+    ):
+        return False
+    return True
+
+
+def get_official_baseline_benchmark_type(spec: Mapping[str, Any]) -> str:
+    scenario_name = str(spec.get("scenario") or "").strip()
+    if not scenario_name:
+        raise ValueError("official baseline spec is missing required field: scenario")
+    return get_scenario(scenario_name).benchmark_type
+
+
+def get_primary_metric_name_for_benchmark_type(benchmark_type: str) -> str:
+    try:
+        return PRIMARY_METRIC_BY_BENCHMARK_TYPE[benchmark_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"unsupported official baseline benchmark type: {benchmark_type}"
+        ) from exc
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_result_artifact_payload(result_dir: Path) -> dict[str, Any] | None:
+    return _load_json_object(result_dir / "submission" / "run_leaderboard.json")
+
+
+def select_canonical_candidate(
+    result_dirs: list[Path], *, benchmark_type: str
+) -> dict[str, Any]:
+    primary_metric_name = get_primary_metric_name_for_benchmark_type(benchmark_type)
+
+    candidates: list[dict[str, Any]] = []
+    for index, result_dir in enumerate(result_dirs):
+        payload = _load_result_artifact_payload(result_dir)
+        if payload is None:
+            continue
+
+        metrics = payload.get("metrics")
+        metrics = metrics if isinstance(metrics, Mapping) else {}
+        primary_metric_value = _safe_float(metrics.get(primary_metric_name))
+        if primary_metric_value is None:
+            continue
+
+        error_rate = _safe_float(metrics.get("error_rate"))
+        candidates.append(
+            {
+                "result_dir": str(result_dir.resolve()),
+                "primary_metric_name": primary_metric_name,
+                "primary_metric_value": primary_metric_value,
+                "error_rate": float(error_rate or 0.0),
+                "index": index,
+            }
+        )
+
+    if not candidates:
+        raise ValueError("no valid repeated runs available for canonical candidate selection")
+
+    metric_median = median(item["primary_metric_value"] for item in candidates)
+    for candidate in candidates:
+        candidate["distance_to_median"] = abs(
+            candidate["primary_metric_value"] - metric_median
+        )
+
+    selected = min(
+        candidates,
+        key=lambda item: (
+            item["error_rate"],
+            item["distance_to_median"],
+            item["index"],
+        ),
+    )
+
+    return {
+        "benchmark_type": benchmark_type,
+        "primary_metric_name": primary_metric_name,
+        "median_value": float(metric_median),
+        "selected_result_dir": selected["result_dir"],
+        "candidates": candidates,
+    }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -1,0 +1,147 @@
+import json
+from pathlib import Path
+
+from vllm_hust_benchmark.official_baselines import get_canonical_submission_dir
+from vllm_hust_benchmark.official_baselines import get_primary_metric_name_for_benchmark_type
+from vllm_hust_benchmark.official_baselines import has_canonical_run
+from vllm_hust_benchmark.official_baselines import select_canonical_candidate
+
+
+def _spec() -> dict:
+    return {
+        "id": "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
+        "scenario": "random-online",
+    }
+
+
+def test_get_canonical_submission_dir_uses_spec_id(tmp_path: Path) -> None:
+    canonical_dir = get_canonical_submission_dir(_spec(), submissions_root=tmp_path)
+    assert canonical_dir == tmp_path / _spec()["id"]
+
+
+def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
+    canonical_dir = tmp_path / _spec()["id"]
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"submitter": "official-ascend-baseline"},
+                "same_spec": {"spec_id": _spec()["id"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (canonical_dir / "leaderboard_manifest.json").write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {"leaderboard_artifact": "run_leaderboard.json"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert has_canonical_run(_spec(), submissions_root=tmp_path)
+
+
+def test_has_canonical_run_rejects_mismatched_submitter(tmp_path: Path) -> None:
+    canonical_dir = tmp_path / _spec()["id"]
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"submitter": "someone-else"},
+                "same_spec": {"spec_id": _spec()["id"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (canonical_dir / "leaderboard_manifest.json").write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {"leaderboard_artifact": "run_leaderboard.json"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not has_canonical_run(_spec(), submissions_root=tmp_path)
+
+
+def _write_result_artifact(
+    result_dir: Path,
+    *,
+    ttft_ms: float | None,
+    throughput_tps: float | None,
+    error_rate: float = 0.0,
+) -> None:
+    submission_dir = result_dir / "submission"
+    submission_dir.mkdir(parents=True)
+    (submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "metrics": {
+                    "ttft_ms": ttft_ms,
+                    "throughput_tps": throughput_tps,
+                    "error_rate": error_rate,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_get_primary_metric_name_for_benchmark_type() -> None:
+    assert get_primary_metric_name_for_benchmark_type("serve") == "ttft_ms"
+    assert get_primary_metric_name_for_benchmark_type("latency") == "ttft_ms"
+    assert get_primary_metric_name_for_benchmark_type("throughput") == "throughput_tps"
+
+
+def test_select_canonical_candidate_prefers_median_ttft(tmp_path: Path) -> None:
+    repeat_a = tmp_path / "repeat-a"
+    repeat_b = tmp_path / "repeat-b"
+    repeat_c = tmp_path / "repeat-c"
+    _write_result_artifact(repeat_a, ttft_ms=120.0, throughput_tps=200.0)
+    _write_result_artifact(repeat_b, ttft_ms=100.0, throughput_tps=220.0)
+    _write_result_artifact(repeat_c, ttft_ms=140.0, throughput_tps=180.0)
+
+    payload = select_canonical_candidate(
+        [repeat_a, repeat_b, repeat_c], benchmark_type="serve"
+    )
+
+    assert payload["primary_metric_name"] == "ttft_ms"
+    assert payload["median_value"] == 120.0
+    assert Path(payload["selected_result_dir"]) == repeat_a.resolve()
+
+
+def test_select_canonical_candidate_uses_throughput_metric(tmp_path: Path) -> None:
+    repeat_a = tmp_path / "repeat-a"
+    repeat_b = tmp_path / "repeat-b"
+    repeat_c = tmp_path / "repeat-c"
+    _write_result_artifact(repeat_a, ttft_ms=0.0, throughput_tps=190.0)
+    _write_result_artifact(repeat_b, ttft_ms=0.0, throughput_tps=210.0)
+    _write_result_artifact(repeat_c, ttft_ms=0.0, throughput_tps=230.0)
+
+    payload = select_canonical_candidate(
+        [repeat_a, repeat_b, repeat_c], benchmark_type="throughput"
+    )
+
+    assert payload["primary_metric_name"] == "throughput_tps"
+    assert payload["median_value"] == 210.0
+    assert Path(payload["selected_result_dir"]) == repeat_b.resolve()
+
+
+def test_select_canonical_candidate_prefers_lower_error_rate(tmp_path: Path) -> None:
+    repeat_a = tmp_path / "repeat-a"
+    repeat_b = tmp_path / "repeat-b"
+    _write_result_artifact(repeat_a, ttft_ms=100.0, throughput_tps=220.0, error_rate=0.1)
+    _write_result_artifact(repeat_b, ttft_ms=110.0, throughput_tps=215.0, error_rate=0.0)
+
+    payload = select_canonical_candidate(
+        [repeat_a, repeat_b], benchmark_type="serve"
+    )
+
+    assert Path(payload["selected_result_dir"]) == repeat_b.resolve()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,8 @@
+import json
+from pathlib import Path
+
 from vllm_hust_benchmark.registry import filter_scenarios, get_scenario, load_official_scenarios
+from vllm_hust_benchmark.same_spec import build_same_spec_payload
 
 
 def test_load_official_scenarios() -> None:
@@ -22,3 +26,74 @@ def test_filter_scenarios() -> None:
 def test_scenario_has_leaderboard_mapping() -> None:
     scenario = get_scenario("sharegpt-online")
     assert scenario.leaderboard["workload_name"] == "sharegpt-online"
+
+
+def test_official_baseline_specs_cover_all_official_scenarios() -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        specs_dir = repo_root / "docs" / "official-baselines"
+        scenario_names = {item.name for item in load_official_scenarios()}
+        covered_scenarios: dict[str, str] = {}
+
+        for spec_path in sorted(specs_dir.glob("official-ascend-*.json")):
+                if spec_path.name.endswith("constraints.stub.json"):
+                        continue
+
+                payload = json.loads(spec_path.read_text(encoding="utf-8"))
+                scenario_name = payload["scenario"]
+                assert scenario_name in scenario_names
+                assert scenario_name not in covered_scenarios
+                build_same_spec_payload(payload)
+                covered_scenarios[scenario_name] = spec_path.name
+
+        assert set(covered_scenarios) == scenario_names
+*** Add File: /home/jeffrey.guest/workspace/vllm/vllm-hust-benchmark/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
+{
+    "id": "official-ascend-jan-2026-v0.11.0-sharegpt-online-qwen25-14b-910b3",
+    "label": "Official Ascend Jan 2026 ShareGPT online baseline for vllm-hust goal tracking",
+    "baseline_target": {
+        "id": "official-ascend-jan-2026-v0.11.0",
+        "label": "Official Ascend Jan 2026",
+        "engine": "vllm",
+        "engine_version": "0.11.0",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ref": "v0.11.0",
+        "vllm_ascend_ref": "v0.11.0"
+    },
+    "scenario": "sharegpt-online",
+    "model": "Qwen/Qwen2.5-14B-Instruct",
+    "model_parameters": "14B",
+    "model_precision": "FP16",
+    "hardware_vendor": "Huawei",
+    "hardware_chip_model": "910B3",
+    "chip_count": 1,
+    "node_count": 1,
+    "server_parameters": {
+        "tensor_parallel_size": 1,
+        "enforce_eager": "",
+        "trust_remote_code": "",
+        "disable_log_stats": "",
+        "disable_log_requests": "",
+        "host": "0.0.0.0",
+        "port": 8000
+    },
+    "client_parameters": {
+        "backend": "vllm",
+        "endpoint": "/v1/completions",
+        "dataset_name": "sharegpt",
+        "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+        "num_prompts": 200,
+        "request_rate": 1,
+        "host": "127.0.0.1",
+        "port": 8000
+    },
+    "export": {
+        "engine": "vllm",
+        "engine_version": "0.11.0",
+        "submitter": "official-ascend-baseline",
+        "baseline_engine": "vllm",
+        "github_repository": "vllm-project/vllm-ascend",
+        "github_ref": "v0.11.0",
+        "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
+        "data_source": "reference-vllm-ascend-benchmark"
+    }
+}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -29,71 +29,20 @@ def test_scenario_has_leaderboard_mapping() -> None:
 
 
 def test_official_baseline_specs_cover_all_official_scenarios() -> None:
-        repo_root = Path(__file__).resolve().parents[1]
-        specs_dir = repo_root / "docs" / "official-baselines"
-        scenario_names = {item.name for item in load_official_scenarios()}
-        covered_scenarios: dict[str, str] = {}
+    repo_root = Path(__file__).resolve().parents[1]
+    specs_dir = repo_root / "docs" / "official-baselines"
+    scenario_names = {item.name for item in load_official_scenarios()}
+    covered_scenarios: dict[str, str] = {}
 
-        for spec_path in sorted(specs_dir.glob("official-ascend-*.json")):
-                if spec_path.name.endswith("constraints.stub.json"):
-                        continue
+    for spec_path in sorted(specs_dir.glob("official-ascend-*.json")):
+        if spec_path.name.endswith("constraints.stub.json"):
+            continue
 
-                payload = json.loads(spec_path.read_text(encoding="utf-8"))
-                scenario_name = payload["scenario"]
-                assert scenario_name in scenario_names
-                assert scenario_name not in covered_scenarios
-                build_same_spec_payload(payload)
-                covered_scenarios[scenario_name] = spec_path.name
+        payload = json.loads(spec_path.read_text(encoding="utf-8"))
+        scenario_name = payload["scenario"]
+        assert scenario_name in scenario_names
+        assert scenario_name not in covered_scenarios
+        build_same_spec_payload(payload)
+        covered_scenarios[scenario_name] = spec_path.name
 
-        assert set(covered_scenarios) == scenario_names
-*** Add File: /home/jeffrey.guest/workspace/vllm/vllm-hust-benchmark/docs/official-baselines/official-ascend-jan-2026-v0110-sharegpt-online-qwen25-14b-910b3.json
-{
-    "id": "official-ascend-jan-2026-v0.11.0-sharegpt-online-qwen25-14b-910b3",
-    "label": "Official Ascend Jan 2026 ShareGPT online baseline for vllm-hust goal tracking",
-    "baseline_target": {
-        "id": "official-ascend-jan-2026-v0.11.0",
-        "label": "Official Ascend Jan 2026",
-        "engine": "vllm",
-        "engine_version": "0.11.0",
-        "github_repository": "vllm-project/vllm-ascend",
-        "vllm_ref": "v0.11.0",
-        "vllm_ascend_ref": "v0.11.0"
-    },
-    "scenario": "sharegpt-online",
-    "model": "Qwen/Qwen2.5-14B-Instruct",
-    "model_parameters": "14B",
-    "model_precision": "FP16",
-    "hardware_vendor": "Huawei",
-    "hardware_chip_model": "910B3",
-    "chip_count": 1,
-    "node_count": 1,
-    "server_parameters": {
-        "tensor_parallel_size": 1,
-        "enforce_eager": "",
-        "trust_remote_code": "",
-        "disable_log_stats": "",
-        "disable_log_requests": "",
-        "host": "0.0.0.0",
-        "port": 8000
-    },
-    "client_parameters": {
-        "backend": "vllm",
-        "endpoint": "/v1/completions",
-        "dataset_name": "sharegpt",
-        "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
-        "num_prompts": 200,
-        "request_rate": 1,
-        "host": "127.0.0.1",
-        "port": 8000
-    },
-    "export": {
-        "engine": "vllm",
-        "engine_version": "0.11.0",
-        "submitter": "official-ascend-baseline",
-        "baseline_engine": "vllm",
-        "github_repository": "vllm-project/vllm-ascend",
-        "github_ref": "v0.11.0",
-        "git_commit": "2f1aed98ccdb0fcbe1ff4fd0abab225bfd8d0367",
-        "data_source": "reference-vllm-ascend-benchmark"
-    }
-}
+    assert set(covered_scenarios) == scenario_names


### PR DESCRIPTION
## What this PR does / why we need it

This PR lands the official Ascend baseline establishment flow for the benchmark repository. It adds the missing official spec skeletons, a batch matrix runner, a manual GitHub Actions workflow entrypoint, and the supporting helper logic needed to create and maintain canonical official baseline submissions.

It also hardens the local/runtime path so the pinned `v0.11.0` official environment is reusable and reproducible:

- adds the official baseline matrix runner and workflow_dispatch entrypoint
- adds canonical candidate selection helpers and regression coverage
- adds missing official baseline spec skeletons for the uncovered scenarios
- changes the official prepare script to use a health-check-first fast path with optional forced repair
- fixes the single-runner path/version resolution issues that blocked same-spec generation under the neutral runtime cwd

Note: GitHub manual dispatch for this workflow is expected to work after the workflow file exists on the default branch. Before merge, the branch still supports local execution and review.

## Why this is not duplicating an existing PR

I checked for existing open PRs with the same official-baseline workflow theme and found none before opening this PR.

## How was this patch tested?

Executed locally in the benchmark repository:

- `bash -n scripts/prepare-official-ascend-baseline-env.sh scripts/run-official-ascend-goal-baseline.sh scripts/run-official-ascend-goal-baseline-matrix.sh`
- direct Python assertions for official scenario coverage, same-spec payload generation, and canonical candidate selection
- `bash scripts/prepare-official-ascend-baseline-env.sh` to verify the new health-check fast path
- single-runner dry run for the official instructcoder spec to verify same-spec resolution and benchmark-type detection
- workflow YAML parse check for `.github/workflows/run-official-ascend-baselines.yml`

Environment note: `pytest` was not available in either `/usr/bin/python3` or `conda run -n base python`, so the logical coverage was verified with direct targeted assertions instead of `pytest`.

## Does this PR introduce any user-facing change?

Yes.

- adds a manual official-baseline workflow for self-hosted Ascend runners
- adds documented local and workflow-based official baseline establishment paths
- adds new official baseline spec files and canonical-selection behavior

## AI assistance

AI assistance was used to help implement, validate, and document this change.
