### PR TITLE
[Fix][CI] Resolve host Python in official baseline workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,37 +14,52 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
+      BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
     steps:
       - name: Require GitHub SSH checkout key
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
             echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
             exit 1
           fi
 
-      - name: Configure GitHub SSH over 443
+      - name: Configure GitHub SSH
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$HOME/.ssh"
-          chmod 700 "$HOME/.ssh"
-          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
-          chmod 600 "$HOME/.ssh/github_actions"
-          cat > "$HOME/.ssh/config" <<'EOF'
+          ssh_dir="$HOME/.ssh"
+          config_file="$ssh_dir/config"
+          key_file="$ssh_dir/github_actions"
+
+          if [[ ! -d "$ssh_dir" ]]; then
+            mkdir -p "$ssh_dir"
+          fi
+          chmod 700 "$ssh_dir"
+
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$key_file"
+          chmod 600 "$key_file"
+
+          config_block="$(cat <<'EOF'
           Host github.com
-            HostName ssh.github.com
-            Port 443
+            HostName github.com
             User git
-            HostKeyAlias github.com
             IdentityFile ~/.ssh/github_actions
             IdentitiesOnly yes
             StrictHostKeyChecking no
           EOF
-          chmod 600 "$HOME/.ssh/config"
-          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+          )"
+
+          if [[ ! -f "$config_file" ]]; then
+            printf '%s\n' "$config_block" > "$config_file"
+          elif ! grep -Fq 'Host github.com' "$config_file" \
+            || ! grep -Fq 'HostName github.com' "$config_file" \
+            || ! grep -Fq 'IdentityFile ~/.ssh/github_actions' "$config_file"; then
+            printf '\n%s\n' "$config_block" >> "$config_file"
+          fi
+
+          chmod 600 "$config_file"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,45 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
     steps:
+      - name: Require GitHub SSH checkout key
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
+            exit 1
+          fi
+
+      - name: Configure GitHub SSH over 443
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
+          chmod 600 "$HOME/.ssh/github_actions"
+          cat > "$HOME/.ssh/config" <<'EOF'
+          Host github.com
+            HostName ssh.github.com
+            Port 443
+            User git
+            HostKeyAlias github.com
+            IdentityFile ~/.ssh/github_actions
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "$HOME/.ssh/config"
+          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -30,38 +30,53 @@ jobs:
   upload-to-hf:
     runs-on: ubuntu-latest
     env:
-      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
+      BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
 
     steps:
       - name: Require GitHub SSH checkout key
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
             echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
             exit 1
           fi
 
-      - name: Configure GitHub SSH over 443
+      - name: Configure GitHub SSH
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$HOME/.ssh"
-          chmod 700 "$HOME/.ssh"
-          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
-          chmod 600 "$HOME/.ssh/github_actions"
-          cat > "$HOME/.ssh/config" <<'EOF'
+          ssh_dir="$HOME/.ssh"
+          config_file="$ssh_dir/config"
+          key_file="$ssh_dir/github_actions"
+
+          if [[ ! -d "$ssh_dir" ]]; then
+            mkdir -p "$ssh_dir"
+          fi
+          chmod 700 "$ssh_dir"
+
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$key_file"
+          chmod 600 "$key_file"
+
+          config_block="$(cat <<'EOF'
           Host github.com
-            HostName ssh.github.com
-            Port 443
+            HostName github.com
             User git
-            HostKeyAlias github.com
             IdentityFile ~/.ssh/github_actions
             IdentitiesOnly yes
             StrictHostKeyChecking no
           EOF
-          chmod 600 "$HOME/.ssh/config"
-          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+          )"
+
+          if [[ ! -f "$config_file" ]]; then
+            printf '%s\n' "$config_block" > "$config_file"
+          elif ! grep -Fq 'Host github.com' "$config_file" \
+            || ! grep -Fq 'HostName github.com' "$config_file" \
+            || ! grep -Fq 'IdentityFile ~/.ssh/github_actions' "$config_file"; then
+            printf '\n%s\n' "$config_block" >> "$config_file"
+          fi
+
+          chmod 600 "$config_file"
 
       - name: Checkout benchmark repo
         uses: actions/checkout@v4

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -29,18 +29,56 @@ permissions:
 jobs:
   upload-to-hf:
     runs-on: ubuntu-latest
+    env:
+      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
 
     steps:
+      - name: Require GitHub SSH checkout key
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
+            exit 1
+          fi
+
+      - name: Configure GitHub SSH over 443
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
+          chmod 600 "$HOME/.ssh/github_actions"
+          cat > "$HOME/.ssh/config" <<'EOF'
+          Host github.com
+            HostName ssh.github.com
+            Port 443
+            User git
+            HostKeyAlias github.com
+            IdentityFile ~/.ssh/github_actions
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "$HOME/.ssh/config"
+          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+
       - name: Checkout benchmark repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Checkout vllm-hust repo
         uses: actions/checkout@v4
         with:
           repository: vLLM-HUST/vllm-hust
           path: vllm-hust
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Checkout website repo (for aggregate script and schema)
         uses: actions/checkout@v4
