### PR TITLE
fix(leaderboard): align display_name with release names

### DIFF
--- a/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
@@ -27,7 +27,7 @@ Seed file:
 
 - `repo_id`: `Qwen/Qwen2.5-14B-Instruct`
 - `short_name`: `Qwen2.5-14B-Instruct`
-- `display_name`: `Qwen 2.5 14B Instruct`
+- `display_name`: `Qwen2.5-14B-Instruct`
 - legacy inputs to normalize:
   - `Qwen/Qwen2.5-14B-Instruct`
   - `Qwen2.5-14B-Instruct`
@@ -36,7 +36,7 @@ Seed file:
 
 - `repo_id`: `Qwen/Qwen2.5-7B-Instruct`
 - `short_name`: `Qwen2.5-7B-Instruct`
-- `display_name`: `Qwen 2.5 7B Instruct`
+- `display_name`: `Qwen2.5-7B-Instruct`
 - legacy inputs to normalize:
   - `Qwen/Qwen2.5-7B-Instruct`
   - `Qwen2.5-7B-Instruct`

--- a/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
@@ -108,7 +108,7 @@ Recommended shape:
       "registry": "hf",
       "repo_id": "Qwen/Qwen2.5-14B-Instruct",
       "short_name": "Qwen2.5-14B-Instruct",
