### PR TITLE
[BugFix] Close leaderboard model identity migration window

### DIFF
--- a/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md
@@ -1,6 +1,15 @@
 # Leaderboard Model Identity Migration Checklist
 
-This checklist tracks the first implementation wave after Phase 0 decisions were frozen in `docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md`.
+This checklist tracked the implementation wave after Phase 0 decisions were frozen in `docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md`.
+
+Current status: complete. The transition window is closed.
+
+## Close-Out Summary
+
+- benchmark exporters and validators emit and enforce normalized model identity fields
+- checked-in historical `submissions/**/run_leaderboard.json` artifacts are backfilled to the final contract
+- website schema and examples require normalized model identity fields
+- website aggregation and frontend filters consume normalized identity directly and no longer infer repo ids from short aliases
 
 ## Scope Of The Initial Seed
 
@@ -45,16 +54,14 @@ Note: the checked-in benchmark snapshots currently expose only the short-name fo
 
 ## Implementation Checklist
 
-- [ ] Add a loader helper in the benchmark package that reads `model_identity_registry.json` through `importlib.resources`
-- [ ] Extend leaderboard schema and field spec docs to permit `model.canonical_id`, `model.repo_id`, `model.short_name`, and `model.display_name`
-- [ ] Update `export-leaderboard-artifact` so new writes emit the normalized field set
-- [ ] Freeze `model.name` writes to `model.repo_id` for all new exporters
-- [ ] Update aggregation logic to resolve legacy `model.name` values through the registry before grouping or deduplicating
-- [ ] Keep fallback reads from legacy snapshots during the transition window
-- [ ] Backfill `leaderboard_single.json`, `leaderboard_multi.json`, and `leaderboard_compare.json` from the normalized pipeline
-- [ ] Update website filters and table rendering to use `canonical_id` as value and `display_name` as label
-- [ ] Add tests that prove `Qwen/Qwen2.5-14B-Instruct` and `Qwen2.5-14B-Instruct` collapse to one canonical model
-- [ ] Add tests that reject unknown or ambiguous short aliases at publish time
+- [x] Add a loader helper in the benchmark package that reads `model_identity_registry.json` through `importlib.resources`
+- [x] Extend leaderboard schema and field spec docs to require `model.canonical_id`, `model.repo_id`, `model.short_name`, and `model.display_name`
+- [x] Update `export-leaderboard-artifact` so new writes emit the normalized field set
+- [x] Freeze `model.name` writes to `model.repo_id` for all new exporters
+- [x] Backfill checked-in historical submissions and website snapshots from the normalized pipeline
+- [x] Update website filters and table rendering to use `canonical_id` as value and `display_name` as label
+- [x] Add tests that prove mixed raw inputs collapse to one canonical model during normalization and that legacy short-alias-only writes are rejected at publish/import time
+- [x] Remove website import-boundary heuristic fallback after historical submissions were normalized
 
 ## Touchpoints
 
@@ -72,7 +79,7 @@ Expected first implementation files:
 
 The initial seed is complete when:
 
-- new exports always write normalized model identity fields
-- legacy 14B short-name and repo-id rows collapse into one logical model in filters and compare scopes
-- 7B rows also publish the same normalized identity structure
-- no new checked-in snapshot introduces a bare short alias as the only machine-readable model identifier
+- [x] new exports always write normalized model identity fields
+- [x] legacy short-name and repo-id rows collapse into one logical model in filters and compare scopes
+- [x] checked-in 7B rows publish the same normalized identity structure
+- [x] no checked-in snapshot introduces a bare short alias as the only machine-readable model identifier

--- a/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
+++ b/docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md
@@ -1,8 +1,16 @@
 # Leaderboard Model Identity Normalization RFC
 
-Status: Phase 0 decisions frozen. Implementation pending.
+Status: Implemented and enforced on checked-in benchmark submissions and website snapshots.
 
-This document records the approved Phase 0 decisions for model identity normalization in the vllm-hust leaderboard pipeline. It is the implementation target for the next migration steps, although the live data contract is not fully enforced yet.
+This document records the approved Phase 0 decisions for model identity normalization in the vllm-hust leaderboard pipeline.
+
+Current status:
+
+- checked-in benchmark submissions are backfilled to the normalized identity contract
+- website aggregation no longer uses heuristic fallback to infer repo ids from short names or cache paths
+- website schema/examples require `model.canonical_id`, `model.repo_id`, `model.short_name`, and `model.display_name`
+
+The problem statement below describes the pre-migration state that motivated this RFC.
 
 See also:
 