@@ -48,6 +86,9 @@ jobs:
           repository: vLLM-HUST/vllm-hust-website
           ref: ${{ env.VLLM_HUST_WEBSITE_REF }}
           path: vllm-hust-website
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -112,10 +112,45 @@ jobs:
           path: vllm-hust-website
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Resolve host Python
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_host_python() {
+            if command -v python3 >/dev/null 2>&1; then
+              command -v python3
+              return 0
+            fi
+
+            if command -v python >/dev/null 2>&1; then
+              command -v python
+              return 0
+            fi
+
+            if command -v conda >/dev/null 2>&1; then
+              local conda_base
+              conda_base="$(conda info --base 2>/dev/null || true)"
+              if [[ -n "$conda_base" ]] && [[ -x "$conda_base/bin/python" ]]; then
+                printf '%s\n' "$conda_base/bin/python"
+                return 0
+              fi
+            fi
+
+            return 1
+          }
+
+          host_python="$(resolve_host_python)" || {
+            echo "Could not locate a host Python interpreter for benchmark repo utilities" >&2
+            exit 1
+          }
+
+          "$host_python" -c 'import sys; version = sys.version.split()[0]; raise SystemExit(0 if sys.version_info >= (3, 10) else f"Python {version} is too old for vllm-hust-benchmark; require >= 3.10")'
+          host_python_version="$($host_python -c 'import sys; print(sys.version.split()[0])')"
+
+          printf 'PYTHON_BIN=%s\n' "$host_python" >> "$GITHUB_ENV"
+          printf 'HOST_PYTHON_BIN=%s\n' "$host_python" >> "$GITHUB_ENV"
+          echo "Resolved host Python: $host_python ($host_python_version)"
 
       - name: Resolve official env prefix
         shell: bash

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -59,7 +59,7 @@ jobs:
       - docker
     timeout-minutes: 360
     env:
-      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
+      BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
       VLLM_HUST_WORKSPACE_ROOT: ${{ github.workspace }}
       HF_HUB_DISABLE_TELEMETRY: "1"
       HF_ENDPOINT: ${{ vars.HF_ENDPOINT || 'https://hf-mirror.com' }}
@@ -90,31 +90,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
             echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
             exit 1
           fi
 
-      - name: Configure GitHub SSH over 443
+      - name: Configure GitHub SSH
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$HOME/.ssh"
-          chmod 700 "$HOME/.ssh"
-          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
-          chmod 600 "$HOME/.ssh/github_actions"
-          cat > "$HOME/.ssh/config" <<'EOF'
+          ssh_dir="$HOME/.ssh"
+          config_file="$ssh_dir/config"
+          key_file="$ssh_dir/github_actions"
+
+          if [[ ! -d "$ssh_dir" ]]; then
+            mkdir -p "$ssh_dir"
+          fi
+          chmod 700 "$ssh_dir"
+
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$key_file"
+          chmod 600 "$key_file"
+
+          config_block="$(cat <<'EOF'
           Host github.com
-            HostName ssh.github.com
-            Port 443
+            HostName github.com
             User git
-            HostKeyAlias github.com
             IdentityFile ~/.ssh/github_actions
             IdentitiesOnly yes
             StrictHostKeyChecking no
           EOF
-          chmod 600 "$HOME/.ssh/config"
-          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+          )"
+
+          if [[ ! -f "$config_file" ]]; then
+            printf '%s\n' "$config_block" > "$config_file"
+          elif ! grep -Fq 'Host github.com' "$config_file" \
+            || ! grep -Fq 'HostName github.com' "$config_file" \
+            || ! grep -Fq 'IdentityFile ~/.ssh/github_actions' "$config_file"; then
+            printf '\n%s\n' "$config_block" >> "$config_file"
+          fi
+
+          chmod 600 "$config_file"
 
       - name: Checkout benchmark repo
         uses: actions/checkout@v4

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -59,6 +59,7 @@ jobs:
       - docker
     timeout-minutes: 360
     env:
+      BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
       HF_HUB_DISABLE_TELEMETRY: "1"
       HF_ENDPOINT: ${{ vars.HF_ENDPOINT || 'https://hf-mirror.com' }}
       HF_HOME: ${{ github.workspace }}/../.hf-cache
@@ -84,10 +85,43 @@ jobs:
                  "$GITHUB_WORKSPACE/artifacts"
           mkdir -p "$GITHUB_WORKSPACE/artifacts/official-baseline"
 
+      - name: Require GitHub SSH checkout key
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH_443" != "1" ]]; then
+            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
+            exit 1
+          fi
+
+      - name: Configure GitHub SSH over 443
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$HOME/.ssh/github_actions"
+          chmod 600 "$HOME/.ssh/github_actions"
+          cat > "$HOME/.ssh/config" <<'EOF'
+          Host github.com
+            HostName ssh.github.com
+            Port 443
+            User git
+            HostKeyAlias github.com
+            IdentityFile ~/.ssh/github_actions
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "$HOME/.ssh/config"
+          git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/
+
       - name: Checkout benchmark repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Checkout upstream vllm reference repo
         uses: actions/checkout@v4