-      "display_name": "Qwen 2.5 14B Instruct",
+      "display_name": "Qwen2.5-14B-Instruct",
       "aliases": [
         "Qwen/Qwen2.5-14B-Instruct",
         "Qwen2.5-14B-Instruct"
@@ -163,7 +163,7 @@ Recommended model payload:
     "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
     "repo_id": "Qwen/Qwen2.5-14B-Instruct",
     "short_name": "Qwen2.5-14B-Instruct",
-    "display_name": "Qwen 2.5 14B Instruct",
+    "display_name": "Qwen2.5-14B-Instruct",
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
@@ -177,7 +177,7 @@ Field semantics:
 - `model.canonical_id`: authoritative machine identifier used by aggregation, compare grouping, and filters
 - `model.repo_id`: upstream repository coordinate when the model comes from a registry such as Hugging Face
 - `model.short_name`: stable human-typed alias without namespace
-- `model.display_name`: UI label shown in dropdowns and tables
+- `model.display_name`: final UI label shown in dropdowns and tables; for the current contract it mirrors the industry-standard public model release string and must not be used as a machine identifier
 - `model.name`: compatibility field kept during migration only; it must mirror `model.repo_id`
 
 The Phase 0 decision is to use prefixed canonical ids from day one, for example `hf:Qwen/Qwen2.5-14B-Instruct`.
@@ -192,6 +192,9 @@ Required rules:
 2. The exporter or aggregator resolves the raw input into one canonical model identity record.
 3. Local cache paths must never become published canonical identifiers.
 4. Unknown aliases must fail fast or be surfaced as validation errors instead of silently creating new logical models.
+5. `display_name` is derived from `short_name`, not from `canonical_id`, and never includes the registry prefix or namespace.
+6. The default `display_name` is the industry-standard release string carried by `short_name`, for example `Qwen2.5-14B-Instruct`.
+7. Writers may curate `display_name` only through the central registry; code matches on `canonical_id`, not on `display_name`.
 
 Required resolution order:
 
@@ -212,7 +215,7 @@ Example:
     "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
     "repo_id": "Qwen/Qwen2.5-14B-Instruct",
     "short_name": "Qwen2.5-14B-Instruct",
-    "display_name": "Qwen 2.5 14B Instruct"
+    "display_name": "Qwen2.5-14B-Instruct"
   }
 }
 ```

--- a/src/vllm_hust_benchmark/data/model_identity_registry.json
+++ b/src/vllm_hust_benchmark/data/model_identity_registry.json
@@ -6,7 +6,7 @@
       "registry": "hf",
       "repo_id": "Qwen/Qwen2.5-0.5B-Instruct",
       "short_name": "Qwen2.5-0.5B-Instruct",
-      "display_name": "Qwen 2.5 0.5B Instruct",
+      "display_name": "Qwen2.5-0.5B-Instruct",
       "aliases": [
         "Qwen2.5-0.5B-Instruct"
       ]
@@ -16,7 +16,7 @@
       "registry": "hf",
       "repo_id": "Qwen/Qwen2.5-14B-Instruct",
       "short_name": "Qwen2.5-14B-Instruct",
-      "display_name": "Qwen 2.5 14B Instruct",
+      "display_name": "Qwen2.5-14B-Instruct",
       "aliases": [
         "Qwen2.5-14B-Instruct"
       ]
@@ -26,7 +26,7 @@
       "registry": "hf",
       "repo_id": "Qwen/Qwen2.5-7B-Instruct",
       "short_name": "Qwen2.5-7B-Instruct",
-      "display_name": "Qwen 2.5 7B Instruct",
+      "display_name": "Qwen2.5-7B-Instruct",
       "aliases": [
         "Qwen2.5-7B-Instruct"
       ]
@@ -36,7 +36,7 @@
       "registry": "hf",
       "repo_id": "meta-llama/Llama-3.1-8B-Instruct",
       "short_name": "Llama-3.1-8B-Instruct",
-      "display_name": "Llama 3.1 8B Instruct",
+      "display_name": "Llama-3.1-8B-Instruct",
       "aliases": [
         "Llama-3.1-8B-Instruct",
         "Meta-Llama-3.1-8B-Instruct"
@@ -47,7 +47,7 @@
       "registry": "hf",
       "repo_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
       "short_name": "DeepSeek-R1-Distill-Qwen-7B",
-      "display_name": "DeepSeek R1 Distill Qwen 7B",
+      "display_name": "DeepSeek-R1-Distill-Qwen-7B",
       "aliases": [
         "DeepSeek-R1-Distill-Qwen-7B"
       ]
@@ -57,7 +57,7 @@
       "registry": "hf",
       "repo_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "short_name": "DeepSeek-R1-Distill-Qwen-14B",
-      "display_name": "DeepSeek R1 Distill Qwen 14B",
+      "display_name": "DeepSeek-R1-Distill-Qwen-14B",
       "aliases": [
         "DeepSeek-R1-Distill-Qwen-14B"
       ]
@@ -67,7 +67,7 @@
       "registry": "hf",
       "repo_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "short_name": "Mistral-7B-Instruct-v0.3",
-      "display_name": "Mistral 7B Instruct v0.3",
+      "display_name": "Mistral-7B-Instruct-v0.3",
       "aliases": [
         "Mistral-7B-Instruct-v0.3"
       ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -843,7 +843,7 @@ def test_export_leaderboard_artifact(tmp_path) -> None:
     assert artifact["model"]["canonical_id"] == "hf:meta-llama/Llama-3.1-8B-Instruct"
     assert artifact["model"]["repo_id"] == "meta-llama/Llama-3.1-8B-Instruct"
     assert artifact["model"]["short_name"] == "Llama-3.1-8B-Instruct"
-    assert artifact["model"]["display_name"] == "Llama 3.1 8B Instruct"
+    assert artifact["model"]["display_name"] == "Llama-3.1-8B-Instruct"
     assert artifact["model"]["name"] == "meta-llama/Llama-3.1-8B-Instruct"
     assert artifact["metadata"]["git_commit"] == "abc123def456"
     assert artifact["metadata"]["github_user"] == "octocat"
@@ -1060,7 +1060,7 @@ def test_export_leaderboard_artifact_normalizes_seeded_short_model_alias(tmp_pat
     assert artifact["model"]["canonical_id"] == "hf:Qwen/Qwen2.5-14B-Instruct"
     assert artifact["model"]["repo_id"] == "Qwen/Qwen2.5-14B-Instruct"
     assert artifact["model"]["short_name"] == "Qwen2.5-14B-Instruct"
-    assert artifact["model"]["display_name"] == "Qwen 2.5 14B Instruct"
+    assert artifact["model"]["display_name"] == "Qwen2.5-14B-Instruct"
     assert artifact["model"]["name"] == "Qwen/Qwen2.5-14B-Instruct"
 
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -27,7 +27,7 @@ def test_resolve_model_identity_by_short_alias() -> None:
     assert identity.canonical_id == "hf:Qwen/Qwen2.5-14B-Instruct"
     assert identity.repo_id == "Qwen/Qwen2.5-14B-Instruct"
     assert identity.short_name == "Qwen2.5-14B-Instruct"
-    assert identity.display_name == "Qwen 2.5 14B Instruct"
+    assert identity.display_name == "Qwen2.5-14B-Instruct"
 
 
 def test_resolve_model_identity_by_hf_cache_path() -> None:
@@ -40,12 +40,12 @@ def test_resolve_model_identity_by_hf_cache_path() -> None:
 
 
 def test_resolve_model_identity_falls_back_for_unseeded_repo_id() -> None:
-    identity = resolve_model_identity("meta-llama/Llama-3.1-8B-Instruct")
+    identity = resolve_model_identity("meta-llama/Llama-3.2-3B-Instruct")
 
-    assert identity.canonical_id == "hf:meta-llama/Llama-3.1-8B-Instruct"
-    assert identity.repo_id == "meta-llama/Llama-3.1-8B-Instruct"
-    assert identity.short_name == "Llama-3.1-8B-Instruct"
-    assert identity.display_name == "Llama 3.1 8B Instruct"
+    assert identity.canonical_id == "hf:meta-llama/Llama-3.2-3B-Instruct"
+    assert identity.repo_id == "meta-llama/Llama-3.2-3B-Instruct"
+    assert identity.short_name == "Llama-3.2-3B-Instruct"
+    assert identity.display_name == "Llama-3.2-3B-Instruct"
 
 
 def test_resolve_model_identity_from_payload_uses_short_alias() -> None:
@@ -67,7 +67,7 @@ def test_normalize_model_identity_payload_sets_required_contract_fields() -> Non
     assert payload["canonical_id"] == "hf:meta-llama/Llama-3.1-8B-Instruct"
     assert payload["repo_id"] == "meta-llama/Llama-3.1-8B-Instruct"
     assert payload["short_name"] == "Llama-3.1-8B-Instruct"
-    assert payload["display_name"] == "Llama 3.1 8B Instruct"
+    assert payload["display_name"] == "Llama-3.1-8B-Instruct"
     assert payload["name"] == "meta-llama/Llama-3.1-8B-Instruct"
 
 
@@ -78,7 +78,7 @@ def test_validate_model_identity_payload_rejects_name_repo_id_mismatch() -> None
                 "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
                 "repo_id": "Qwen/Qwen2.5-14B-Instruct",
                 "short_name": "Qwen2.5-14B-Instruct",
-                "display_name": "Qwen 2.5 14B Instruct",
+                "display_name": "Qwen2.5-14B-Instruct",
                 "name": "Qwen2.5-14B-Instruct",
             }
         )


### PR DESCRIPTION
## Summary
- align leaderboard model identity docs, registry data, and tests so `display_name` uses the industry-standard short release string
- keep `canonical_id` as the machine identity and `model.name = model.repo_id` as the compatibility rule
- refresh the migration checklist examples to match the finalized short-style contract

## Why this is not duplicate work
- checked `gh pr list --repo vLLM-HUST/vllm-hust-benchmark --state open --search 'model identity display name'`
- no matching open PR was found before opening this PR

## Testing
- `PYTHONPATH=src pytest -q tests/test_model_registry.py tests/test_cli.py`

## Notes
- companion website PR updates the aggregator, frontend, and regenerated snapshots to consume the normalized model identity fields
- AI assistance was used to help prepare this change