@@ -189,19 +197,19 @@ Normalization should happen at the benchmark export or aggregation boundary, not
 Required rules:
 
 1. Raw input may arrive as a repo coordinate, a short alias, or a local snapshot path.
-2. The exporter or aggregator resolves the raw input into one canonical model identity record.
-3. Local cache paths must never become published canonical identifiers.
-4. Unknown aliases must fail fast or be surfaced as validation errors instead of silently creating new logical models.
-5. `display_name` is derived from `short_name`, not from `canonical_id`, and never includes the registry prefix or namespace.
-6. The default `display_name` is the industry-standard release string carried by `short_name`, for example `Qwen2.5-14B-Instruct`.
-7. Writers may curate `display_name` only through the central registry; code matches on `canonical_id`, not on `display_name`.
+1. The exporter or aggregator resolves the raw input into one canonical model identity record.
+1. Local cache paths must never become published canonical identifiers.
+1. Unknown aliases must fail fast or be surfaced as validation errors instead of silently creating new logical models.
+1. `display_name` is derived from `short_name`, not from `canonical_id`, and never includes the registry prefix or namespace.
+1. The default `display_name` is the industry-standard release string carried by `short_name`, for example `Qwen2.5-14B-Instruct`.
+1. Writers may curate `display_name` only through the central registry; code matches on `canonical_id`, not on `display_name`.
 
 Required resolution order:
 
 1. explicit model registry metadata from the submission
-2. exact alias-map match
-3. exact repo-id match
-4. explicit rejection with remediation guidance
+1. exact alias-map match
+1. exact repo-id match
+1. explicit rejection with remediation guidance
 
 ## Alias Registry
 

--- a/src/vllm_hust_benchmark/model_registry.py
+++ b/src/vllm_hust_benchmark/model_registry.py
@@ -8,7 +8,9 @@ from functools import lru_cache
 from importlib import resources
 
 DEFAULT_MODEL_REGISTRY = "hf"
