### PR TITLE
fix(leaderboard): enforce benchmark model identity contract

### DIFF
--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -83,14 +83,14 @@ jobs:
               print("No submission manifests found — nothing to do")
               sys.exit(0)
 
-            errors = validate_manifest_artifacts(manifests=manifests, validator=validator)
-            if errors:
+          errors = validate_manifest_artifacts(manifests=manifests, validator=validator)
+          if errors:
               errors_found = True
               for error in errors:
-                print(f"FAIL {error}")
-            else:
+                  print(f"FAIL {error}")
+          else:
               for manifest_path in manifests:
-                print(f"OK   {manifest_path}")
+                  print(f"OK   {manifest_path}")
 
           sys.exit(1 if errors_found else 0)
           PYEOF

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -11,6 +11,10 @@ on:
         description: 'Dry run only (do not upload to HF)'
         type: boolean
         default: false
+      backfill_existing_only:
+        description: 'Backfill and republish already-hosted HF submissions without new local submissions'
+        type: boolean
+        default: false
       submission_dirs:
         description: 'Optional newline-separated submission directories to sync'
         type: string
@@ -63,6 +67,7 @@ jobs:
           import json, sys
           from pathlib import Path
           from jsonschema import Draft7Validator
+          from vllm_hust_benchmark.submission_artifacts import validate_manifest_artifacts
 
           schema_path = Path("vllm-hust-website/data/schemas/leaderboard_v1.schema.json")
           if not schema_path.exists():
@@ -78,18 +83,14 @@ jobs:
               print("No submission manifests found — nothing to do")
               sys.exit(0)
 
-          for manifest_path in manifests:
-              artifact_path = manifest_path.parent / "run_leaderboard.json"
-              if not artifact_path.exists():
-                  print(f"WARNING: manifest present but artifact missing: {artifact_path}")
-                  continue
-              artifact = json.loads(artifact_path.read_text())
-              errs = sorted(validator.iter_errors(artifact), key=lambda e: list(e.path))
-              if errs:
-                  print(f"FAIL {artifact_path}: {errs[0].message[:120]} @ {list(errs[0].path)}")
-                  errors_found = True
-              else:
-                  print(f"OK   {artifact_path}")
+            errors = validate_manifest_artifacts(manifests=manifests, validator=validator)
+            if errors:
+              errors_found = True
+              for error in errors:
+                print(f"FAIL {error}")
+            else:
+              for manifest_path in manifests:
+                print(f"OK   {manifest_path}")
 
           sys.exit(1 if errors_found else 0)
           PYEOF
@@ -160,10 +161,11 @@ jobs:
           MANUAL_SUBMISSION_DIRS: ${{ github.event.inputs.submission_dirs }}
 
       - name: Sync submissions into HF leaderboard snapshots