@@ -95,6 +129,9 @@ jobs:
           repository: vllm-project/vllm
           path: reference-repos/vllm
           fetch-depth: 0
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Checkout upstream vllm-ascend reference repo
         uses: actions/checkout@v4
@@ -102,6 +139,9 @@ jobs:
           repository: vllm-project/vllm-ascend
           path: reference-repos/vllm-ascend
           fetch-depth: 0
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Checkout website repo
         if: ${{ inputs.publish_website }}
@@ -111,6 +151,9 @@ jobs:
           ref: ${{ env.VLLM_HUST_WEBSITE_REF }}
           path: vllm-hust-website
           fetch-depth: 1
+          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
+          ssh-strict: false
+          persist-credentials: false
 
       - name: Resolve host Python
         shell: bash

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -60,6 +60,7 @@ jobs:
     timeout-minutes: 360
     env:
       BENCHMARK_CHECKOUT_USE_SSH_443: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
+      VLLM_HUST_WORKSPACE_ROOT: ${{ github.workspace }}
       HF_HUB_DISABLE_TELEMETRY: "1"
       HF_ENDPOINT: ${{ vars.HF_ENDPOINT || 'https://hf-mirror.com' }}
       HF_HOME: ${{ github.workspace }}/../.hf-cache
@@ -144,7 +145,6 @@ jobs:
           persist-credentials: false
 
       - name: Checkout website repo
-        if: ${{ inputs.publish_website }}
         uses: actions/checkout@v4
         with:
           repository: vLLM-HUST/vllm-hust-website

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:conda",
+            "packageManager": "ms-python.python:conda"
+        }
+    ]
+}

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -33,6 +33,11 @@ OFFICIAL_TORCH_NPU_WHEEL_URL=${OFFICIAL_TORCH_NPU_WHEEL_URL:-""}
 OFFICIAL_TORCHVISION_WHEEL_URL=${OFFICIAL_TORCHVISION_WHEEL_URL:-""}
 OFFICIAL_TORCHAUDIO_WHEEL_URL=${OFFICIAL_TORCHAUDIO_WHEEL_URL:-""}
 FORCE_REPAIR_OFFICIAL_ENV=${FORCE_REPAIR_OFFICIAL_ENV:-"0"}