-CANONICAL_ID_PATTERN = re.compile(r"^(?P<registry>[a-z0-9][a-z0-9_-]*):(?P<repo_id>.+)$")
+CANONICAL_ID_PATTERN = re.compile(
+    r"^(?P<registry>[a-z0-9][a-z0-9_-]*):(?P<repo_id>.+)$"
+)
 HF_CACHE_PATH_PATTERN = re.compile(
     r"(?:^|/)models--(?P<namespace>[^/]+)--(?P<name>[^/]+)/(?:snapshots|refs)/",
     re.IGNORECASE,
@@ -62,9 +64,11 @@ def _build_fallback_identity(repo_id: str, *, registry: str) -> ModelIdentity:
 
 @lru_cache(maxsize=1)
 def load_model_identity_registry() -> tuple[ModelIdentity, ...]:
-    with resources.files("vllm_hust_benchmark.data").joinpath(
-        "model_identity_registry.json"
-    ).open("r", encoding="utf-8") as handle:
+    with (
+        resources.files("vllm_hust_benchmark.data")
+        .joinpath("model_identity_registry.json")
+        .open("r", encoding="utf-8") as handle
+    ):
         payload = json.load(handle)
 
     models = payload.get("models")
@@ -127,7 +131,11 @@ def resolve_model_identity(
     if canonical is not None:
         registry, repo_id = canonical
         seeded = lookup.get(repo_id)
-        return seeded if seeded is not None else _build_fallback_identity(repo_id, registry=registry)
+        return (
+            seeded
+            if seeded is not None
+            else _build_fallback_identity(repo_id, registry=registry)
+        )
 
     repo_id_from_path = _extract_hf_repo_id_from_path(normalized)
     if repo_id_from_path is not None:
@@ -135,7 +143,9 @@ def resolve_model_identity(
         return (
             seeded
             if seeded is not None
-            else _build_fallback_identity(repo_id_from_path, registry=DEFAULT_MODEL_REGISTRY)
+            else _build_fallback_identity(
+                repo_id_from_path, registry=DEFAULT_MODEL_REGISTRY
+            )
         )
 
     if _looks_like_repo_id(normalized):
@@ -161,7 +171,9 @@ def resolve_model_identity_from_payload(
         if not candidate:
             continue
         return resolve_model_identity(candidate, default_registry=default_registry)
-    raise ValueError("model payload must contain canonical_id, repo_id, name, or short_name")
+    raise ValueError(
+        "model payload must contain canonical_id, repo_id, name, or short_name"
+    )
 
 
 def normalize_model_identity_payload(
@@ -194,10 +206,21 @@ def validate_model_identity_payload(model_payload: Mapping[str, object]) -> None
         "display_name",
         "name",
     )
-    missing = [field for field in required_fields if not str(model_payload.get(field) or "").strip()]
+    missing = [
+        field
+        for field in required_fields
+        if not str(model_payload.get(field) or "").strip()
+    ]
     if missing:
         raise ValueError(
             "model payload missing normalized identity fields: " + ", ".join(missing)
         )
-    if str(model_payload.get("name") or "").strip() != str(model_payload.get("repo_id") or "").strip():
+    canonical_id = str(model_payload.get("canonical_id") or "").strip()
+    repo_id = str(model_payload.get("repo_id") or "").strip()
+    parsed_canonical = _parse_canonical_id(canonical_id)
+    if parsed_canonical is None:
+        raise ValueError("model payload canonical_id must match <registry>:<repo_id>")
+    if parsed_canonical[1] != repo_id:
+        raise ValueError("model payload canonical_id must embed model.repo_id")
+    if str(model_payload.get("name") or "").strip() != repo_id:
         raise ValueError("model payload must set model.name equal to model.repo_id")

--- a/submissions/ci-25711003140-2-df3c5f40/run_leaderboard.json
+++ b/submissions/ci-25711003140-2-df3c5f40/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25723435363-1-17cf013f/run_leaderboard.json
+++ b/submissions/ci-25723435363-1-17cf013f/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25724602219-1-1162a690/run_leaderboard.json
+++ b/submissions/ci-25724602219-1-1162a690/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25728380978-1-bc9634de/run_leaderboard.json
+++ b/submissions/ci-25728380978-1-bc9634de/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25729041371-1-526e0578/run_leaderboard.json
+++ b/submissions/ci-25729041371-1-526e0578/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25729496104-1-b7728605/run_leaderboard.json
+++ b/submissions/ci-25729496104-1-b7728605/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25736867515-1-51a516f5/run_leaderboard.json
+++ b/submissions/ci-25736867515-1-51a516f5/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-25773082322-1-ea6fbe4d/run_leaderboard.json
+++ b/submissions/ci-25773082322-1-ea6fbe4d/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26320149267-1-3a5c529a8373487c6c00e143b9f3ec038d24c9f7/run_leaderboard.json
+++ b/submissions/ci-26320149267-1-3a5c529a8373487c6c00e143b9f3ec038d24c9f7/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26321661397-1-6974720a65704a54b6e47a7fce0558d669fde023/run_leaderboard.json
+++ b/submissions/ci-26321661397-1-6974720a65704a54b6e47a7fce0558d669fde023/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26321961788-1-a60057da7de705a486ecad0ffcbe78cac141c2ef/run_leaderboard.json
+++ b/submissions/ci-26321961788-1-a60057da7de705a486ecad0ffcbe78cac141c2ef/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26330048879-1-a8ddfb0acf1b84ee3b8d9ad87073cf52df2d9497/run_leaderboard.json
+++ b/submissions/ci-26330048879-1-a8ddfb0acf1b84ee3b8d9ad87073cf52df2d9497/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26382211426-5-234611d110d0130251094dd73ecbf63589b8e760/run_leaderboard.json
+++ b/submissions/ci-26382211426-5-234611d110d0130251094dd73ecbf63589b8e760/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26400201772-1-04b63e26d43b3057ecfde71f083fa4974a15b8ab/run_leaderboard.json
+++ b/submissions/ci-26400201772-1-04b63e26d43b3057ecfde71f083fa4974a15b8ab/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26400678313-1-ec6b812514545d9a92d6ecea91131c11b7f56347/run_leaderboard.json
+++ b/submissions/ci-26400678313-1-ec6b812514545d9a92d6ecea91131c11b7f56347/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26401192501-1-80cfccad4daf5f011a18f6667c5f5cacde58352c/run_leaderboard.json
+++ b/submissions/ci-26401192501-1-80cfccad4daf5f011a18f6667c5f5cacde58352c/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26429831074-1-2c00de49a7d409053773781ba9e10cc4a817a42b/run_leaderboard.json
+++ b/submissions/ci-26429831074-1-2c00de49a7d409053773781ba9e10cc4a817a42b/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26430072719-1-d6fe8f2f2cc3b3407f250bebed0c665c8aead440/run_leaderboard.json
+++ b/submissions/ci-26430072719-1-d6fe8f2f2cc3b3407f250bebed0c665c8aead440/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/ci-26434223887-1-4ca39960f5058498cb8097aa65074d572487cc3b/run_leaderboard.json
+++ b/submissions/ci-26434223887-1-4ca39960f5058498cb8097aa65074d572487cc3b/run_leaderboard.json
@@ -15,7 +15,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3/run_leaderboard.json
+++ b/submissions/official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3/run_leaderboard.json
@@ -13,7 +13,11 @@
     "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/qwen25-14b-910b3-prefix-repetition-online-1npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-prefix-repetition-online-1npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "prefix-repetition-online",

--- a/submissions/qwen25-14b-910b3-random-latency-1npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-random-latency-1npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-latency",

--- a/submissions/qwen25-14b-910b3-random-online-1npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-random-online-1npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "random-online",

--- a/submissions/qwen25-14b-910b3-sonnet-throughput-1npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-sonnet-throughput-1npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "sonnet-throughput",

--- a/submissions/qwen25-14b-910b3-sonnet-throughput-2npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-sonnet-throughput-2npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "sonnet-throughput",

--- a/submissions/qwen25-14b-910b3-sonnet-throughput-4npu-20260506/run_leaderboard.json
+++ b/submissions/qwen25-14b-910b3-sonnet-throughput-4npu-20260506/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-14B-Instruct",
+    "name": "Qwen/Qwen2.5-14B-Instruct",
     "parameters": "14B",
     "precision": "FP16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-14B-Instruct",
+    "short_name": "Qwen2.5-14B-Instruct",
+    "display_name": "Qwen2.5-14B-Instruct"
   },
   "workload": {
     "name": "sonnet-throughput",

--- a/submissions/qwen25-7b-910b2-20260417/run_leaderboard.json
+++ b/submissions/qwen25-7b-910b2-20260417/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-7B-Instruct",
+    "name": "Qwen/Qwen2.5-7B-Instruct",
     "parameters": "7B",
     "precision": "BF16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-7B-Instruct",
+    "short_name": "Qwen2.5-7B-Instruct",
+    "display_name": "Qwen2.5-7B-Instruct"
   },
   "workload": {
     "name": "sharegpt-online",

--- a/submissions/qwen25-7b-910b2-4chip-20260417/run_leaderboard.json
+++ b/submissions/qwen25-7b-910b2-4chip-20260417/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-7B-Instruct",
+    "name": "Qwen/Qwen2.5-7B-Instruct",
     "parameters": "7B",
     "precision": "BF16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-7B-Instruct",
+    "short_name": "Qwen2.5-7B-Instruct",
+    "display_name": "Qwen2.5-7B-Instruct"
   },
   "workload": {
     "name": "sharegpt-online",

--- a/submissions/qwen25-7b-vllm-ascend-910b2-20260417/run_leaderboard.json
+++ b/submissions/qwen25-7b-vllm-ascend-910b2-20260417/run_leaderboard.json
@@ -10,10 +10,14 @@
     "interconnect": "unknown"
   },
   "model": {
-    "name": "Qwen2.5-7B-Instruct",
+    "name": "Qwen/Qwen2.5-7B-Instruct",
     "parameters": "7B",
     "precision": "BF16",
-    "quantization": null
+    "quantization": null,
+    "canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct",
+    "repo_id": "Qwen/Qwen2.5-7B-Instruct",
+    "short_name": "Qwen2.5-7B-Instruct",
+    "display_name": "Qwen2.5-7B-Instruct"
   },
   "workload": {
     "name": "sharegpt-online",

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -84,6 +84,19 @@ def test_validate_model_identity_payload_rejects_name_repo_id_mismatch() -> None
         )
 
 
+def test_validate_model_identity_payload_rejects_canonical_repo_id_mismatch() -> None:
+    with pytest.raises(ValueError, match="canonical_id must embed model.repo_id"):
+        validate_model_identity_payload(
+            {
+                "canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct",
+                "repo_id": "Qwen/Qwen2.5-7B-Instruct",
+                "short_name": "Qwen2.5-14B-Instruct",
+                "display_name": "Qwen2.5-14B-Instruct",
+                "name": "Qwen/Qwen2.5-7B-Instruct",
+            }
+        )
+
+
 def test_resolve_model_identity_rejects_unknown_short_alias() -> None:
     with pytest.raises(ValueError, match="unknown short model alias"):
         resolve_model_identity("Llama-3.3-70B-Instruct")

--- a/tests/test_submission_artifacts.py
+++ b/tests/test_submission_artifacts.py
@@ -1,13 +1,23 @@
 import json
+from copy import deepcopy
 from pathlib import Path
 
 from jsonschema import Draft7Validator
 
-from vllm_hust_benchmark.submission_artifacts import normalize_submission_artifacts_in_tree
+from vllm_hust_benchmark.submission_artifacts import iter_submission_artifact_paths
+from vllm_hust_benchmark.submission_artifacts import load_submission_artifact
+from vllm_hust_benchmark.submission_artifacts import (
+    normalize_submission_artifacts_in_tree,
+)
+from vllm_hust_benchmark.submission_artifacts import (
+    normalize_submission_artifact_contract,
+)
 from vllm_hust_benchmark.submission_artifacts import validate_manifest_artifacts
 
 
-def test_validate_manifest_artifacts_uses_manifest_referenced_artifact(tmp_path: Path) -> None:
+def test_validate_manifest_artifacts_uses_manifest_referenced_artifact(
+    tmp_path: Path,
+) -> None:
     submission_dir = tmp_path / "submission-a"
     submission_dir.mkdir()
     artifact_path = submission_dir / "custom_leaderboard.json"
@@ -73,3 +83,16 @@ def test_normalize_submission_artifacts_in_tree_backfills_legacy_manifest(
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert payload["model"]["name"] == "Qwen/Qwen2.5-14B-Instruct"
     assert payload["model"]["canonical_id"] == "hf:Qwen/Qwen2.5-14B-Instruct"
+
+
+def test_checked_in_submissions_are_already_normalized() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    artifact_paths = iter_submission_artifact_paths(repo_root / "submissions")
+
+    assert artifact_paths
+
+    for artifact_path in artifact_paths:
+        payload = load_submission_artifact(artifact_path)
+        normalized = normalize_submission_artifact_contract(deepcopy(payload))
+
+        assert payload == normalized, artifact_path


### PR DESCRIPTION
## What this PR does / why we need it?

This PR closes the remaining benchmark-side model identity migration debt.

## Dependency / review order

- Paired downstream website PR: `vLLM-HUST/vllm-hust-website#60`
- Recommended order: review and merge this benchmark PR first, then merge the website heuristic-removal PR.

It:
- backfills every checked-in `submissions/**/run_leaderboard.json` artifact to the normalized model identity contract
- tightens benchmark validation so `model.canonical_id`, `model.repo_id`, and `model.name` must remain consistent
- adds regression coverage that fails if a checked-in historical submission falls back to legacy short-name-only shape again
- updates the migration docs to reflect that the transition window is now closed

## Does this PR introduce any user-facing change?

Yes.

Historical benchmark submissions now consistently publish:
- `model.canonical_id`
- `model.repo_id`
- `model.short_name`
- `model.display_name`
- `model.name == model.repo_id`

That removes the need for downstream consumers to infer repo ids from legacy payloads.

## How was this patch tested?

- `PYTHONPATH=src python3 -m pytest tests/test_model_registry.py tests/test_submission_artifacts.py -q`
- `ruff check src/vllm_hust_benchmark/model_registry.py tests/test_model_registry.py tests/test_submission_artifacts.py`
- `ruff format --check src/vllm_hust_benchmark/model_registry.py tests/test_model_registry.py tests/test_submission_artifacts.py`
- `mdformat --check docs/LEADERBOARD_MODEL_IDENTITY_MIGRATION_CHECKLIST.md docs/LEADERBOARD_MODEL_IDENTITY_NORMALIZATION.md`