-        if: ${{ steps.resolve-submissions.outputs.count != '0' }}
+        if: ${{ steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.DATASET_WRITE_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          BACKFILL_EXISTING_ONLY: ${{ github.event.inputs.backfill_existing_only || 'false' }}
           VLLM_HUST_REPO: ${{ github.workspace }}/vllm-hust
           VLLM_HUST_WEBSITE_REPO: ${{ github.workspace }}/vllm-hust-website
         run: |
@@ -176,6 +178,9 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then
             extra_args+=(--dry-run)
           fi
+          if [[ "$BACKFILL_EXISTING_ONLY" == "true" ]]; then
+            extra_args+=(--existing-only)
+          fi
 
           submission_args=()
           while IFS= read -r submission_dir; do
@@ -184,7 +189,7 @@ jobs:
             submission_args+=(--submission-dir "$submission_dir")
           done <<< "${{ steps.resolve-submissions.outputs.dirs }}"
 
-          if [[ ${#submission_args[@]} -eq 0 ]]; then
+          if [[ ${#submission_args[@]} -eq 0 && "$BACKFILL_EXISTING_ONLY" != "true" ]]; then
             echo "No submission directories resolved; nothing to sync."
             exit 0
           fi
@@ -199,11 +204,11 @@ jobs:
             "${extra_args[@]}"
 
       - name: Dry run summary
-        if: ${{ github.event.inputs.dry_run == 'true' && steps.resolve-submissions.outputs.count != '0' }}
+        if: ${{ github.event.inputs.dry_run == 'true' && (steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true') }}
         run: |
           echo "=== DRY RUN: files that would be uploaded ==="
           ls -lh /tmp/leaderboard-data/
 
       - name: No submissions to sync
-        if: ${{ steps.resolve-submissions.outputs.count == '0' }}
+        if: ${{ steps.resolve-submissions.outputs.count == '0' && github.event.inputs.backfill_existing_only != 'true' }}
         run: echo "No submission directories matched this event; nothing to upload."

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -106,14 +106,14 @@ jobs:
           event_name = os.environ.get("GITHUB_EVENT_NAME", "")
           before_sha = os.environ.get("BEFORE_SHA", "")
           current_sha = os.environ.get("GITHUB_SHA", "")
-            backfill_existing_only = os.environ.get("BACKFILL_EXISTING_ONLY", "").lower() == "true"
+          backfill_existing_only = os.environ.get("BACKFILL_EXISTING_ONLY", "").lower() == "true"
           manual_submission_dirs = os.environ.get("MANUAL_SUBMISSION_DIRS", "")
           submissions_root = Path("submissions")
 
           submission_dirs: list[str] = []
-            if backfill_existing_only:
+          if backfill_existing_only:
               print("Backfill existing-only mode enabled; skipping local submission directory resolution.")
-            elif manual_submission_dirs.strip():
+          elif manual_submission_dirs.strip():
               seen: set[str] = set()
               for raw_dir in manual_submission_dirs.splitlines():
                   raw_dir = raw_dir.strip()

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -106,11 +106,14 @@ jobs:
           event_name = os.environ.get("GITHUB_EVENT_NAME", "")
           before_sha = os.environ.get("BEFORE_SHA", "")
           current_sha = os.environ.get("GITHUB_SHA", "")
+            backfill_existing_only = os.environ.get("BACKFILL_EXISTING_ONLY", "").lower() == "true"
           manual_submission_dirs = os.environ.get("MANUAL_SUBMISSION_DIRS", "")
           submissions_root = Path("submissions")
 
           submission_dirs: list[str] = []
-          if manual_submission_dirs.strip():
+            if backfill_existing_only:
+              print("Backfill existing-only mode enabled; skipping local submission directory resolution.")
+            elif manual_submission_dirs.strip():
               seen: set[str] = set()
               for raw_dir in manual_submission_dirs.splitlines():
                   raw_dir = raw_dir.strip()
@@ -157,6 +160,7 @@ jobs:
               fh.write("EOF\n")
           PYEOF
         env:
+          BACKFILL_EXISTING_ONLY: ${{ github.event.inputs.backfill_existing_only || 'false' }}
           BEFORE_SHA: ${{ github.event.before }}
           MANUAL_SUBMISSION_DIRS: ${{ github.event.inputs.submission_dirs }}
 

--- a/docs/LEADERBOARD_ALIGNMENT.md
+++ b/docs/LEADERBOARD_ALIGNMENT.md
@@ -2,6 +2,8 @@
 
 This document defines the contract between benchmark scenarios in this repository and the website leaderboard ingestion pipeline.
 
+See also: `docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md` for the proposed refactor plan that separates canonical model identity from UI display naming.
+
 ## Goal
 
 Keep benchmark outputs merge-safe and directly consumable by `vllm-hust-website/scripts/aggregate_results.py` without ad-hoc conversion code.
@@ -42,6 +44,8 @@ Current mapping:
 - scenario `leaderboard.workload_name` -> artifact `workload.name`
 - scenario `leaderboard.representative_business_scenario` -> `constraints.accountable_scope.representative_business_scenario`
 - scenario source -> `constraints.scenario_source = vllm-benchmark`
+- exporter model input -> normalized `model.canonical_id`, `model.repo_id`, `model.short_name`, and `model.display_name`
+- exporter compatibility field -> `model.name = model.repo_id` for normalized writes
 - benchmark metrics payload `metrics` -> artifact `metrics`
 - benchmark metrics payload `constraints_metrics` -> `constraints.metrics`
 - run metadata -> `metadata.*`, including deterministic `metadata.idempotency_key`

--- a/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
@@ -1,0 +1,78 @@
+# Leaderboard Model Identity Migration Checklist
+
+This checklist tracks the first implementation wave after Phase 0 decisions were frozen in `docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md`.
+
+## Scope Of The Initial Seed
+
+The initial registry seed intentionally covers only models already present in the checked-in leaderboard snapshots.
+
+Current raw values observed in website snapshots:
+
+- `Qwen/Qwen2.5-14B-Instruct` with 13 rows
+- `Qwen2.5-14B-Instruct` with 6 rows
+- `Qwen2.5-7B-Instruct` with 3 rows
+
+Initial canonical model set:
+
+- `hf:Qwen/Qwen2.5-14B-Instruct`
+- `hf:Qwen/Qwen2.5-7B-Instruct`
+
+Seed file:
+
+- `src/vllm_hust_benchmark/data/model_identity_registry.json`
+
+## Seed Mapping
+
+### Canonical record: `hf:Qwen/Qwen2.5-14B-Instruct`
+
+- `repo_id`: `Qwen/Qwen2.5-14B-Instruct`
+- `short_name`: `Qwen2.5-14B-Instruct`
+- `display_name`: `Qwen 2.5 14B Instruct`
+- legacy inputs to normalize:
+  - `Qwen/Qwen2.5-14B-Instruct`
+  - `Qwen2.5-14B-Instruct`
+
+### Canonical record: `hf:Qwen/Qwen2.5-7B-Instruct`
+
+- `repo_id`: `Qwen/Qwen2.5-7B-Instruct`
+- `short_name`: `Qwen2.5-7B-Instruct`
+- `display_name`: `Qwen 2.5 7B Instruct`
+- legacy inputs to normalize:
+  - `Qwen/Qwen2.5-7B-Instruct`
+  - `Qwen2.5-7B-Instruct`
+
+Note: the checked-in benchmark snapshots currently expose only the short-name form for 7B, but the canonical repo id is already used elsewhere in the workspace model catalog and bootstrap scripts. That is sufficient for the initial seed.
+
+## Implementation Checklist
+
+- [ ] Add a loader helper in the benchmark package that reads `model_identity_registry.json` through `importlib.resources`
+- [ ] Extend leaderboard schema and field spec docs to permit `model.canonical_id`, `model.repo_id`, `model.short_name`, and `model.display_name`
+- [ ] Update `export-leaderboard-artifact` so new writes emit the normalized field set
+- [ ] Freeze `model.name` writes to `model.repo_id` for all new exporters
+- [ ] Update aggregation logic to resolve legacy `model.name` values through the registry before grouping or deduplicating
+- [ ] Keep fallback reads from legacy snapshots during the transition window
+- [ ] Backfill `leaderboard_single.json`, `leaderboard_multi.json`, and `leaderboard_compare.json` from the normalized pipeline
+- [ ] Update website filters and table rendering to use `canonical_id` as value and `display_name` as label
+- [ ] Add tests that prove `Qwen/Qwen2.5-14B-Instruct` and `Qwen2.5-14B-Instruct` collapse to one canonical model
+- [ ] Add tests that reject unknown or ambiguous short aliases at publish time
+
+## Touchpoints
+
+Expected first implementation files:
+
+- `src/vllm_hust_benchmark/leaderboard_export.py`
+- `src/vllm_hust_benchmark/integration.py`
+- `src/vllm_hust_benchmark/data/model_identity_registry.json`
+- `vllm-hust-website/data/schemas/leaderboard_v1.schema.json`
+- `vllm-hust-website/data/FIELD_SPECIFICATION.md`
+- `vllm-hust-website/assets/leaderboard.js`
+- benchmark and website snapshot tests that currently assert raw `model.name`
+
+## Exit Condition For This Seed
+
+The initial seed is complete when:
+
+- new exports always write normalized model identity fields
+- legacy 14B short-name and repo-id rows collapse into one logical model in filters and compare scopes
+- 7B rows also publish the same normalized identity structure
+- no new checked-in snapshot introduces a bare short alias as the only machine-readable model identifier

--- a/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
@@ -1,0 +1,325 @@
+# Leaderboard Model Identity Normalization RFC
+
+Status: Phase 0 decisions frozen. Implementation pending.
+
+This document records the approved Phase 0 decisions for model identity normalization in the vllm-hust leaderboard pipeline. It is the implementation target for the next migration steps, although the live data contract is not fully enforced yet.
+
+See also:
+
+- `src/vllm_hust_benchmark/data/model_identity_registry.json` for the initial seed registry
+- `docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md` for the implementation checklist
+
+## Problem Statement
+
+The current leaderboard pipeline uses `model.name` for multiple meanings at once:
+
+- canonical upstream model coordinate, for example `Qwen/Qwen2.5-14B-Instruct`
+- short model alias, for example `Qwen2.5-14B-Instruct`
+- UI display label in some downstream discussions
+
+Because the exporter writes `--model-name` into the artifact unchanged, different submission sources can publish different strings for the same model. The website filter then de-duplicates on the raw `model.name` value and exposes multiple entries for one logical model.
+
+## Observed Current State
+
+Representative examples already exist in checked-in snapshots:
+
+- `Qwen/Qwen2.5-14B-Instruct`
+- `Qwen2.5-14B-Instruct`
+
+The current behavior is internally inconsistent:
+
+- main leaderboard snapshots preserve the raw submitted `model.name`
+- compare goal grouping already strips the namespace for some matching paths
+- official same-spec and baseline specs use the full upstream coordinate
+
+This means the system already treats these values as partially equivalent, but that equivalence is not expressed in the data contract.
+
+## Industry Convention
+
+For machine-readable model identity, the industry-standard format is a registry coordinate or repository coordinate, not a short alias.
+
+Examples:
+
+- Hugging Face: `Qwen/Qwen2.5-14B-Instruct`
+- ModelScope or internal registries: typically `registry + namespace/model`
+
+Short names such as `Qwen2.5-14B-Instruct` are useful as aliases or display values, but they are not a strong canonical identifier because they lose the namespace and can collide across forks, mirrors, or vendor-specific repacks.
+
+## Design Goal
+
+Split model identity into separate fields so each field has one meaning only:
+
+- canonical identity for matching, deduplication, and contracts
+- upstream source coordinate for traceability
+- short alias for convenience
+- display label for UI rendering
+
+The design should preserve merge safety for benchmark artifacts and avoid ad-hoc website-side normalization.
+
+## Frozen Decisions
+
+This section completes Phase 0. The following decisions are fixed unless a later RFC explicitly supersedes them.
+
+### Decision 1: Canonical Identifier Format
+
+`model.canonical_id` uses the format `<registry>:<repo_id>`.
+
+Examples:
+
+- `hf:Qwen/Qwen2.5-14B-Instruct`
+- `hf:deepseek-ai/DeepSeek-R1-Distill-Qwen-14B`
+
+Rules:
+
+- `registry` is a short lowercase token such as `hf`
+- `repo_id` is the upstream namespace-qualified coordinate without registry prefix
+- `canonical_id` is the only field allowed to act as the machine identity for deduplication, compare grouping, filtering, and validation
+- when the source model comes from Hugging Face, `canonical_id` must be `hf:<repo_id>`
+- local cache paths, snapshot paths, and bare short aliases are never valid canonical ids
+
+Reasoning:
+
+- this preserves namespace information
+- this leaves room for future multi-registry ingestion without another schema break
+- this avoids treating short aliases as globally unique identifiers
+
+### Decision 2: Registry Source Of Truth Location
+
+The source-of-truth registry file will live at:
+
+- `src/vllm_hust_benchmark/data/model_identity_registry.json`
+
+Why this location is fixed:
+
+- the benchmark package already ships JSON data files from `src/vllm_hust_benchmark/data`
+- both exporter and aggregation logic can consume it through `importlib.resources`
+- the registry is part of the benchmark contract, not a website-only concern
+
+The registry will store one canonical record per logical model, plus explicit aliases.
+
+Recommended shape:
+
+```json
+{
+  "version": 1,
+  "models": [
+    {
+      "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+      "registry": "hf",
+      "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+      "short_name": "Qwen2.5-14B-Instruct",
+      "display_name": "Qwen 2.5 14B Instruct",
+      "aliases": [
+        "Qwen/Qwen2.5-14B-Instruct",
+        "Qwen2.5-14B-Instruct"
+      ]
+    }
+  ]
+}
+```
+
+Operational rules:
+
+- one canonical record per logical model
+- aliases must resolve to exactly one canonical record
+- short-name collisions must be handled by adding an explicit non-ambiguous alias, not by inference
+- official baseline specs and same-spec docs should reference the same canonical record
+
+### Decision 3: Compatibility Policy For `model.name`
+
+`model.name` remains in schema v1 during the migration window, but its semantics are frozen as a compatibility mirror of `model.repo_id`.
+
+Rules:
+
+- new writers must populate `model.name` with the same value as `model.repo_id`
+- new writers must not emit a short alias in `model.name`
+- readers must treat `model.name` as legacy compatibility input only
+- new matching, grouping, and filtering logic must not use `model.name` when `canonical_id` is available
+- schema v1 compatibility ends only after all active writers and checked-in snapshots have migrated
+
+This freezes the transition policy and avoids a mixed state where some new submissions keep using short aliases in `model.name`.
+
+### Decision 4: Minimal Field Set For Phase 1 Writers
+
+All new normalized writers must produce at least:
+
+- `model.canonical_id`
+- `model.repo_id`
+- `model.short_name`
+- `model.display_name`
+- `model.name` as a compatibility mirror of `model.repo_id`
+
+No new writer may publish only a short alias.
+
+## Proposed Data Contract
+
+Add explicit model identity fields to leaderboard artifacts.
+
+Recommended model payload:
+
+```json
+{
+  "model": {
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen 2.5 14B Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
+    "parameters": "14B",
+    "precision": "FP16",
+    "quantization": null
+  }
+}
+```
+
+Field semantics:
+
+- `model.canonical_id`: authoritative machine identifier used by aggregation, compare grouping, and filters
+- `model.repo_id`: upstream repository coordinate when the model comes from a registry such as Hugging Face
+- `model.short_name`: stable human-typed alias without namespace
+- `model.display_name`: UI label shown in dropdowns and tables
+- `model.name`: compatibility field kept during migration only; it must mirror `model.repo_id`
+
+The Phase 0 decision is to use prefixed canonical ids from day one, for example `hf:Qwen/Qwen2.5-14B-Instruct`.
+
+## Normalization Rules
+
+Normalization should happen at the benchmark export or aggregation boundary, not in the website render layer.
+
+Required rules:
+
+1. Raw input may arrive as a repo coordinate, a short alias, or a local snapshot path.
+2. The exporter or aggregator resolves the raw input into one canonical model identity record.
+3. Local cache paths must never become published canonical identifiers.
+4. Unknown aliases must fail fast or be surfaced as validation errors instead of silently creating new logical models.
+
+Required resolution order:
+
+1. explicit model registry metadata from the submission
+2. exact alias-map match
+3. exact repo-id match
+4. explicit rejection with remediation guidance
+
+## Alias Registry
+
+To support historical data and operator convenience, maintain a small explicit alias registry.
+
+Example:
+
+```json
+{
+  "Qwen2.5-14B-Instruct": {
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen 2.5 14B Instruct"
+  }
+}
+```
+
+This registry should be versioned with the benchmark repository, reviewed like a contract file, and reused by:
+
+- exporter validation
+- snapshot aggregation
+- compare scope generation
+- website filter labeling
+
+## Website Rendering Rules
+
+The website should stop treating `model.name` as both label and identity.
+
+Recommended UI behavior:
+
+- filter option value: `model.canonical_id`
+- filter option label: `model.display_name`
+- table primary text: `model.display_name`
+- tooltip or details panel: `model.repo_id`
+
+This keeps the user-facing UI clean while preserving source traceability.
+
+## Migration Plan
+
+### Phase 0: Proposal And Schema Preparation
+
+- document the new field semantics
+- freeze the canonical id format as `<registry>:<repo_id>`
+- freeze the registry location as `src/vllm_hust_benchmark/data/model_identity_registry.json`
+- freeze `model.name` as a compatibility mirror of `model.repo_id`
+- extend the schema to allow the new fields
+
+### Phase 1: Writer Normalization
+
+- update benchmark export paths to resolve raw model inputs into canonical identity fields
+- update same-spec-related exports so their canonical model remains stable even if runtime paths differ
+- reject unresolved aliases during publish
+
+### Phase 2: Reader Compatibility
+
+- update aggregation to prefer `canonical_id`, then fall back to legacy `name`
+- normalize historical snapshots through the same alias registry
+- keep backward compatibility for old artifacts during a transition window
+
+### Phase 3: Website Consumption
+
+- switch filter, grouping, and display logic to the new fields
+- stop deriving logical identity from raw `model.name`
+
+### Phase 4: Historical Backfill
+
+- regenerate `leaderboard_single.json`, `leaderboard_multi.json`, and `leaderboard_compare.json`
+- ensure each logical model appears once per canonical identity
+- verify compare scopes and hard-constraint scope keys remain stable where intended
+
+### Phase 5: Contract Tightening
+
+- deprecate new writes to `model.name` as an identity field
+- keep `model.name` as a mirror of `repo_id` for one compatibility release after all active writers migrate
+- remove legacy fallback logic after all active producers are migrated
+
+## Why Frontend-Only Normalization Is Not Enough
+
+A website-only fix can hide duplicate filter entries, but it does not solve the underlying contract problem.
+
+It leaves the following issues in place:
+
+- compare grouping and validation still see mixed identifiers
+- historical snapshots remain semantically inconsistent
+- new submissions can continue to publish ambiguous names
+- downstream analytics cannot rely on one stable model key
+
+Therefore the recommended fix point is the benchmark data boundary, with the website consuming normalized fields.
+
+## Compatibility And Risk Notes
+
+Main risks:
+
+- accidental merge of genuinely different models that share a short alias
+- drift between alias registry and official baseline specs
+- compare scope churn if identity normalization changes grouping keys without a controlled migration
+
+Mitigations:
+
+- require explicit alias mapping for short names
+- prefer repo coordinates over inferred aliases
+- keep compare grouping on canonical identity only after backfill is ready
+- add snapshot validation that rejects multiple display labels for one canonical id
+
+## Acceptance Criteria
+
+The normalization is complete when all of the following hold:
+
+- one logical model produces one filter option in the website
+- aggregation and compare logic use a stable canonical model identifier
+- official baselines, same-spec exports, and ad-hoc benchmark submissions converge on the same identity record
+- legacy snapshots can still be read during the migration window
+- new submissions cannot introduce unregistered ambiguous short names
+
+## Phase 0 Outcome
+
+Phase 0 is complete when future implementation work treats the following as already decided:
+
+- canonical ids use `<registry>:<repo_id>` and Hugging Face models use the `hf:` prefix
+- the source-of-truth identity registry lives at `src/vllm_hust_benchmark/data/model_identity_registry.json`
+- `model.name` remains in schema v1 only as a compatibility mirror of `model.repo_id`
+
+The next implementation step is to update schema and writer paths to emit the frozen field set without changing website behavior yet.

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -522,8 +522,12 @@ def _build_parser() -> argparse.ArgumentParser:
     sync_submission_parser.add_argument(
         "--submission-dir",
         action="append",
-        required=True,
         help="Submission directory to merge and upload. Repeat this flag to sync multiple submissions in one rebuild.",
+    )
+    sync_submission_parser.add_argument(
+        "--existing-only",
+        action="store_true",
+        help="Backfill and republish already-hosted HF submissions without supplying any new local submission directory.",
     )
     sync_submission_parser.add_argument("--aggregate-output-dir", required=True)
     sync_submission_parser.add_argument("--repo-id", required=True)
@@ -982,7 +986,11 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         return sync_submission_to_huggingface(
             layout=layout,
-            submission_dirs=[Path(path).resolve() for path in args.submission_dir],
+            submission_dirs=(
+                [Path(path).resolve() for path in args.submission_dir]
+                if args.submission_dir
+                else None
+            ),
             aggregate_output_dir=Path(args.aggregate_output_dir).resolve(),
             repo_id=args.repo_id,
             token=getattr(args, "token", None),
@@ -994,6 +1002,7 @@ def main(argv: list[str] | None = None) -> int:
                 "chore: sync benchmark submission and leaderboard data",
             ),
             dry_run=getattr(args, "dry_run", False),
+            allow_existing_only=getattr(args, "existing_only", False),
         )
 
     if args.command == "submit":

--- a/src/vllm_hust_benchmark/data/model_identity_registry.json
+++ b/src/vllm_hust_benchmark/data/model_identity_registry.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "canonical_id": "hf:Qwen/Qwen2.5-0.5B-Instruct",
+      "registry": "hf",
+      "repo_id": "Qwen/Qwen2.5-0.5B-Instruct",
+      "short_name": "Qwen2.5-0.5B-Instruct",
+      "display_name": "Qwen 2.5 0.5B Instruct",
+      "aliases": [
+        "Qwen2.5-0.5B-Instruct"
+      ]
+    },
+    {
+      "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+      "registry": "hf",
+      "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+      "short_name": "Qwen2.5-14B-Instruct",
+      "display_name": "Qwen 2.5 14B Instruct",
+      "aliases": [
+        "Qwen2.5-14B-Instruct"
+      ]
+    },
+    {
+      "canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct",
+      "registry": "hf",
+      "repo_id": "Qwen/Qwen2.5-7B-Instruct",
+      "short_name": "Qwen2.5-7B-Instruct",
+      "display_name": "Qwen 2.5 7B Instruct",
+      "aliases": [
+        "Qwen2.5-7B-Instruct"
+      ]
+    },
+    {
+      "canonical_id": "hf:meta-llama/Llama-3.1-8B-Instruct",
+      "registry": "hf",
+      "repo_id": "meta-llama/Llama-3.1-8B-Instruct",
+      "short_name": "Llama-3.1-8B-Instruct",
+      "display_name": "Llama 3.1 8B Instruct",
+      "aliases": [
+        "Llama-3.1-8B-Instruct",
+        "Meta-Llama-3.1-8B-Instruct"
+      ]
+    },
+    {
+      "canonical_id": "hf:deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+      "registry": "hf",
+      "repo_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+      "short_name": "DeepSeek-R1-Distill-Qwen-7B",
+      "display_name": "DeepSeek R1 Distill Qwen 7B",
+      "aliases": [
+        "DeepSeek-R1-Distill-Qwen-7B"
+      ]
+    },
+    {
+      "canonical_id": "hf:deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+      "registry": "hf",
+      "repo_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+      "short_name": "DeepSeek-R1-Distill-Qwen-14B",
+      "display_name": "DeepSeek R1 Distill Qwen 14B",
+      "aliases": [
+        "DeepSeek-R1-Distill-Qwen-14B"
+      ]
+    },
+    {
+      "canonical_id": "hf:mistralai/Mistral-7B-Instruct-v0.3",
+      "registry": "hf",
+      "repo_id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "short_name": "Mistral-7B-Instruct-v0.3",
+      "display_name": "Mistral 7B Instruct v0.3",
+      "aliases": [
+        "Mistral-7B-Instruct-v0.3"
+      ]
+    }
+  ]
+}

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1118,8 +1118,6 @@ def validate_aggregated_leaderboard_outputs(
         baseline_engine = _normalize_baseline_engine(accountable.get("baseline_engine"))
 
         if official_coverage_keys is not None:
-            expected_coverage_key = ""
-            in_official_specs = False
             if declared_baseline_engine:
                 expected_coverage_key = _build_baseline_coverage_key(
                     engine=declared_baseline_engine,
@@ -1128,8 +1126,7 @@ def validate_aggregated_leaderboard_outputs(
                     workload=workload_name,
                     config_type=config_type,
                 )
-                in_official_specs = expected_coverage_key in official_coverage_keys
-                if in_official_specs:
+                if expected_coverage_key in official_coverage_keys:
                     baseline_status = BASELINE_STATUS_OFFICIAL_COVERED
                     baseline_engine = declared_baseline_engine
                 else:
@@ -1138,17 +1135,6 @@ def validate_aggregated_leaderboard_outputs(
             else:
                 baseline_status = BASELINE_STATUS_NONE
                 baseline_engine = ""
-
-            print(
-                "aggregated compare debug: validation baseline resolution"
-                f" | scope_key={scope.get('scope_key') or ''}"
-                f" | declared_baseline_engine={declared_baseline_engine}"
-                f" | resolved_baseline_engine={baseline_engine}"
-                f" | resolved_status={baseline_status}"
-                f" | expected_coverage_key={expected_coverage_key}"
-                f" | in_official_specs={in_official_specs}",
-                file=sys.stderr,
-            )
         else:
             baseline_status = str(accountable.get("baseline_status") or "").strip()
             if baseline_status not in VALID_BASELINE_STATUSES:

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -978,7 +978,11 @@ def _print_aggregated_compare_diagnostics(data_dir: Path) -> None:
     )
 
 
-def validate_aggregated_leaderboard_outputs(data_dir: Path) -> None:
+def validate_aggregated_leaderboard_outputs(
+    data_dir: Path,
+    *,
+    official_coverage_keys: set[str] | None = None,
+) -> None:
     single = _load_snapshot_json(data_dir / "leaderboard_single.json")
     multi = _load_snapshot_json(data_dir / "leaderboard_multi.json")
     compare = _load_snapshot_json(data_dir / "leaderboard_compare.json")
@@ -1075,31 +1079,58 @@ def validate_aggregated_leaderboard_outputs(data_dir: Path) -> None:
         scope_payload = scope_payload if isinstance(scope_payload, Mapping) else {}
         accountable = scope_payload.get("accountable_scope")
         accountable = accountable if isinstance(accountable, Mapping) else {}
+        model_name = str(scope_payload.get("model") or "unknown-model")
+        hardware_name = str(scope_payload.get("hardware") or "unknown-hardware")
+        workload_name = str(scope_payload.get("workload") or "Other")
+        config_type = str(scope_payload.get("config_type") or "unknown-config")
         declared_baseline_engine = _normalize_baseline_engine(
-            accountable.get("declared_baseline_engine") or accountable.get("baseline_engine")
+            accountable.get("declared_baseline_engine")
+            or accountable.get("baseline_engine")
         )
-        baseline_status = str(accountable.get("baseline_status") or "").strip()
-        if baseline_status not in VALID_BASELINE_STATUSES:
-            if accountable.get("baseline_engine"):
-                baseline_status = BASELINE_STATUS_OFFICIAL_COVERED
-            elif declared_baseline_engine:
-                baseline_status = BASELINE_STATUS_PENDING
+        baseline_engine = _normalize_baseline_engine(accountable.get("baseline_engine"))
+
+        if official_coverage_keys is not None:
+            if declared_baseline_engine:
+                expected_coverage_key = _build_baseline_coverage_key(
+                    engine=declared_baseline_engine,
+                    model=model_name,
+                    hardware=hardware_name,
+                    workload=workload_name,
+                    config_type=config_type,
+                )
+                if expected_coverage_key in official_coverage_keys:
+                    baseline_status = BASELINE_STATUS_OFFICIAL_COVERED
+                    baseline_engine = declared_baseline_engine
+                else:
+                    baseline_status = BASELINE_STATUS_PENDING
+                    baseline_engine = ""
             else:
                 baseline_status = BASELINE_STATUS_NONE
+                baseline_engine = ""
+        else:
+            baseline_status = str(accountable.get("baseline_status") or "").strip()
+            if baseline_status not in VALID_BASELINE_STATUSES:
+                if accountable.get("baseline_engine"):
+                    baseline_status = BASELINE_STATUS_OFFICIAL_COVERED
+                elif declared_baseline_engine:
+                    baseline_status = BASELINE_STATUS_PENDING
+                else:
+                    baseline_status = BASELINE_STATUS_NONE
+
+            if baseline_status == BASELINE_STATUS_OFFICIAL_COVERED:
+                baseline_engine = baseline_engine or declared_baseline_engine
+            else:
+                baseline_engine = ""
 
         if baseline_status != BASELINE_STATUS_OFFICIAL_COVERED:
             continue
 
-        baseline_engine = _normalize_baseline_engine(
-            accountable.get("baseline_engine") or declared_baseline_engine
-        )
-
         baseline_key = _build_baseline_coverage_key(
             engine=baseline_engine,
-            model=str(scope_payload.get("model") or "unknown-model"),
-            hardware=str(scope_payload.get("hardware") or "unknown-hardware"),
-            workload=str(scope_payload.get("workload") or "Other"),
-            config_type=str(scope_payload.get("config_type") or "unknown-config"),
+            model=model_name,
+            hardware=hardware_name,
+            workload=workload_name,
+            config_type=config_type,
         )
         if baseline_key not in baseline_coverage_keys:
             missing_baseline_coverage.append(scope.get("scope_key") or baseline_key)
@@ -1253,10 +1284,12 @@ def sync_submission_to_huggingface(
                 submission_dir, current_submission_target, dirs_exist_ok=True
             )
 
+        official_coverage_keys = _load_official_baseline_coverage_keys(layout)
+
         normalize_submission_artifacts_in_tree(merged_source_dir)
         _normalize_submission_baseline_metadata(
             merged_source_dir,
-            official_coverage_keys=_load_official_baseline_coverage_keys(layout),
+            official_coverage_keys=official_coverage_keys,
         )
 
         aggregate_rc = aggregate_to_website(
@@ -1269,7 +1302,10 @@ def sync_submission_to_huggingface(
             return aggregate_rc
 
         try:
-            validate_aggregated_leaderboard_outputs(aggregate_output_dir)
+            validate_aggregated_leaderboard_outputs(
+                aggregate_output_dir,
+                official_coverage_keys=official_coverage_keys,
+            )
         except ValueError as exc:
             _print_aggregated_compare_diagnostics(aggregate_output_dir)
             print(str(exc), file=sys.stderr)

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1090,6 +1090,8 @@ def validate_aggregated_leaderboard_outputs(
         baseline_engine = _normalize_baseline_engine(accountable.get("baseline_engine"))
 
         if official_coverage_keys is not None:
+            expected_coverage_key = ""
+            in_official_specs = False
             if declared_baseline_engine:
                 expected_coverage_key = _build_baseline_coverage_key(
                     engine=declared_baseline_engine,
@@ -1098,7 +1100,8 @@ def validate_aggregated_leaderboard_outputs(
                     workload=workload_name,
                     config_type=config_type,
                 )
-                if expected_coverage_key in official_coverage_keys:
+                in_official_specs = expected_coverage_key in official_coverage_keys
+                if in_official_specs:
                     baseline_status = BASELINE_STATUS_OFFICIAL_COVERED
                     baseline_engine = declared_baseline_engine
                 else:
@@ -1107,6 +1110,17 @@ def validate_aggregated_leaderboard_outputs(
             else:
                 baseline_status = BASELINE_STATUS_NONE
                 baseline_engine = ""
+
+            print(
+                "aggregated compare debug: validation baseline resolution"
+                f" | scope_key={scope.get('scope_key') or ''}"
+                f" | declared_baseline_engine={declared_baseline_engine}"
+                f" | resolved_baseline_engine={baseline_engine}"
+                f" | resolved_status={baseline_status}"
+                f" | expected_coverage_key={expected_coverage_key}"
+                f" | in_official_specs={in_official_specs}",
+                file=sys.stderr,
+            )
         else:
             baseline_status = str(accountable.get("baseline_status") or "").strip()
             if baseline_status not in VALID_BASELINE_STATUSES:

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -19,6 +19,8 @@ from typing import Any, Mapping
 
 from vllm_hust_benchmark.models import render_parameter_flags
 from vllm_hust_benchmark.registry import get_scenario
+from vllm_hust_benchmark.submission_artifacts import iter_submission_artifact_paths
+from vllm_hust_benchmark.submission_artifacts import normalize_submission_artifacts_in_tree
 
 FLAG_PATTERN = re.compile(r"^\s+--([a-z0-9][a-z0-9-_]*)\b", re.MULTILINE)
 DEFAULT_RUNTIME_ENGINE = "vllm-hust"
@@ -721,7 +723,7 @@ def _normalize_submission_baseline_metadata(
     *,
     official_coverage_keys: set[str],
 ) -> None:
-    for artifact_path in sorted(source_dir.rglob("run_leaderboard.json")):
+    for artifact_path in iter_submission_artifact_paths(source_dir):
         try:
             payload = json.loads(artifact_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
@@ -1154,7 +1156,7 @@ def _resolve_hf_token(token: str | None) -> str | None:
 def sync_submission_to_huggingface(
     *,
     layout: RepoLayout,
-    submission_dirs: Path | Sequence[Path],
+    submission_dirs: Path | Sequence[Path] | None,
     aggregate_output_dir: Path,
     repo_id: str,
     token: str | None = None,
@@ -1162,6 +1164,7 @@ def sync_submission_to_huggingface(
     submissions_prefix: str = "submissions-auto",
     commit_message: str = "chore: sync benchmark submission and leaderboard data",
     dry_run: bool = False,
+    allow_existing_only: bool = False,
 ) -> int:
     try:
         from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
@@ -1174,13 +1177,18 @@ def sync_submission_to_huggingface(
         )
         return 2
 
-    if isinstance(submission_dirs, Path):
+    if submission_dirs is None:
+        normalized_submission_dirs: list[Path] = []
+    elif isinstance(submission_dirs, Path):
         normalized_submission_dirs = [submission_dirs]
     else:
         normalized_submission_dirs = list(submission_dirs)
 
-    if not normalized_submission_dirs:
-        print("at least one submission directory is required", file=sys.stderr)
+    if not normalized_submission_dirs and not allow_existing_only:
+        print(
+            "at least one submission directory is required unless --existing-only is set",
+            file=sys.stderr,
+        )
         return 2
 
     for submission_dir in normalized_submission_dirs:
@@ -1224,16 +1232,13 @@ def sync_submission_to_huggingface(
             )
             shutil.copy2(downloaded_path, local_path)
 
-        current_submission_targets: list[tuple[Path, Path]] = []
         for submission_dir in normalized_submission_dirs:
             current_submission_target = merged_source_dir / submission_dir.name
             shutil.copytree(
                 submission_dir, current_submission_target, dirs_exist_ok=True
             )
-            current_submission_targets.append(
-                (submission_dir, current_submission_target)
-            )
 
+        normalize_submission_artifacts_in_tree(merged_source_dir)
         _normalize_submission_baseline_metadata(
             merged_source_dir,
             official_coverage_keys=_load_official_baseline_coverage_keys(layout),
@@ -1274,24 +1279,17 @@ def sync_submission_to_huggingface(
             )
             planned_paths.append(file_name)
 
-        for submission_dir, current_submission_target in current_submission_targets:
-            for local_file in sorted(current_submission_target.rglob("*")):
-                if not local_file.is_file():
-                    continue
-                relative_path = local_file.relative_to(
-                    current_submission_target
-                ).as_posix()
-                repo_path = "/".join(
-                    part
-                    for part in [normalized_prefix, submission_dir.name, relative_path]
-                    if part
-                )
-                operations.append(
-                    CommitOperationAdd(
-                        path_in_repo=repo_path, path_or_fileobj=local_file
-                    )
-                )
-                planned_paths.append(repo_path)
+        for local_file in sorted(merged_source_dir.rglob("*")):
+            if not local_file.is_file():
+                continue
+            relative_path = local_file.relative_to(merged_source_dir).as_posix()
+            repo_path = "/".join(
+                part for part in [normalized_prefix, relative_path] if part
+            )
+            operations.append(
+                CommitOperationAdd(path_in_repo=repo_path, path_or_fileobj=local_file)
+            )
+            planned_paths.append(repo_path)
 
         if dry_run:
             print(

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -673,7 +673,7 @@ def _load_official_baseline_coverage_keys(layout: RepoLayout) -> set[str]:
     if not official_specs_dir.is_dir():
         return set()
 
-    coverage_keys: set[str] = set()
+    declared_coverage_keys: set[str] = set()
     for spec_path in sorted(official_specs_dir.glob("*.json")):
         if spec_path.name.endswith("constraints.stub.json"):
             continue
@@ -703,7 +703,7 @@ def _load_official_baseline_coverage_keys(layout: RepoLayout) -> set[str]:
         workload = scenario.leaderboard.get("workload_name") or scenario_name
         chip_count = int(payload.get("chip_count") or 1)
         node_count = int(payload.get("node_count") or 1)
-        coverage_keys.add(
+        declared_coverage_keys.add(
             _build_baseline_coverage_key(
                 engine=baseline_engine,
                 model=str(payload.get("model") or "unknown-model"),
@@ -715,7 +715,35 @@ def _load_official_baseline_coverage_keys(layout: RepoLayout) -> set[str]:
                 ),
             )
         )
-    return coverage_keys
+
+    if not declared_coverage_keys:
+        return set()
+
+    submissions_root = layout.benchmark_repo / "submissions"
+    if not submissions_root.is_dir():
+        return set()
+
+    published_coverage_keys: set[str] = set()
+    for artifact_path in sorted(submissions_root.rglob("run_leaderboard.json")):
+        if not artifact_path.parent.name.startswith("official-ascend-"):
+            continue
+
+        try:
+            payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if not isinstance(payload, Mapping):
+            continue
+
+        coverage_key = _build_entry_baseline_coverage_key(
+            payload,
+            engine=_normalize_engine(payload),
+        )
+        if coverage_key in declared_coverage_keys:
+            published_coverage_keys.add(coverage_key)
+
+    return published_coverage_keys
 
 
 def _normalize_submission_baseline_metadata(

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1215,12 +1215,27 @@ def sync_submission_to_huggingface(
                 repo_type="dataset",
                 revision=branch,
             )
-        except Exception:
-            repo_files = []
+        except Exception as exc:
+            print(
+                f"failed to list dataset files from {repo_id}@{branch}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
 
-        for repo_path in repo_files:
-            if repo_prefix and not repo_path.startswith(repo_prefix):
-                continue
+        prefixed_repo_files = [
+            repo_path
+            for repo_path in repo_files
+            if not repo_prefix or repo_path.startswith(repo_prefix)
+        ]
+        if allow_existing_only and not prefixed_repo_files:
+            print(
+                f"no historical submissions found under prefix {normalized_prefix!r} "
+                f"in {repo_id}@{branch}",
+                file=sys.stderr,
+            )
+            return 2
+
+        for repo_path in prefixed_repo_files:
             local_path = merged_root / repo_path
             local_path.parent.mkdir(parents=True, exist_ok=True)
             downloaded_path = hf_hub_download(

--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Any
 
 from vllm_hust_benchmark import __version__ as benchmark_version
+from vllm_hust_benchmark.model_registry import normalize_model_identity_payload
+from vllm_hust_benchmark.model_registry import resolve_model_identity
+from vllm_hust_benchmark.model_registry import validate_model_identity_payload
 from vllm_hust_benchmark.models import ScenarioDefinition
 
 REQUIRED_METRIC_KEYS = (
@@ -317,7 +320,7 @@ def _build_idempotency_key(
     scenario_name: str,
     engine: str,
     engine_version: str,
-    model_name: str,
+    model_identity: str,
     hardware_chip_model: str,
     chip_count: int,
     node_count: int,
@@ -328,7 +331,7 @@ def _build_idempotency_key(
             scenario_name,
             engine,
             engine_version,
-            model_name,
+            model_identity,
             hardware_chip_model,
             str(chip_count),
             str(node_count),
@@ -426,6 +429,7 @@ def export_leaderboard_artifacts(
     plugin_source_commit: str | None,
 ) -> tuple[Path, Path]:
     engine_version = _sanitize_engine_version(engine_version, git_commit=git_commit)
+    model_identity = resolve_model_identity(model_name)
     payload = load_export_payload(
         metrics_file=metrics_file,
         benchmark_result_file=benchmark_result_file,
@@ -465,7 +469,7 @@ def export_leaderboard_artifacts(
         scenario_name=scenario.name,
         engine=engine,
         engine_version=engine_version,
-        model_name=model_name,
+        model_identity=model_identity.canonical_id,
         hardware_chip_model=hardware_chip_model,
         chip_count=chip_count,
         node_count=node_count,
@@ -500,7 +504,11 @@ def export_leaderboard_artifacts(
             "total_memory_gb": resolved_total_memory_gb,
         },
         "model": {
-            "name": model_name,
+            "canonical_id": model_identity.canonical_id,
+            "repo_id": model_identity.repo_id,
+            "short_name": model_identity.short_name,
+            "display_name": model_identity.display_name,
+            "name": model_identity.repo_id,
             "parameters": model_parameters,
             "precision": model_precision,
             "quantization": None,
@@ -584,6 +592,8 @@ def export_leaderboard_artifacts(
             },
         },
     }
+    artifact["model"] = normalize_model_identity_payload(artifact["model"])
+    validate_model_identity_payload(artifact["model"])
     if same_spec_payload is not None:
         artifact["same_spec"] = same_spec_payload
 

--- a/src/vllm_hust_benchmark/model_registry.py
+++ b/src/vllm_hust_benchmark/model_registry.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+
+DEFAULT_MODEL_REGISTRY = "hf"
+CANONICAL_ID_PATTERN = re.compile(r"^(?P<registry>[a-z0-9][a-z0-9_-]*):(?P<repo_id>.+)$")
+HF_CACHE_PATH_PATTERN = re.compile(
+    r"(?:^|/)models--(?P<namespace>[^/]+)--(?P<name>[^/]+)/(?:snapshots|refs)/",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ModelIdentity:
+    canonical_id: str
+    registry: str
+    repo_id: str
+    short_name: str
+    display_name: str
+    aliases: tuple[str, ...] = ()
+
+
+def _looks_like_repo_id(value: str) -> bool:
+    if not value or value.startswith("/"):
+        return False
+    parts = value.split("/")
+    return len(parts) == 2 and all(part.strip() for part in parts)
+
+
+def _parse_canonical_id(value: str) -> tuple[str, str] | None:
+    match = CANONICAL_ID_PATTERN.match(value)
+    if not match:
+        return None
+    return match.group("registry"), match.group("repo_id")
+
+
+def _extract_hf_repo_id_from_path(value: str) -> str | None:
+    match = HF_CACHE_PATH_PATTERN.search(value)
+    if not match:
+        return None
+    namespace = match.group("namespace")
+    name = match.group("name")
+    return f"{namespace}/{name}"
+
+
+def _build_fallback_identity(repo_id: str, *, registry: str) -> ModelIdentity:
+    short_name = repo_id.rsplit("/", maxsplit=1)[-1]
+    return ModelIdentity(
+        canonical_id=f"{registry}:{repo_id}",
+        registry=registry,
+        repo_id=repo_id,
+        short_name=short_name,
+        display_name=short_name,
+        aliases=(),
+    )
+
+
+@lru_cache(maxsize=1)
+def load_model_identity_registry() -> tuple[ModelIdentity, ...]:
+    with resources.files("vllm_hust_benchmark.data").joinpath(
+        "model_identity_registry.json"
+    ).open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise ValueError("model identity registry must contain a models array")
+
+    records: list[ModelIdentity] = []
+    for item in models:
+        if not isinstance(item, dict):
+            raise ValueError("model identity registry entries must be objects")
+        aliases = item.get("aliases") or []
+        if not isinstance(aliases, list):
+            raise ValueError("model identity registry aliases must be an array")
+        records.append(
+            ModelIdentity(
+                canonical_id=str(item["canonical_id"]),
+                registry=str(item["registry"]),
+                repo_id=str(item["repo_id"]),
+                short_name=str(item["short_name"]),
+                display_name=str(item["display_name"]),
+                aliases=tuple(str(alias) for alias in aliases if str(alias).strip()),
+            )
+        )
+    return tuple(records)
+
+
+@lru_cache(maxsize=1)
+def _build_identity_lookup() -> dict[str, ModelIdentity]:
+    lookup: dict[str, ModelIdentity] = {}
+    for record in load_model_identity_registry():
+        keys = {
+            record.canonical_id,
+            record.repo_id,
+            record.short_name,
+            *record.aliases,
+        }
+        for key in keys:
+            existing = lookup.get(key)
+            if existing is not None and existing != record:
+                raise ValueError(f"duplicate model identity alias in registry: {key}")
+            lookup[key] = record
+    return lookup
+
+
+def resolve_model_identity(
+    raw_model_name: str,
+    *,
+    default_registry: str = DEFAULT_MODEL_REGISTRY,
+) -> ModelIdentity:
+    normalized = str(raw_model_name or "").strip()
+    if not normalized:
+        raise ValueError("model name is required for leaderboard export")
+
+    lookup = _build_identity_lookup()
+    direct_match = lookup.get(normalized)
+    if direct_match is not None:
+        return direct_match
+
+    canonical = _parse_canonical_id(normalized)
+    if canonical is not None:
+        registry, repo_id = canonical
+        seeded = lookup.get(repo_id)
+        return seeded if seeded is not None else _build_fallback_identity(repo_id, registry=registry)
+
+    repo_id_from_path = _extract_hf_repo_id_from_path(normalized)
+    if repo_id_from_path is not None:
+        seeded = lookup.get(repo_id_from_path)
+        return (
+            seeded
+            if seeded is not None
+            else _build_fallback_identity(repo_id_from_path, registry=DEFAULT_MODEL_REGISTRY)
+        )
+
+    if _looks_like_repo_id(normalized):
+        return _build_fallback_identity(normalized, registry=default_registry)
+
+    raise ValueError(
+        "unknown short model alias; add it to model_identity_registry.json or pass a repo id"
+    )
+
+
+def resolve_model_identity_from_payload(
+    model_payload: Mapping[str, object],
+    *,
+    default_registry: str = DEFAULT_MODEL_REGISTRY,
+) -> ModelIdentity:
+    candidates = [
+        str(model_payload.get("canonical_id") or "").strip(),
+        str(model_payload.get("repo_id") or "").strip(),
+        str(model_payload.get("name") or "").strip(),
+        str(model_payload.get("short_name") or "").strip(),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        return resolve_model_identity(candidate, default_registry=default_registry)
+    raise ValueError("model payload must contain canonical_id, repo_id, name, or short_name")
+
+
+def normalize_model_identity_payload(
+    model_payload: Mapping[str, object],
+    *,
+    default_registry: str = DEFAULT_MODEL_REGISTRY,
+) -> dict[str, object]:
+    identity = resolve_model_identity_from_payload(
+        model_payload,
+        default_registry=default_registry,
+    )
+    normalized = dict(model_payload)
+    normalized.update(
+        {
+            "canonical_id": identity.canonical_id,
+            "repo_id": identity.repo_id,
+            "short_name": identity.short_name,
+            "display_name": identity.display_name,
+            "name": identity.repo_id,
+        }
+    )
+    return normalized
+
+
+def validate_model_identity_payload(model_payload: Mapping[str, object]) -> None:
+    required_fields = (
+        "canonical_id",
+        "repo_id",
+        "short_name",
+        "display_name",
+        "name",
+    )
+    missing = [field for field in required_fields if not str(model_payload.get(field) or "").strip()]
+    if missing:
+        raise ValueError(
+            "model payload missing normalized identity fields: " + ", ".join(missing)
+        )
+    if str(model_payload.get("name") or "").strip() != str(model_payload.get("repo_id") or "").strip():
+        raise ValueError("model payload must set model.name equal to model.repo_id")

--- a/src/vllm_hust_benchmark/submission_artifacts.py
+++ b/src/vllm_hust_benchmark/submission_artifacts.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft7Validator
+
+from vllm_hust_benchmark.model_registry import normalize_model_identity_payload
+from vllm_hust_benchmark.model_registry import validate_model_identity_payload
+
+SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {
+    "leaderboard-export-manifest/v1",
+    "leaderboard-export-manifest/v2",
+}
+
+
+def load_submission_manifest(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{manifest_path}: manifest payload must be a JSON object")
+
+    schema_version = str(payload.get("schema_version") or "").strip()
+    if schema_version not in SUPPORTED_MANIFEST_SCHEMA_VERSIONS:
+        raise ValueError(
+            f"{manifest_path}: unsupported schema_version {payload.get('schema_version')!r}"
+        )
+
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"{manifest_path}: entries must be a list")
+    return payload
+
+
+def iter_manifest_artifact_paths(manifest_path: Path) -> list[Path]:
+    payload = load_submission_manifest(manifest_path)
+    artifact_paths: list[Path] = []
+    for index, record in enumerate(payload["entries"]):
+        if not isinstance(record, dict):
+            raise ValueError(f"{manifest_path}: entries[{index}] must be a JSON object")
+        artifact_rel = record.get("leaderboard_artifact")
+        if not isinstance(artifact_rel, str) or not artifact_rel.strip():
+            raise ValueError(
+                f"{manifest_path}: entries[{index}].leaderboard_artifact is required"
+            )
+        artifact_path = manifest_path.parent / artifact_rel
+        if not artifact_path.is_file():
+            raise ValueError(
+                f"{manifest_path}: missing leaderboard artifact {artifact_path}"
+            )
+        artifact_paths.append(artifact_path)
+    return artifact_paths
+
+
+def iter_submission_artifact_paths(source_dir: Path) -> list[Path]:
+    artifact_paths: list[Path] = []
+    for manifest_path in sorted(source_dir.rglob("leaderboard_manifest.json")):
+        artifact_paths.extend(iter_manifest_artifact_paths(manifest_path))
+    return artifact_paths
+
+
+def ensure_submission_manifests_in_tree(source_dir: Path) -> list[Path]:
+    created: list[Path] = []
+    for artifact_path in sorted(source_dir.rglob("run_leaderboard.json")):
+        manifest_path = artifact_path.parent / "leaderboard_manifest.json"
+        if manifest_path.exists():
+            continue
+        artifact = load_submission_artifact(artifact_path)
+        metadata = artifact.get("metadata") if isinstance(artifact.get("metadata"), dict) else {}
+        entry: dict[str, str] = {
+            "leaderboard_artifact": artifact_path.name,
+        }
+        idempotency_key = str(metadata.get("idempotency_key") or "").strip()
+        if idempotency_key:
+            entry["idempotency_key"] = idempotency_key
+        manifest = {
+            "schema_version": "leaderboard-export-manifest/v2",
+            "generated_at": str(metadata.get("submitted_at") or ""),
+            "entries": [entry],
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        created.append(manifest_path)
+    return created
+
+
+def load_submission_artifact(artifact_path: Path) -> dict[str, Any]:
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{artifact_path}: leaderboard artifact must be a JSON object")
+    return payload
+
+
+def normalize_submission_artifact_contract(artifact: dict[str, Any]) -> dict[str, Any]:
+    model_payload = artifact.get("model")
+    if not isinstance(model_payload, dict):
+        raise ValueError("leaderboard artifact model payload must be an object")
+    normalized_model_payload = normalize_model_identity_payload(model_payload)
+    validate_model_identity_payload(normalized_model_payload)
+    artifact["model"] = normalized_model_payload
+    return artifact
+
+
+def normalize_submission_artifact_file(artifact_path: Path) -> bool:
+    artifact = normalize_submission_artifact_contract(load_submission_artifact(artifact_path))
+    serialized = json.dumps(artifact, ensure_ascii=False, indent=2) + "\n"
+    current = artifact_path.read_text(encoding="utf-8")
+    if current == serialized:
+        return False
+    artifact_path.write_text(serialized, encoding="utf-8")
+    return True
+
+
+def normalize_submission_artifacts_in_tree(source_dir: Path) -> list[Path]:
+    ensure_submission_manifests_in_tree(source_dir)
+    changed: list[Path] = []
+    for artifact_path in iter_submission_artifact_paths(source_dir):
+        if normalize_submission_artifact_file(artifact_path):
+            changed.append(artifact_path)
+    return changed
+
+
+def validate_submission_artifacts(
+    *,
+    source_dir: Path,
+    validator: Draft7Validator,
+) -> list[str]:
+    errors: list[str] = []
+    artifact_paths = iter_submission_artifact_paths(source_dir)
+    if not artifact_paths:
+        return errors
+
+    for artifact_path in artifact_paths:
+        artifact = load_submission_artifact(artifact_path)
+        artifact = normalize_submission_artifact_contract(artifact)
+        schema_errors = sorted(
+            validator.iter_errors(artifact), key=lambda error: list(error.path)
+        )
+        if schema_errors:
+            first = schema_errors[0]
+            errors.append(
+                f"{artifact_path}: {first.message} @ {list(first.path)}"
+            )
+    return errors
+
+
+def validate_manifest_artifacts(
+    *,
+    manifests: Iterable[Path],
+    validator: Draft7Validator,
+) -> list[str]:
+    errors: list[str] = []
+    for manifest_path in manifests:
+        try:
+            artifact_paths = iter_manifest_artifact_paths(manifest_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        for artifact_path in artifact_paths:
+            try:
+                artifact = normalize_submission_artifact_contract(
+                    load_submission_artifact(artifact_path)
+                )
+            except ValueError as exc:
+                errors.append(f"{artifact_path}: {exc}")
+                continue
+            schema_errors = sorted(
+                validator.iter_errors(artifact), key=lambda error: list(error.path)
+            )
+            if schema_errors:
+                first = schema_errors[0]
+                errors.append(
+                    f"{artifact_path}: {first.message} @ {list(first.path)}"
+                )
+    return errors

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,6 +840,11 @@ def test_export_leaderboard_artifact(tmp_path) -> None:
     assert (output_dir / "run_leaderboard.json").is_file()
     assert (output_dir / "leaderboard_manifest.json").is_file()
     artifact = json.loads((output_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
+    assert artifact["model"]["canonical_id"] == "hf:meta-llama/Llama-3.1-8B-Instruct"
+    assert artifact["model"]["repo_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert artifact["model"]["short_name"] == "Llama-3.1-8B-Instruct"
+    assert artifact["model"]["display_name"] == "Llama 3.1 8B Instruct"
+    assert artifact["model"]["name"] == "meta-llama/Llama-3.1-8B-Instruct"
     assert artifact["metadata"]["git_commit"] == "abc123def456"
     assert artifact["metadata"]["github_user"] == "octocat"
     assert artifact["metadata"]["github_commit_url"] == "https://github.com/vLLM-HUST/vllm-hust/commit/abc123def456"
@@ -986,7 +991,77 @@ def test_export_leaderboard_artifact_from_raw_benchmark_result(tmp_path) -> None
     assert (output_dir / "run_leaderboard.json").is_file()
     assert (output_dir / "leaderboard_manifest.json").is_file()
     artifact = json.loads((output_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
+    assert artifact["model"]["canonical_id"] == "hf:meta-llama/Llama-3.1-8B-Instruct"
+    assert artifact["model"]["repo_id"] == "meta-llama/Llama-3.1-8B-Instruct"
     assert artifact["metadata"]["github_user"] == "benchmark-bot"
+
+
+def test_export_leaderboard_artifact_normalizes_seeded_short_model_alias(tmp_path) -> None:
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text(
+        """
+{
+    "metrics": {
+        "ttft_ms": 42.0,
+        "throughput_tps": 321.0,
+        "peak_mem_mb": 10240,
+        "error_rate": 0.0
+    },
+    "constraints_metrics": {
+        "single_chip_effective_utilization_pct": 92.0,
+        "typical_throughput_ratio_vs_baseline": 2.2,
+        "typical_ttft_reduction_pct_vs_baseline": 23.0,
+        "typical_tpot_reduction_pct_vs_baseline": 25.0,
+        "long_context_length": 32768,
+        "long_context_throughput_stable": true,
+        "long_context_ttft_p95_ms": 80.0,
+        "long_context_ttft_p99_ms": 95.0,
+        "long_context_tpot_p95_ms": 9.0,
+        "long_context_tpot_p99_ms": 10.0,
+        "long_context_ttft_p95_stable": true,
+        "long_context_ttft_p99_stable": true,
+        "long_context_tpot_p95_stable": true,
+        "long_context_tpot_p99_stable": true,
+        "unit_token_cost_reduction_pct": 35.0,
+        "multi_tenant_high_utilization": true
+    }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "export_seeded_alias"
+    exit_code = main(
+        [
+            "export-leaderboard-artifact",
+            "random-online",
+            "--metrics-file",
+            str(metrics_file),
+            "--output-dir",
+            str(output_dir),
+            "--run-id",
+            "seeded-alias-run",
+            "--engine",
+            "vllm-hust",
+            "--engine-version",
+            "0.7.3",
+            "--model-name",
+            "Qwen2.5-14B-Instruct",
+            "--hardware-chip-model",
+            "910B3",
+            "--submitter",
+            "ci",
+        ]
+    )
+
+    assert exit_code == 0
+    artifact = json.loads((output_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
+    assert artifact["model"]["canonical_id"] == "hf:Qwen/Qwen2.5-14B-Instruct"
+    assert artifact["model"]["repo_id"] == "Qwen/Qwen2.5-14B-Instruct"
+    assert artifact["model"]["short_name"] == "Qwen2.5-14B-Instruct"
+    assert artifact["model"]["display_name"] == "Qwen 2.5 14B Instruct"
+    assert artifact["model"]["name"] == "Qwen/Qwen2.5-14B-Instruct"
 
 
 def test_export_leaderboard_artifact_embeds_same_spec_payload(tmp_path: Path) -> None:
@@ -1271,6 +1346,8 @@ def test_export_leaderboard_artifacts_sanitizes_dirty_engine_version(
     assert artifact["metadata"]["engine_version"] == "gd4a408c4"
     assert artifact["hardware"]["memory_per_chip_gb"] == 64.0
     assert artifact["hardware"]["total_memory_gb"] == 64.0
+    assert artifact["model"]["canonical_id"] == "hf:Qwen/Qwen2.5-14B-Instruct"
+    assert artifact["model"]["repo_id"] == "Qwen/Qwen2.5-14B-Instruct"
 
 
 def test_export_leaderboard_artifacts_normalizes_invalid_component_versions(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -698,6 +698,67 @@ def test_validate_aggregated_leaderboard_outputs_downgrades_legacy_baselines_not
     )
 
 
+def test_load_official_baseline_coverage_keys_requires_published_submission(
+    tmp_path: Path,
+) -> None:
+    benchmark_repo = tmp_path / "vllm-hust-benchmark"
+    official_specs_dir = benchmark_repo / "docs" / "official-baselines"
+    official_specs_dir.mkdir(parents=True)
+    submissions_root = benchmark_repo / "submissions"
+    submissions_root.mkdir(parents=True)
+
+    for scenario_name in ("random-online", "prefix-repetition-online"):
+        (official_specs_dir / f"official-{scenario_name}.json").write_text(
+            json.dumps(
+                {
+                    "scenario": scenario_name,
+                    "model": "Qwen/Qwen2.5-14B-Instruct",
+                    "hardware_chip_model": "910B3",
+                    "chip_count": 1,
+                    "node_count": 1,
+                    "export": {"baseline_engine": "vllm"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    official_submission_dir = (
+        submissions_root / "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    )
+    official_submission_dir.mkdir()
+    (official_submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "engine": "vllm",
+                "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+                "hardware": {"chip_model": "910B3"},
+                "workload": {"name": "random-online"},
+                "config_type": "single_gpu",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=benchmark_repo,
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=tmp_path / "vllm-hust-website",
+    )
+
+    coverage_keys = integration._load_official_baseline_coverage_keys(layout)
+
+    assert coverage_keys == {
+        integration._build_baseline_coverage_key(
+            engine="vllm",
+            model="Qwen/Qwen2.5-14B-Instruct",
+            hardware="910B3",
+            workload="random-online",
+            config_type="single_gpu",
+        )
+    }
+
+
 def test_split_vllm_serve_scenario_parameters_uses_cli_help(monkeypatch) -> None:
     monkeypatch.setattr(
         integration,
@@ -1227,6 +1288,24 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
                 "chip_count": 1,
                 "node_count": 1,
                 "export": {"baseline_engine": "vllm"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    official_submission_dir = (
+        benchmark_repo
+        / "submissions"
+        / "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    )
+    official_submission_dir.mkdir(parents=True)
+    (official_submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "engine": "vllm",
+                "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+                "hardware": {"chip_model": "910B3"},
+                "workload": {"name": "random-online"},
+                "config_type": "single_gpu",
             }
         ),
         encoding="utf-8",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,20 @@ from vllm_hust_benchmark.integration import (
 )
 
 
+def _minimal_manifest(artifact_name: str = "run_leaderboard.json") -> str:
+    return json.dumps(
+        {
+            "schema_version": "leaderboard-export-manifest/v2",
+            "generated_at": "2026-05-26T00:00:00Z",
+            "entries": [{"leaderboard_artifact": artifact_name}],
+        }
+    )
+
+
+def _minimal_artifact(model_name: str = "Qwen/Qwen2.5-14B-Instruct") -> str:
+    return json.dumps({"model": {"name": model_name}})
+
+
 def test_resolve_repo_layout_defaults_to_repo_sibling_workspace(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_HUST_WORKSPACE_ROOT", raising=False)
     monkeypatch.delenv("VLLM_HUST_REPO", raising=False)
@@ -777,11 +791,15 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
 
     submission_dir = tmp_path / "submission-a"
     submission_dir.mkdir()
-    (submission_dir / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
-    (submission_dir / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_dir / "run_leaderboard.json").write_text(
+        _minimal_artifact() + "\n", encoding="utf-8"
+    )
+    (submission_dir / "leaderboard_manifest.json").write_text(
+        _minimal_manifest() + "\n", encoding="utf-8"
+    )
 
     downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text("{}\n", encoding="utf-8")
+    downloaded_submission.write_text(_minimal_artifact() + "\n", encoding="utf-8")
 
     aggregate_calls: list[tuple[Path, Path]] = []
     merged_markers: dict[str, bool] = {}
@@ -892,16 +910,24 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
 
     submission_a = tmp_path / "submission-a"
     submission_a.mkdir()
-    (submission_a / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
-    (submission_a / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_a / "run_leaderboard.json").write_text(
+        _minimal_artifact() + "\n", encoding="utf-8"
+    )
+    (submission_a / "leaderboard_manifest.json").write_text(
+        _minimal_manifest() + "\n", encoding="utf-8"
+    )
 
     submission_b = tmp_path / "submission-b"
     submission_b.mkdir()
-    (submission_b / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
-    (submission_b / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_b / "run_leaderboard.json").write_text(
+        _minimal_artifact("Qwen/Qwen2.5-7B-Instruct") + "\n", encoding="utf-8"
+    )
+    (submission_b / "leaderboard_manifest.json").write_text(
+        _minimal_manifest() + "\n", encoding="utf-8"
+    )
 
     downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text("{}\n", encoding="utf-8")
+    downloaded_submission.write_text(_minimal_artifact() + "\n", encoding="utf-8")
 
     merged_markers: dict[str, bool] = {}
     uploaded_paths: list[str] = []
@@ -1016,11 +1042,15 @@ def test_sync_submission_to_huggingface_rejects_invalid_aggregated_snapshots(
 
     submission_dir = tmp_path / "submission-a"
     submission_dir.mkdir()
-    (submission_dir / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
-    (submission_dir / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_dir / "run_leaderboard.json").write_text(
+        _minimal_artifact() + "\n", encoding="utf-8"
+    )
+    (submission_dir / "leaderboard_manifest.json").write_text(
+        _minimal_manifest() + "\n", encoding="utf-8"
+    )
 
     downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text("{}\n", encoding="utf-8")
+    downloaded_submission.write_text(_minimal_artifact() + "\n", encoding="utf-8")
     uploaded_paths: list[str] = []
 
     def fake_aggregate_to_website(*, layout, source_dir, output_dir, execute):
@@ -1155,7 +1185,9 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
     (submission_dir / "run_leaderboard.json").write_text(
         json.dumps(current_payload), encoding="utf-8"
     )
-    (submission_dir / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_dir / "leaderboard_manifest.json").write_text(
+        _minimal_manifest() + "\n", encoding="utf-8"
+    )
 
     downloaded_run = tmp_path / "downloaded-existing-run.json"
     downloaded_manifest = tmp_path / "downloaded-existing-manifest.json"
@@ -1177,7 +1209,7 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
         ),
         encoding="utf-8",
     )
-    downloaded_manifest.write_text("{}\n", encoding="utf-8")
+    downloaded_manifest.write_text(_minimal_manifest() + "\n", encoding="utf-8")
 
     seen_baselines: dict[str, dict[str, str]] = {}
 
@@ -1302,6 +1334,124 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
             "baseline_status": "official-covered",
         },
     }
+
+
+def test_sync_submission_to_huggingface_existing_only_backfills_historical_artifacts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    website_repo = tmp_path / "vllm-hust-website"
+    (website_repo / "scripts").mkdir(parents=True)
+    (website_repo / "scripts" / "aggregate_results.py").write_text(
+        "print('ok')\n", encoding="utf-8"
+    )
+
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=tmp_path / "vllm-hust-benchmark",
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=website_repo,
+    )
+
+    downloaded_submission = tmp_path / "downloaded-existing.json"
+    downloaded_submission.write_text(
+        json.dumps({"model": {"name": "Qwen2.5-7B-Instruct"}}),
+        encoding="utf-8",
+    )
+
+    uploaded_paths: list[str] = []
+    seen_model: dict[str, str] = {}
+
+    def fake_aggregate_to_website(*, layout, source_dir, output_dir, execute):
+        historical = json.loads(
+            source_dir.joinpath("existing-run", "run_leaderboard.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        seen_model.update(historical["model"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for file_name in (
+            "leaderboard_single.json",
+            "leaderboard_multi.json",
+            "leaderboard_compare.json",
+            "last_updated.json",
+        ):
+            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+        return 0
+
+    class FakeCommitOperationAdd:
+        def __init__(self, *, path_in_repo, path_or_fileobj):
+            uploaded_paths.append(path_in_repo)
+            self.path_in_repo = path_in_repo
+            self.path_or_fileobj = path_or_fileobj
+
+    class FakeHfApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def list_repo_files(self, repo_id, repo_type, revision):
+            return ["submissions-auto/existing-run/run_leaderboard.json"]
+
+        def repo_info(self, repo_id, repo_type):
+            return {"repo_id": repo_id, "repo_type": repo_type}
+
+        def create_repo(self, repo_id, repo_type, private, exist_ok):
+            return None
+
+        def create_commit(
+            self,
+            repo_id,
+            repo_type,
+            operations,
+            commit_message,
+            revision=None,
+        ):
+            return {
+                "repo_id": repo_id,
+                "repo_type": repo_type,
+                "branch": revision,
+                "commit_message": commit_message,
+                "count": len(operations),
+            }
+
+    def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
+        return str(downloaded_submission)
+
+    monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
+    monkeypatch.setattr(
+        integration,
+        "validate_aggregated_leaderboard_outputs",
+        lambda _data_dir: None,
+    )
+    fake_hf_module = types.SimpleNamespace(
+        CommitOperationAdd=FakeCommitOperationAdd,
+        HfApi=FakeHfApi,
+        hf_hub_download=fake_hf_hub_download,
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "huggingface_hub":
+            return fake_hf_module
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    aggregate_output_dir = tmp_path / "aggregated"
+    exit_code = sync_submission_to_huggingface(
+        layout=layout,
+        submission_dirs=None,
+        aggregate_output_dir=aggregate_output_dir,
+        repo_id="owner/repo",
+        submissions_prefix="submissions-auto",
+        allow_existing_only=True,
+    )
+
+    assert exit_code == 0
+    assert seen_model["name"] == "Qwen/Qwen2.5-7B-Instruct"
+    assert seen_model["repo_id"] == "Qwen/Qwen2.5-7B-Instruct"
+    assert seen_model["canonical_id"] == "hf:Qwen/Qwen2.5-7B-Instruct"
+    assert "submissions-auto/existing-run/run_leaderboard.json" in uploaded_paths
+    assert "submissions-auto/existing-run/leaderboard_manifest.json" in uploaded_paths
 
 
 def test_upload_to_huggingface_rejects_invalid_aggregated_snapshots(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -626,6 +626,78 @@ def test_validate_aggregated_leaderboard_outputs_allows_pending_baseline_rows(
     validate_aggregated_leaderboard_outputs(data_dir)
 
 
+def test_validate_aggregated_leaderboard_outputs_downgrades_legacy_baselines_not_in_official_specs(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "aggregated"
+    data_dir.mkdir()
+    current_entry = {
+        "engine": "vllm-hust",
+        "config_type": "single_gpu",
+        "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+        "hardware": {"chip_model": "910B3"},
+        "workload": {"name": "prefix-repetition-online"},
+        "constraints": {
+            "accountable_scope": {
+                "representative_business_scenario": "long-context-chat",
+                "baseline_engine": "vllm",
+            }
+        },
+    }
+    unrelated_baseline_entry = {
+        **current_entry,
+        "engine": "vllm",
+        "workload": {"name": "random-online"},
+        "constraints": {"accountable_scope": {}},
+    }
+    (data_dir / "leaderboard_single.json").write_text(
+        json.dumps([current_entry, unrelated_baseline_entry]),
+        encoding="utf-8",
+    )
+    (data_dir / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+    (data_dir / "leaderboard_compare.json").write_text(
+        json.dumps(
+            {
+                "groups": [{"scope_key": "present-group"}],
+                "goal_progress": {"pairs": []},
+                "hard_constraints": {
+                    "scopes": [
+                        {
+                            "scope_key": "vllm-hust|Qwen/Qwen2.5-14B-Instruct|910B3|prefix-repetition-online|single_gpu|long-context-chat|vllm",
+                            "scope": {
+                                "model": "Qwen/Qwen2.5-14B-Instruct",
+                                "hardware": "910B3",
+                                "workload": "prefix-repetition-online",
+                                "config_type": "single_gpu",
+                                "accountable_scope": {
+                                    "baseline_engine": "vllm",
+                                },
+                            },
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing matching baseline rows"):
+        validate_aggregated_leaderboard_outputs(data_dir)
+
+    validate_aggregated_leaderboard_outputs(
+        data_dir,
+        official_coverage_keys={
+            integration._build_baseline_coverage_key(
+                engine="vllm",
+                model="Qwen/Qwen2.5-14B-Instruct",
+                hardware="910B3",
+                workload="random-online",
+                config_type="single_gpu",
+            )
+        },
+    )
+
+
 def test_split_vllm_serve_scenario_parameters_uses_cli_help(monkeypatch) -> None:
     monkeypatch.setattr(
         integration,
@@ -1309,7 +1381,7 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
     monkeypatch.setattr(
         integration,
         "validate_aggregated_leaderboard_outputs",
-        lambda _data_dir: None,
+        lambda _data_dir, **_kwargs: None,
     )
 
     aggregate_output_dir = tmp_path / "aggregated"
@@ -1420,7 +1492,7 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
     monkeypatch.setattr(
         integration,
         "validate_aggregated_leaderboard_outputs",
-        lambda _data_dir: None,
+        lambda _data_dir, **_kwargs: None,
     )
     fake_hf_module = types.SimpleNamespace(
         CommitOperationAdd=FakeCommitOperationAdd,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1454,6 +1454,65 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
     assert "submissions-auto/existing-run/leaderboard_manifest.json" in uploaded_paths
 
 
+def test_sync_submission_to_huggingface_reports_hf_listing_failure(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    website_repo = tmp_path / "vllm-hust-website"
+    (website_repo / "scripts").mkdir(parents=True)
+    (website_repo / "scripts" / "aggregate_results.py").write_text(
+        "print('ok')\n", encoding="utf-8"
+    )
+
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=tmp_path / "vllm-hust-benchmark",
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=website_repo,
+    )
+
+    class FakeCommitOperationAdd:
+        def __init__(self, *, path_in_repo, path_or_fileobj):
+            self.path_in_repo = path_in_repo
+            self.path_or_fileobj = path_or_fileobj
+
+    class FakeHfApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def list_repo_files(self, repo_id, repo_type, revision):
+            raise RuntimeError("network is unreachable")
+
+    def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
+        raise AssertionError("hf_hub_download should not be called when listing fails")
+
+    fake_hf_module = types.SimpleNamespace(
+        CommitOperationAdd=FakeCommitOperationAdd,
+        HfApi=FakeHfApi,
+        hf_hub_download=fake_hf_hub_download,
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "huggingface_hub":
+            return fake_hf_module
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    exit_code = sync_submission_to_huggingface(
+        layout=layout,
+        submission_dirs=None,
+        aggregate_output_dir=tmp_path / "aggregated",
+        repo_id="owner/repo",
+        submissions_prefix="submissions-auto",
+        allow_existing_only=True,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "failed to list dataset files from owner/repo@main: network is unreachable" in captured.err
+
+
 def test_upload_to_huggingface_rejects_invalid_aggregated_snapshots(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_hust_benchmark.model_registry import load_model_identity_registry
+from vllm_hust_benchmark.model_registry import normalize_model_identity_payload
+from vllm_hust_benchmark.model_registry import resolve_model_identity
+from vllm_hust_benchmark.model_registry import resolve_model_identity_from_payload
+from vllm_hust_benchmark.model_registry import validate_model_identity_payload
+
+
+def test_load_model_identity_registry_contains_seeded_qwen_models() -> None:
+    records = load_model_identity_registry()
+    canonical_ids = {record.canonical_id for record in records}
+
+    assert "hf:Qwen/Qwen2.5-0.5B-Instruct" in canonical_ids
+    assert "hf:Qwen/Qwen2.5-14B-Instruct" in canonical_ids
+    assert "hf:Qwen/Qwen2.5-7B-Instruct" in canonical_ids
+    assert "hf:meta-llama/Llama-3.1-8B-Instruct" in canonical_ids
+    assert "hf:deepseek-ai/DeepSeek-R1-Distill-Qwen-7B" in canonical_ids
+    assert "hf:mistralai/Mistral-7B-Instruct-v0.3" in canonical_ids
+
+
+def test_resolve_model_identity_by_short_alias() -> None:
+    identity = resolve_model_identity("Qwen2.5-14B-Instruct")
+
+    assert identity.canonical_id == "hf:Qwen/Qwen2.5-14B-Instruct"
+    assert identity.repo_id == "Qwen/Qwen2.5-14B-Instruct"
+    assert identity.short_name == "Qwen2.5-14B-Instruct"
+    assert identity.display_name == "Qwen 2.5 14B Instruct"
+
+
+def test_resolve_model_identity_by_hf_cache_path() -> None:
+    identity = resolve_model_identity(
+        "/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-14B-Instruct/snapshots/abc123"
+    )
+
+    assert identity.canonical_id == "hf:Qwen/Qwen2.5-14B-Instruct"
+    assert identity.repo_id == "Qwen/Qwen2.5-14B-Instruct"
+
+
+def test_resolve_model_identity_falls_back_for_unseeded_repo_id() -> None:
+    identity = resolve_model_identity("meta-llama/Llama-3.1-8B-Instruct")
+
+    assert identity.canonical_id == "hf:meta-llama/Llama-3.1-8B-Instruct"
+    assert identity.repo_id == "meta-llama/Llama-3.1-8B-Instruct"
+    assert identity.short_name == "Llama-3.1-8B-Instruct"
+    assert identity.display_name == "Llama 3.1 8B Instruct"
+
+
+def test_resolve_model_identity_from_payload_uses_short_alias() -> None:
+    identity = resolve_model_identity_from_payload({"name": "Qwen2.5-0.5B-Instruct"})
+
+    assert identity.canonical_id == "hf:Qwen/Qwen2.5-0.5B-Instruct"
+    assert identity.repo_id == "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+def test_normalize_model_identity_payload_sets_required_contract_fields() -> None:
+    payload = normalize_model_identity_payload(
+        {
+            "name": "Llama-3.1-8B-Instruct",
+            "parameters": "8B",
+            "precision": "BF16",
+        }
+    )
+
+    assert payload["canonical_id"] == "hf:meta-llama/Llama-3.1-8B-Instruct"
+    assert payload["repo_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert payload["short_name"] == "Llama-3.1-8B-Instruct"
+    assert payload["display_name"] == "Llama 3.1 8B Instruct"
+    assert payload["name"] == "meta-llama/Llama-3.1-8B-Instruct"
+
+
+def test_validate_model_identity_payload_rejects_name_repo_id_mismatch() -> None:
+    with pytest.raises(ValueError, match="model.name equal to model.repo_id"):
+        validate_model_identity_payload(
+            {
+                "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+                "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+                "short_name": "Qwen2.5-14B-Instruct",
+                "display_name": "Qwen 2.5 14B Instruct",
+                "name": "Qwen2.5-14B-Instruct",
+            }
+        )
+
+
+def test_resolve_model_identity_rejects_unknown_short_alias() -> None:
+    with pytest.raises(ValueError, match="unknown short model alias"):
+        resolve_model_identity("Llama-3.3-70B-Instruct")

--- a/tests/test_submission_artifacts.py
+++ b/tests/test_submission_artifacts.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+from vllm_hust_benchmark.submission_artifacts import normalize_submission_artifacts_in_tree
+from vllm_hust_benchmark.submission_artifacts import validate_manifest_artifacts
+
+
+def test_validate_manifest_artifacts_uses_manifest_referenced_artifact(tmp_path: Path) -> None:
+    submission_dir = tmp_path / "submission-a"
+    submission_dir.mkdir()
+    artifact_path = submission_dir / "custom_leaderboard.json"
+    artifact_path.write_text(
+        json.dumps({"model": {"name": "Qwen2.5-7B-Instruct"}}),
+        encoding="utf-8",
+    )
+    (submission_dir / "leaderboard_manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "leaderboard-export-manifest/v2",
+                "generated_at": "2026-05-26T00:00:00Z",
+                "entries": [{"leaderboard_artifact": "custom_leaderboard.json"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    validator = Draft7Validator(
+        {
+            "type": "object",
+            "required": ["model"],
+            "properties": {
+                "model": {
+                    "type": "object",
+                    "required": [
+                        "canonical_id",
+                        "repo_id",
+                        "short_name",
+                        "display_name",
+                        "name",
+                    ],
+                }
+            },
+        }
+    )
+
+    errors = validate_manifest_artifacts(
+        manifests=[submission_dir / "leaderboard_manifest.json"],
+        validator=validator,
+    )
+
+    assert errors == []
+
+
+def test_normalize_submission_artifacts_in_tree_backfills_legacy_manifest(
+    tmp_path: Path,
+) -> None:
+    legacy_dir = tmp_path / "existing-run"
+    legacy_dir.mkdir()
+    artifact_path = legacy_dir / "run_leaderboard.json"
+    artifact_path.write_text(
+        json.dumps({"model": {"name": "Qwen2.5-14B-Instruct"}}),
+        encoding="utf-8",
+    )
+
+    changed = normalize_submission_artifacts_in_tree(tmp_path)
+
+    manifest_path = legacy_dir / "leaderboard_manifest.json"
+    assert manifest_path.is_file()
+    assert changed == [artifact_path]
+
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["model"]["name"] == "Qwen/Qwen2.5-14B-Instruct"
+    assert payload["model"]["canonical_id"] == "hf:Qwen/Qwen2.5-14B-Instruct"


### PR DESCRIPTION
## Summary
- make the benchmark model registry the single source of truth for canonical model identity and aliases
- enforce the normalized model contract in export, manifest-driven validation, and HF sync/backfill paths
- add an existing-only backfill mode and republish the full merged raw submission tree so historical fixes persist

## Validation
- `PYTHONPATH=src pytest -q tests/test_model_registry.py`
- `PYTHONPATH=src pytest -q tests/test_model_registry.py tests/test_submission_artifacts.py tests/test_cli.py::test_export_leaderboard_artifact tests/test_cli.py::test_export_leaderboard_artifact_infers_910b3_memory tests/test_cli.py::test_export_leaderboard_artifact_from_raw_benchmark_result tests/test_cli.py::test_export_leaderboard_artifact_normalizes_seeded_short_model_alias tests/test_integration.py::test_sync_submission_to_huggingface_merges_existing_submission_and_uploads tests/test_integration.py::test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads tests/test_integration.py::test_sync_submission_to_huggingface_rejects_invalid_aggregated_snapshots tests/test_integration.py::test_sync_submission_to_huggingface_normalizes_unsupported_historical_baselines tests/test_integration.py::test_sync_submission_to_huggingface_existing_only_backfills_historical_artifacts`
- `PYTHONPATH=src pytest -q tests/test_integration.py::test_load_official_baseline_coverage_keys_requires_published_submission tests/test_integration.py::test_validate_aggregated_leaderboard_outputs_downgrades_legacy_baselines_not_in_official_specs tests/test_integration.py::test_sync_submission_to_huggingface_normalizes_unsupported_historical_baselines tests/test_integration.py::test_sync_submission_to_huggingface_existing_only_backfills_historical_artifacts`
- remote workflow `push-to-hf.yml` with `dry_run=false` and `backfill_existing_only=true` completed successfully in run `26436324514`

## Backfill Status
- the existing-only HF backfill is no longer blocked and now completes successfully on the branch head
- workflow step 7 and step 8 failures were caused by embedded Python indentation regressions in `.github/workflows/push-to-hf.yml`
- workflow step 9 failures were caused by official baseline coverage being inferred too broadly from `docs/official-baselines/*.json` alone

## Final Baseline Contract
- a scope is treated as `official-covered` only when it is declared in `docs/official-baselines/*.json` and a published official raw submission artifact already exists under `submissions/official-ascend-*/run_leaderboard.json`
- scopes that have an official spec but no published official raw artifact are downgraded to `pending-baseline` during historical backfill validation instead of hard-failing aggregated outputs
- this keeps manifest-driven snapshot validation aligned with the leaderboard artifacts that are actually published to HF