+BENCHMARK_RUNTIME_STATE_ROOT=${BENCHMARK_RUNTIME_STATE_ROOT:-"$REPO_ROOT/.benchmarks"}
+MANAGED_BENCHMARK_RUNNER_BASENAME=${MANAGED_BENCHMARK_RUNNER_BASENAME:-"run-official-ascend-goal-baseline.sh"}
+CURRENT_PREPARE_USER_ID=${CURRENT_PREPARE_USER_ID:-$(id -u 2>/dev/null || true)}
+CURRENT_PREPARE_PID_NAMESPACE=${CURRENT_PREPARE_PID_NAMESPACE:-$(readlink /proc/self/ns/pid 2>/dev/null || true)}
+CURRENT_PREPARE_MOUNT_NAMESPACE=${CURRENT_PREPARE_MOUNT_NAMESPACE:-$(readlink /proc/self/ns/mnt 2>/dev/null || true)}
 
 ensure_worktree() {
   local source_repo=$1
@@ -353,12 +358,202 @@ list_port_listener_pids() {
   fi
 }
 
+process_args() {
+  local pid=$1
+  ps -p "$pid" -o args= 2>/dev/null || true
+}
+
+process_user_id() {
+  local pid=$1
+  ps -p "$pid" -o uid= 2>/dev/null | tr -d '[:space:]' || true
+}
+
+process_namespace() {
+  local pid=$1
+  local namespace_name=$2
+
+  readlink "/proc/${pid}/ns/${namespace_name}" 2>/dev/null || true
+}
+
+is_benchmark_process() {
+  local pid=$1
+  local args
+
+  args=$(process_args "$pid")
+  [[ -n "$args" ]] && [[ "$args" =~ vllm\.entrypoints\.openai\.api_server|vllm\.entrypoints\.cli\.main\ bench\ serve|EngineCore_DP0 ]]
+}
+
+is_managed_runner_wrapper_process() {
+  local pid=$1
+  local args
+
+  args=$(process_args "$pid")
+  [[ -n "$args" ]] && [[ "$args" == *"$MANAGED_BENCHMARK_RUNNER_BASENAME"* ]]
+}
+
+is_process_in_cleanup_scope() {
+  local pid=$1
+  local candidate_user_id
+  local candidate_pid_namespace
+  local candidate_mount_namespace
+
+  if [[ -z "$pid" ]] || [[ "$pid" == "$$" ]]; then
+    return 1
+  fi
+
+  candidate_user_id=$(process_user_id "$pid")
+  if [[ -z "$candidate_user_id" ]] || [[ "$candidate_user_id" != "$CURRENT_PREPARE_USER_ID" ]]; then
+    return 1
+  fi
+
+  candidate_pid_namespace=$(process_namespace "$pid" pid)
+  if [[ -z "$candidate_pid_namespace" ]] || [[ "$candidate_pid_namespace" != "$CURRENT_PREPARE_PID_NAMESPACE" ]]; then
+    return 1
+  fi
+
+  candidate_mount_namespace=$(process_namespace "$pid" mnt)
+  if [[ -z "$candidate_mount_namespace" ]] || [[ "$candidate_mount_namespace" != "$CURRENT_PREPARE_MOUNT_NAMESPACE" ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+list_child_pids() {
+  local parent_pid=$1
+  ps -eo pid=,ppid= | awk -v target="$parent_pid" '$2 == target {print $1}'
+}
+
+collect_process_tree_pids() {
+  local root_pid=$1
+  local child_pid
+
+  if ! kill -0 "$root_pid" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "$root_pid"
+  while IFS= read -r child_pid; do
+    [[ -z "$child_pid" ]] && continue
+    collect_process_tree_pids "$child_pid"
+  done < <(list_child_pids "$root_pid")
+}
+
+log_process_snapshots() {
+  local label=$1
+  local pids=$2
+  local pid
+  local snapshot
+  local process_tree
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    snapshot=$(ps -p "$pid" -o pid=,ppid=,stat=,args= 2>/dev/null | sed 's/^[[:space:]]*//')
+    if [[ -n "$snapshot" ]]; then
+      echo "[official-env] ${label}: ${snapshot}"
+      if command -v pstree >/dev/null 2>&1; then
+        process_tree=$(pstree -sp "$pid" 2>/dev/null || true)
+        if [[ -n "$process_tree" ]]; then
+          echo "[official-env] ${label} tree: ${process_tree}"
+        fi
+      fi
+    else
+      echo "[official-env] ${label}: pid=${pid} exited before inspection"
+    fi
+  done <<< "$pids"
+}
+
+terminate_pid_tree() {
+  local pid=$1
+  local description=$2
+  local tree_pids
+  local tree_list
+  local still_running
+  local tree_pid
+  local attempt
+
+  tree_pids=$(collect_process_tree_pids "$pid" | sort -u)
+  [[ -z "$tree_pids" ]] && return 0
+  tree_list=$(printf '%s\n' "$tree_pids" | tr '\n' ' ')
+
+  echo "[official-env] stopping ${description}: ${tree_list}"
+  kill $tree_list 2>/dev/null || true
+
+  for attempt in $(seq 1 5); do
+    still_running=0
+    while IFS= read -r tree_pid; do
+      [[ -z "$tree_pid" ]] && continue
+      if is_live_process "$tree_pid"; then
+        still_running=1
+        break
+      fi
+    done <<< "$tree_pids"
+
+    if [[ "$still_running" == "0" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  kill -9 $tree_list 2>/dev/null || true
+
+  for attempt in $(seq 1 5); do
+    still_running=0
+    while IFS= read -r tree_pid; do
+      [[ -z "$tree_pid" ]] && continue
+      if is_live_process "$tree_pid"; then
+        still_running=1
+        break
+      fi
+    done <<< "$tree_pids"
+
+    if [[ "$still_running" == "0" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+terminate_benchmark_pid_set() {
+  local pids=$1
+  local pid
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    terminate_pid_tree "$pid" "benchmark residual process tree rooted at ${pid}" || true
+  done <<< "$pids"
+}
+
 list_matching_benchmark_pids() {
   ps -eo pid=,args= | awk '
     /vllm\.entrypoints\.openai\.api_server|vllm\.entrypoints\.cli\.main bench serve|EngineCore_DP0/ && !/awk/ {
       print $1
     }
   ' | sort -u
+}
+
+list_managed_runtime_state_dirs() {
+  if [[ ! -d "$BENCHMARK_RUNTIME_STATE_ROOT" ]]; then
+    return 0
+  fi
+
+  find "$BENCHMARK_RUNTIME_STATE_ROOT" -type d -name '.runtime-state' 2>/dev/null | sort || true
+}
+
+list_managed_runtime_state_pids() {
+  local state_dir
+
+  while IFS= read -r state_dir; do
+    [[ -z "$state_dir" ]] && continue
+    if [[ -f "$state_dir/server.wrapper.pid" ]]; then
+      tr '[:space:]' '\n' < "$state_dir/server.wrapper.pid"
+    fi
+    if [[ -f "$state_dir/server.listener.pids" ]]; then
+      tr '[:space:]' '\n' < "$state_dir/server.listener.pids"
+    fi
+  done < <(list_managed_runtime_state_dirs) | sed '/^$/d' | sort -u
 }
 
 process_state() {
@@ -379,16 +574,48 @@ is_zombie_process() {
   [[ -n "$state" ]] && [[ "$state" == Z* ]]
 }
 
+is_live_process() {
+  local pid=$1
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  if is_zombie_process "$pid"; then
+    return 1
+  fi
+
+  return 0
+}
+
 list_benchmark_residual_pids() {
   local pid
 
-  while IFS= read -r pid; do
-    [[ -z "$pid" ]] && continue
-    if is_zombie_process "$pid"; then
-      continue
-    fi
-    printf '%s\n' "$pid"
-  done < <(list_matching_benchmark_pids) | sort -u
+  {
+    while IFS= read -r pid; do
+      [[ -z "$pid" ]] && continue
+      if is_zombie_process "$pid"; then
+        continue
+      fi
+      if ! is_process_in_cleanup_scope "$pid"; then
+        continue
+      fi
+      if is_benchmark_process "$pid" || is_managed_runner_wrapper_process "$pid"; then
+        printf '%s\n' "$pid"
+      fi
+    done < <(list_managed_runtime_state_pids)
+
+    while IFS= read -r pid; do
+      [[ -z "$pid" ]] && continue
+      if is_zombie_process "$pid"; then
+        continue
+      fi
+      if ! is_process_in_cleanup_scope "$pid"; then
+        continue
+      fi
+      printf '%s\n' "$pid"
+    done < <(list_matching_benchmark_pids)
+  } | sort -u
 }
 
 list_benchmark_zombie_pids() {
@@ -397,8 +624,26 @@ list_benchmark_zombie_pids() {
   while IFS= read -r pid; do
     [[ -z "$pid" ]] && continue
     if is_zombie_process "$pid"; then
+      if ! is_process_in_cleanup_scope "$pid"; then
+        continue
+      fi
       printf '%s\n' "$pid"
     fi
+  done < <(list_matching_benchmark_pids) | sort -u
+}
+
+list_out_of_scope_benchmark_pids() {
+  local pid
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    if is_zombie_process "$pid"; then
+      continue
+    fi
+    if is_process_in_cleanup_scope "$pid"; then
+      continue
+    fi
+    printf '%s\n' "$pid"
   done < <(list_matching_benchmark_pids) | sort -u
 }
 
@@ -445,12 +690,21 @@ cleanup_benchmark_residual_processes() {
     local port_pids
     port_pids=$(list_port_listener_pids "$BENCHMARK_SERVER_PORT")
     if [[ -n "$port_pids" ]]; then
+      log_process_snapshots "port listener during admission check" "$port_pids"
       echo "Port ${BENCHMARK_SERVER_PORT} is already occupied by listening processes: $port_pids" >&2
       return 1
     fi
 
     if [[ -n "$(list_benchmark_residual_pids)" ]]; then
       echo "Residual benchmark processes still exist during admission check" >&2
+      return 1
+    fi
+
+    local out_of_scope_pids
+    out_of_scope_pids=$(list_out_of_scope_benchmark_pids)
+    if [[ -n "$out_of_scope_pids" ]]; then
+      log_process_snapshots "out-of-scope residual during admission check" "$out_of_scope_pids"
+      echo "Out-of-scope benchmark processes exist outside the runner cleanup scope during admission check: $out_of_scope_pids" >&2
       return 1
     fi
 
@@ -470,14 +724,16 @@ cleanup_benchmark_residual_processes() {
 
   if [[ -n "$pids" ]]; then
     echo "[official-env] cleaning residual benchmark processes: $pids"
-    kill $pids 2>/dev/null || true
+    log_process_snapshots "residual before cleanup" "$pids"
+    terminate_benchmark_pid_set "$pids"
 
     if ! wait_for_no_benchmark_residual_pids 5; then
       local remaining_pids
       remaining_pids=$(list_benchmark_residual_pids)
       if [[ -n "$remaining_pids" ]]; then
         echo "[official-env] escalating residual benchmark cleanup: $remaining_pids"
-        kill -9 $remaining_pids 2>/dev/null || true
+        log_process_snapshots "residual before escalation" "$remaining_pids"
+        terminate_benchmark_pid_set "$remaining_pids"
         wait_for_no_benchmark_residual_pids 5 || true
       fi
     fi
@@ -486,6 +742,7 @@ cleanup_benchmark_residual_processes() {
   local port_pids
   port_pids=$(list_port_listener_pids "$BENCHMARK_SERVER_PORT")
   if [[ -n "$port_pids" ]]; then
+    log_process_snapshots "port listener after cleanup" "$port_pids"
     echo "Port ${BENCHMARK_SERVER_PORT} is already occupied by listening processes: $port_pids" >&2
     return 1
   fi
@@ -493,7 +750,16 @@ cleanup_benchmark_residual_processes() {
   local final_residual_pids
   final_residual_pids=$(list_benchmark_residual_pids)
   if [[ -n "$final_residual_pids" ]]; then
+    log_process_snapshots "residual after cleanup" "$final_residual_pids"
     echo "Residual benchmark processes still exist after cleanup: $final_residual_pids" >&2
+    return 1
+  fi
+
+  local final_out_of_scope_pids
+  final_out_of_scope_pids=$(list_out_of_scope_benchmark_pids)
+  if [[ -n "$final_out_of_scope_pids" ]]; then
+    log_process_snapshots "out-of-scope residual after cleanup" "$final_out_of_scope_pids"
+    echo "Out-of-scope benchmark processes remain outside the runner cleanup scope; refusing to kill them automatically: $final_out_of_scope_pids" >&2
     return 1
   fi
 

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -361,6 +361,20 @@ list_benchmark_residual_pids() {
   ' | sort -u
 }
 
+wait_for_no_benchmark_residual_pids() {
+  local max_attempts=${1:-10}
+  local attempt
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    if [[ -z "$(list_benchmark_residual_pids)" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
 cleanup_benchmark_residual_processes() {
   if [[ "$PREPARE_BENCHMARK_ADMISSION_ONLY" == "1" ]]; then
     local port_pids
@@ -386,12 +400,15 @@ cleanup_benchmark_residual_processes() {
     echo "[official-env] cleaning residual benchmark processes: $pids"
     kill $pids 2>/dev/null || true
 
-    local pid
-    for pid in $pids; do
-      if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null || true
+    if ! wait_for_no_benchmark_residual_pids 5; then
+      local remaining_pids
+      remaining_pids=$(list_benchmark_residual_pids)
+      if [[ -n "$remaining_pids" ]]; then
+        echo "[official-env] escalating residual benchmark cleanup: $remaining_pids"
+        kill -9 $remaining_pids 2>/dev/null || true
+        wait_for_no_benchmark_residual_pids 5 || true
       fi
-    done
+    fi
   fi
 
   local port_pids
@@ -401,8 +418,10 @@ cleanup_benchmark_residual_processes() {
     return 1
   fi
 
-  if [[ -n "$(list_benchmark_residual_pids)" ]]; then
-    echo "Residual benchmark processes still exist after cleanup" >&2
+  local final_residual_pids
+  final_residual_pids=$(list_benchmark_residual_pids)
+  if [[ -n "$final_residual_pids" ]]; then
+    echo "Residual benchmark processes still exist after cleanup: $final_residual_pids" >&2
     return 1
   fi
 

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -353,12 +353,77 @@ list_port_listener_pids() {
   fi
 }
 
-list_benchmark_residual_pids() {
+list_matching_benchmark_pids() {
   ps -eo pid=,args= | awk '
     /vllm\.entrypoints\.openai\.api_server|vllm\.entrypoints\.cli\.main bench serve|EngineCore_DP0/ && !/awk/ {
       print $1
     }
   ' | sort -u
+}
+
+process_state() {
+  local pid=$1
+  ps -p "$pid" -o stat= 2>/dev/null | tr -d '[:space:]' || true
+}
+
+process_parent_pid() {
+  local pid=$1
+  ps -p "$pid" -o ppid= 2>/dev/null | tr -d '[:space:]' || true
+}
+
+is_zombie_process() {
+  local pid=$1
+  local state
+
+  state=$(process_state "$pid")
+  [[ -n "$state" ]] && [[ "$state" == Z* ]]
+}
+
+list_benchmark_residual_pids() {
+  local pid
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    if is_zombie_process "$pid"; then
+      continue
+    fi
+    printf '%s\n' "$pid"
+  done < <(list_matching_benchmark_pids) | sort -u
+}
+
+list_benchmark_zombie_pids() {
+  local pid
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    if is_zombie_process "$pid"; then
+      printf '%s\n' "$pid"
+    fi
+  done < <(list_matching_benchmark_pids) | sort -u
+}
+
+reap_benchmark_zombie_parents() {
+  local zombie_pids=$1
+  local pid
+  local parent_pid
+  local parent_pids=""
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    parent_pid=$(process_parent_pid "$pid")
+    if [[ -z "$parent_pid" ]] || [[ "$parent_pid" == "1" ]] || [[ "$parent_pid" == "$$" ]]; then
+      continue
+    fi
+    parent_pids+="$parent_pid"$'\n'
+  done <<< "$zombie_pids"
+
+  parent_pids=$(printf '%s' "$parent_pids" | sed '/^$/d' | sort -u)
+  if [[ -z "$parent_pids" ]]; then
+    return 0
+  fi
+
+  echo "[official-env] reaping zombie benchmark parents: $parent_pids"
+  kill $parent_pids 2>/dev/null || true
 }
 
 wait_for_no_benchmark_residual_pids() {
@@ -393,6 +458,13 @@ cleanup_benchmark_residual_processes() {
     return 0
   fi
 
+  local zombie_pids
+  zombie_pids=$(list_benchmark_zombie_pids)
+  if [[ -n "$zombie_pids" ]]; then
+    echo "[official-env] found zombie benchmark processes: $zombie_pids"
+    reap_benchmark_zombie_parents "$zombie_pids"
+  fi
+
   local pids
   pids=$(list_benchmark_residual_pids)
 
@@ -423,6 +495,12 @@ cleanup_benchmark_residual_processes() {
   if [[ -n "$final_residual_pids" ]]; then
     echo "Residual benchmark processes still exist after cleanup: $final_residual_pids" >&2
     return 1
+  fi
+
+  local final_zombie_pids
+  final_zombie_pids=$(list_benchmark_zombie_pids)
+  if [[ -n "$final_zombie_pids" ]]; then
+    echo "[official-env] continuing with zombie benchmark processes that have no listening port: $final_zombie_pids"
   fi
 
   echo "[official-env] benchmark admission preflight passed: no residual benchmark processes"

--- a/tests/test_prepare_official_env_script.py
+++ b/tests/test_prepare_official_env_script.py
@@ -1,0 +1,225 @@
+import os
+import shlex
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PREPARE_SCRIPT = REPO_ROOT / "scripts/prepare-official-ascend-baseline-env.sh"
+
+
+def _source_prepare_functions(snippet: str) -> str:
+    script_path = shlex.quote(str(PREPARE_SCRIPT))
+    return (
+        "source <(awk '/^if ! command -v conda / {exit} {print}' "
+        f"{script_path}) && {snippet}"
+    )
+
+
+def _run_bash(command: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-lc", command],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_pid_file(pid_file: Path, timeout_seconds: float = 5.0) -> int:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if pid_file.exists():
+            contents = pid_file.read_text(encoding="utf-8").strip()
+            if contents:
+                return int(contents)
+        time.sleep(0.1)
+    raise AssertionError(f"Timed out waiting for child pid file: {pid_file}")
+
+
+def _wait_for_pid_exit(pid: int, timeout_seconds: float = 5.0) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if not _pid_exists(pid):
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"Timed out waiting for pid {pid} to exit")
+
+
+def _cleanup_process_tree(root_pid: int, child_pid: int | None) -> None:
+    try:
+        os.killpg(root_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+    if child_pid is not None:
+        try:
+            os.kill(child_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def _spawn_process_tree(tmp_path: Path) -> tuple[subprocess.Popen[str], int]:
+    child_pid_file = tmp_path / "child.pid"
+    wrapper_script = tmp_path / "wrapper.sh"
+    wrapper_script.write_text(
+        "#!/bin/bash\n"
+        f"sleep 300 &\n"
+        f"echo $! > {shlex.quote(str(child_pid_file))}\n"
+        "wait\n",
+        encoding="utf-8",
+    )
+    wrapper_script.chmod(0o755)
+
+    process = subprocess.Popen(
+        [
+            "bash",
+            "-lc",
+            f'exec -a "vllm.entrypoints.cli.main bench serve" {shlex.quote(str(wrapper_script))}',
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+    child_pid = _wait_for_pid_file(child_pid_file)
+    return process, child_pid
+
+
+def test_collect_process_tree_pids_includes_child_process(tmp_path: Path) -> None:
+    process, child_pid = _spawn_process_tree(tmp_path)
+
+    try:
+        result = _run_bash(
+            _source_prepare_functions(f"collect_process_tree_pids {process.pid}")
+        )
+        collected_pids = {
+            int(line)
+            for line in result.stdout.splitlines()
+            if line.strip()
+        }
+
+        assert process.pid in collected_pids
+        assert child_pid in collected_pids
+    finally:
+        _cleanup_process_tree(process.pid, child_pid)
+
+
+def test_terminate_pid_tree_kills_root_and_child(tmp_path: Path) -> None:
+    process, child_pid = _spawn_process_tree(tmp_path)
+
+    try:
+        result = _run_bash(
+            _source_prepare_functions(
+                f'terminate_pid_tree {process.pid} "test process tree"'
+            )
+        )
+
+        assert "[official-env] stopping test process tree:" in result.stdout
+        process.wait(timeout=5)
+        _wait_for_pid_exit(child_pid)
+        assert not _pid_exists(process.pid)
+        assert not _pid_exists(child_pid)
+    finally:
+        _cleanup_process_tree(process.pid, child_pid)
+
+
+def test_is_process_in_cleanup_scope_requires_same_user_and_namespaces() -> None:
+        result = _run_bash(
+                _source_prepare_functions(
+                        """
+                        CURRENT_PREPARE_USER_ID=1000
+                        CURRENT_PREPARE_PID_NAMESPACE='pid:[11]'
+                        CURRENT_PREPARE_MOUNT_NAMESPACE='mnt:[22]'
+
+                        process_user_id() {
+                            case "$1" in
+                                101|102|103) printf '1000\n' ;;
+                                104) printf '2000\n' ;;
+                            esac
+                        }
+
+                        process_namespace() {
+                            case "$1:$2" in
+                                101:pid) printf 'pid:[11]\n' ;;
+                                101:mnt) printf 'mnt:[22]\n' ;;
+                                102:pid) printf 'pid:[11]\n' ;;
+                                102:mnt) printf 'mnt:[33]\n' ;;
+                                103:pid) printf 'pid:[99]\n' ;;
+                                103:mnt) printf 'mnt:[22]\n' ;;
+                                104:pid) printf 'pid:[11]\n' ;;
+                                104:mnt) printf 'mnt:[22]\n' ;;
+                            esac
+                        }
+
+                        for pid in 101 102 103 104; do
+                            if is_process_in_cleanup_scope "$pid"; then
+                                echo "allow:$pid"
+                            else
+                                echo "deny:$pid"
+                            fi
+                        done
+                        """
+                )
+        )
+
+        assert result.stdout.splitlines() == [
+                "allow:101",
+                "deny:102",
+                "deny:103",
+                "deny:104",
+        ]
+
+
+def test_residual_pid_lists_keep_only_in_scope_targets() -> None:
+        result = _run_bash(
+                _source_prepare_functions(
+                        """
+                        list_managed_runtime_state_pids() {
+                            printf '501\n502\n'
+                        }
+
+                        list_matching_benchmark_pids() {
+                            printf '601\n602\n'
+                        }
+
+                        is_zombie_process() {
+                            return 1
+                        }
+
+                        is_process_in_cleanup_scope() {
+                            [[ "$1" == '501' || "$1" == '601' ]]
+                        }
+
+                        is_benchmark_process() {
+                            [[ "$1" == '601' || "$1" == '602' ]]
+                        }
+
+                        is_managed_runner_wrapper_process() {
+                            [[ "$1" == '501' || "$1" == '502' ]]
+                        }
+
+                        echo 'residual:'
+                        list_benchmark_residual_pids
+                        echo 'out-of-scope:'
+                        list_out_of_scope_benchmark_pids
+                        """
+                )
+        )
+
+        assert result.stdout.splitlines() == [
+                "residual:",
+                "501",
+                "601",
+                "out-of-scope:",
+                "602",
+        ]

--- a/tests/test_workflow_ssh_config.py
+++ b/tests/test_workflow_ssh_config.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATHS = [
+    ".github/workflows/ci.yml",
+    ".github/workflows/push-to-hf.yml",
+    ".github/workflows/run-official-ascend-baselines.yml",
+]
+
+
+@pytest.mark.parametrize("workflow_path", WORKFLOW_PATHS)
+def test_workflows_use_standard_github_ssh_without_overwriting_config(
+    workflow_path: str,
+) -> None:
+    workflow_text = (REPO_ROOT / workflow_path).read_text(encoding="utf-8")
+
+    assert "BENCHMARK_CHECKOUT_USE_SSH_443" not in workflow_text
+    assert "Configure GitHub SSH over 443" not in workflow_text
+    assert "ssh.github.com" not in workflow_text
+    assert 'git config --global url."ssh://git@ssh.github.com:443/".insteadOf https://github.com/' not in workflow_text
+
+    assert "BENCHMARK_CHECKOUT_USE_SSH" in workflow_text
+    assert "Configure GitHub SSH" in workflow_text
+    assert 'if [[ ! -d "$ssh_dir" ]]; then' in workflow_text
+    assert 'if [[ ! -f "$config_file" ]]; then' in workflow_text
+    assert 'Host github.com' in workflow_text
+    assert 'HostName github.com' in workflow_text
+    assert 'IdentityFile ~/.ssh/github_actions' in workflow_text
+    assert "printf '\\n%s\\n' \"$config_block\" >> \"$config_file\"" in workflow_text


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes the manual official-baseline workflow on the self-hosted aarch64 runner.

The workflow previously used `actions/setup-python@v5` with `python-version: 3.11`, but that step failed on the runner before the matrix script could execute. The benchmark scripts only need an existing host Python for repo-local helpers, while the pinned official runtime itself is still created or validated inside `vllm-ascend-official-v0110` by the prepare/matrix scripts.

This change removes the setup-python dependency and resolves an existing host Python interpreter instead, enforcing only the benchmark repo requirement of Python >= 3.10.

## Why this is not duplicating an existing PR

I checked for an existing open PR for this official-baseline host-Python fix and found no matching open PR before creating this one.

## How was this patch tested?

Executed locally in the benchmark repository:

- workflow YAML parse check for `.github/workflows/run-official-ascend-baselines.yml`
- local execution of the new host-Python resolution shell logic, which resolved `/usr/bin/python3 (3.10.12)`

GitHub validation:

- dispatched `run-official-ascend-baselines.yml` from `ws/run-official-baseline` to validate the runner-side fix

## Does this PR introduce any user-facing change?

Yes. The manual official-baseline workflow can now start on the self-hosted aarch64 runner without depending on `actions/setup-python`.

## AI assistance

AI assistance was used to help diagnose, implement, validate, and document this change.
