### PR TITLE
[codex] Add msprof profiling wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.cache/
 dist/
 build/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -386,6 +386,40 @@ Workflow artifacts:
 
 The workflow does not auto-commit promoted canonical submissions back to the repository. Review the uploaded artifacts or the self-hosted runner workspace first, then decide whether to commit the promoted `submissions/<spec-id>/` directories.
 
+## Ascend msprof Profiling
+
+For a same-spec run that needs Ascend `msprof` collection, use the profiling wrapper:
+
+```bash
+bash scripts/run-current-ascend-same-spec-msprof.sh \
+	docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+```
+
+It keeps the existing current same-spec runner as the workload and writes this layout:
+
+```text
+.benchmarks/current-ascend-msprof/<run-id>/
+  msprof_raw/
+  benchmark/
+  msprof.log
+  run_meta.env
+```
+
+Default `msprof` settings live in `scripts/run-current-ascend-same-spec-msprof.env`.
+
+Useful overrides:
+
+- `CONFIG_FILE`: load another shell config file instead of `scripts/run-current-ascend-same-spec-msprof.env`.
+- `PROFILE_RUN_ID` or `PROFILE_RUN_DIR`: choose the output location.
+- `MSPROF_FLAGS`: replace the default `--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text`.
+
+The raw profile directory can be analyzed later by a separate analyzer. For example, with TraceLoom:
+
+```bash
+traceloom analysis .benchmarks/current-ascend-msprof/<run-id>/msprof_raw \
+	--out-dir .benchmarks/current-ascend-msprof/<run-id>/analysis
+```
+
 ## Batch Same-Spec Matrices
 
 When you want to benchmark one machine group under multiple runtime settings and keep every setting visible on the website leaderboard, use the matrix wrapper instead of invoking the single-spec runner repeatedly by hand.
@@ -393,6 +427,8 @@ When you want to benchmark one machine group under multiple runtime settings and
 Files:
 
 - `scripts/run-current-ascend-same-spec.sh`: execute one resolved same-spec benchmark and export one submission
+- `scripts/run-current-ascend-same-spec-msprof.sh`: wrap one same-spec benchmark with `msprof`
+- `scripts/run-current-ascend-same-spec-msprof.env`: default `msprof` wrapper configuration
 - `scripts/run-current-ascend-same-spec-matrix.sh`: iterate a directory or list of spec files, assign one result directory per spec, and optionally regenerate website data after the whole batch
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -388,11 +388,11 @@ The workflow does not auto-commit promoted canonical submissions back to the rep
 
 ## Ascend msprof Profiling
 
-For a same-spec run that needs Ascend `msprof` collection, use the profiling wrapper:
+For a same-spec run that needs Ascend `msprof` collection, use the profiling wrapper. With no argument, it uses the current default Ascend same-spec baseline, so confirm the target model and hardware before starting a long profiling run:
 
 ```bash
 bash scripts/run-current-ascend-same-spec-msprof.sh \
-	docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
+  docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json
 ```
 
 It keeps the existing current same-spec runner as the workload and writes this layout:
@@ -410,14 +410,17 @@ Default `msprof` settings live in `scripts/run-current-ascend-same-spec-msprof.e
 Useful overrides:
 
 - `CONFIG_FILE`: load another shell config file instead of `scripts/run-current-ascend-same-spec-msprof.env`.
+- `MSPROF_EXECUTABLE`: use a specific `msprof` binary path.
 - `PROFILE_RUN_ID` or `PROFILE_RUN_DIR`: choose the output location.
-- `MSPROF_FLAGS`: replace the default `--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text`.
+- `PROFILE_RUN_OVERWRITE=1`: allow reusing an existing output location.
+- `MSPROF_FLAGS`: replace the default `--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text`. This is split on whitespace.
+- `MSPROF_ARGS`: in a sourced config file, define a bash array for arguments that need quoting, for example `MSPROF_ARGS=(--foo "a b")`.
 
 The raw profile directory can be analyzed later by a separate analyzer. For example, with TraceLoom:
 
 ```bash
 traceloom analysis .benchmarks/current-ascend-msprof/<run-id>/msprof_raw \
-	--out-dir .benchmarks/current-ascend-msprof/<run-id>/analysis
+  --out-dir .benchmarks/current-ascend-msprof/<run-id>/analysis
 ```
 
 ## Batch Same-Spec Matrices

--- a/scripts/run-current-ascend-same-spec-msprof.env
+++ b/scripts/run-current-ascend-same-spec-msprof.env
@@ -5,6 +5,10 @@
 #
 #   MSPROF_FLAGS="--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text" \
 #     bash scripts/run-current-ascend-same-spec-msprof.sh <spec.json>
+#
+# If an msprof argument value contains spaces, prefer a config file with:
+#
+#   MSPROF_ARGS=(--foo "a b")
 
 : "${MSPROF_EXECUTABLE:=msprof}"
 : "${MSPROF_FLAGS:=--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text}"
@@ -12,6 +16,7 @@
 : "${PROFILE_RUN_ROOT:=${REPO_ROOT:-.}/.benchmarks/current-ascend-msprof}"
 : "${PROFILE_RUN_ID:=}"
 : "${PROFILE_RUN_DIR:=}"
+: "${PROFILE_RUN_OVERWRITE:=0}"
 
 : "${MSPROF_RAW_DIR:=}"
 : "${BENCHMARK_RESULT_DIR:=}"

--- a/scripts/run-current-ascend-same-spec-msprof.env
+++ b/scripts/run-current-ascend-same-spec-msprof.env
@@ -1,0 +1,22 @@
+# Default configuration for scripts/run-current-ascend-same-spec-msprof.sh.
+#
+# This file is sourced by the wrapper. Keep assignments in shell-default form so
+# callers can override them with environment variables, for example:
+#
+#   MSPROF_FLAGS="--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text" \
+#     bash scripts/run-current-ascend-same-spec-msprof.sh <spec.json>
+
+: "${MSPROF_EXECUTABLE:=msprof}"
+: "${MSPROF_FLAGS:=--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text}"
+
+: "${PROFILE_RUN_ROOT:=${REPO_ROOT:-.}/.benchmarks/current-ascend-msprof}"
+: "${PROFILE_RUN_ID:=}"
+: "${PROFILE_RUN_DIR:=}"
+
+: "${MSPROF_RAW_DIR:=}"
+: "${BENCHMARK_RESULT_DIR:=}"
+: "${MSPROF_LOG_FILE:=}"
+: "${WORKLOAD_WRAPPER:=}"
+: "${RUN_META_FILE:=}"
+
+: "${DRY_RUN:=0}"

--- a/scripts/run-current-ascend-same-spec-msprof.sh
+++ b/scripts/run-current-ascend-same-spec-msprof.sh
@@ -20,7 +20,7 @@ MSPROF_EXECUTABLE=${MSPROF_EXECUTABLE:-msprof}
 MSPROF_FLAGS=${MSPROF_FLAGS:-"--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text"}
 DRY_RUN=${DRY_RUN:-0}
 
-PROFILE_RUN_ID=${PROFILE_RUN_ID:-${RUN_ID:-"current-ascend-msprof-$(date -u +%Y%m%dT%H%M%SZ)"}}
+PROFILE_RUN_ID=${PROFILE_RUN_ID:-${RUN_ID:-"current-ascend-msprof-$(date -u +%Y%m%dT%H%M%SZ)-$$"}}
 PROFILE_RUN_ROOT=${PROFILE_RUN_ROOT:-"$REPO_ROOT/.benchmarks/current-ascend-msprof"}
 PROFILE_RUN_DIR=${PROFILE_RUN_DIR:-"$PROFILE_RUN_ROOT/$PROFILE_RUN_ID"}
 MSPROF_RAW_DIR=${MSPROF_RAW_DIR:-"$PROFILE_RUN_DIR/msprof_raw"}
@@ -28,6 +28,7 @@ BENCHMARK_RESULT_DIR=${BENCHMARK_RESULT_DIR:-"$PROFILE_RUN_DIR/benchmark"}
 MSPROF_LOG_FILE=${MSPROF_LOG_FILE:-"$PROFILE_RUN_DIR/msprof.log"}
 WORKLOAD_WRAPPER=${WORKLOAD_WRAPPER:-"$PROFILE_RUN_DIR/run_benchmark_under_msprof.sh"}
 RUN_META_FILE=${RUN_META_FILE:-"$PROFILE_RUN_DIR/run_meta.env"}
+PROFILE_RUN_OVERWRITE=${PROFILE_RUN_OVERWRITE:-0}
 
 bool_true() {
   case "${1,,}" in
@@ -43,13 +44,19 @@ write_shell_var() {
   printf '%q\n' "$value"
 }
 
+join_shell_words() {
+  local value
+  printf -v value '%q ' "$@"
+  printf '%s\n' "${value% }"
+}
+
 if [[ ! -f "$SPEC_FILE" ]]; then
   echo "Spec file not found: $SPEC_FILE" >&2
   exit 2
 fi
 
-if [[ ! -x "$RUNNER_SCRIPT" ]]; then
-  echo "Runner script is not executable: $RUNNER_SCRIPT" >&2
+if [[ ! -f "$RUNNER_SCRIPT" ]]; then
+  echo "Runner script not found: $RUNNER_SCRIPT" >&2
   exit 2
 fi
 
@@ -58,16 +65,42 @@ if ! bool_true "$DRY_RUN" && ! command -v "$MSPROF_EXECUTABLE" >/dev/null 2>&1; 
   exit 2
 fi
 
-mkdir -p "$PROFILE_RUN_DIR" "$MSPROF_RAW_DIR" "$BENCHMARK_RESULT_DIR"
+if [[ -e "$PROFILE_RUN_DIR" ]] && ! bool_true "$PROFILE_RUN_OVERWRITE"; then
+  echo "Profile run directory already exists: $PROFILE_RUN_DIR" >&2
+  echo "Choose a different PROFILE_RUN_ID/PROFILE_RUN_DIR or set PROFILE_RUN_OVERWRITE=1." >&2
+  exit 2
+fi
+
+if bool_true "$PROFILE_RUN_OVERWRITE"; then
+  mkdir -p "$PROFILE_RUN_DIR"
+else
+  mkdir -p "$(dirname "$PROFILE_RUN_DIR")"
+  mkdir "$PROFILE_RUN_DIR"
+fi
+mkdir -p "$MSPROF_RAW_DIR" "$BENCHMARK_RESULT_DIR"
 
 cat > "$WORKLOAD_WRAPPER" <<EOF
 #!/bin/bash
 set -euo pipefail
 export RUN_ID=$(printf '%q' "$PROFILE_RUN_ID")
 export RESULT_DIR=\${RESULT_DIR:-$(printf '%q' "$BENCHMARK_RESULT_DIR")}
-exec $(printf '%q' "$RUNNER_SCRIPT") $(printf '%q' "$SPEC_FILE")
+exec bash $(printf '%q' "$RUNNER_SCRIPT") $(printf '%q' "$SPEC_FILE")
 EOF
 chmod +x "$WORKLOAD_WRAPPER"
+
+msprof_args=()
+msprof_args_source=MSPROF_FLAGS
+if declare -p MSPROF_ARGS >/dev/null 2>&1; then
+  msprof_args_decl=$(declare -p MSPROF_ARGS)
+  if [[ "$msprof_args_decl" != declare\ -*a*\ MSPROF_ARGS=* ]]; then
+    echo "MSPROF_ARGS must be a bash array when set." >&2
+    exit 2
+  fi
+  msprof_args=("${MSPROF_ARGS[@]}")
+  msprof_args_source=MSPROF_ARGS
+else
+  read -r -a msprof_args <<< "$MSPROF_FLAGS"
+fi
 
 {
   write_shell_var profile_run_id "$PROFILE_RUN_ID"
@@ -78,13 +111,14 @@ chmod +x "$WORKLOAD_WRAPPER"
   write_shell_var benchmark_result_dir "$BENCHMARK_RESULT_DIR"
   write_shell_var msprof_executable "$MSPROF_EXECUTABLE"
   write_shell_var msprof_flags "$MSPROF_FLAGS"
+  write_shell_var msprof_args_source "$msprof_args_source"
+  write_shell_var msprof_args "$(join_shell_words "${msprof_args[@]}")"
   write_shell_var msprof_raw_dir "$MSPROF_RAW_DIR"
   write_shell_var msprof_log_file "$MSPROF_LOG_FILE"
   write_shell_var workload_wrapper "$WORKLOAD_WRAPPER"
   write_shell_var created_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$RUN_META_FILE"
 
-read -r -a msprof_args <<< "$MSPROF_FLAGS"
 msprof_command=(
   "$MSPROF_EXECUTABLE"
   "--output=$MSPROF_RAW_DIR"
@@ -95,7 +129,7 @@ msprof_command=(
 echo "profile_run_dir: $PROFILE_RUN_DIR"
 echo "msprof_raw_dir: $MSPROF_RAW_DIR"
 echo "benchmark_result_dir: $BENCHMARK_RESULT_DIR"
-echo "+ ${msprof_command[*]} > $MSPROF_LOG_FILE 2>&1"
+echo "+ $(join_shell_words "${msprof_command[@]}") > $(printf '%q' "$MSPROF_LOG_FILE") 2>&1"
 
 if ! bool_true "$DRY_RUN"; then
   if "${msprof_command[@]}" >"$MSPROF_LOG_FILE" 2>&1; then

--- a/scripts/run-current-ascend-same-spec-msprof.sh
+++ b/scripts/run-current-ascend-same-spec-msprof.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0110-random-online-qwen25-14b-910b3.json"}
+CONFIG_FILE=${CONFIG_FILE:-"$SCRIPT_DIR/run-current-ascend-same-spec-msprof.env"}
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  # The default config uses shell defaults, so exported environment variables
+  # can still override it without editing the file.
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+SPEC_FILE=$(realpath -m "$SPEC_FILE")
+
+RUNNER_SCRIPT=${RUNNER_SCRIPT:-"$SCRIPT_DIR/run-current-ascend-same-spec.sh"}
+MSPROF_EXECUTABLE=${MSPROF_EXECUTABLE:-msprof}
+MSPROF_FLAGS=${MSPROF_FLAGS:-"--ascendcl=on --runtime-api=on --task-time=l1 --hccl=on --type=text"}
+DRY_RUN=${DRY_RUN:-0}
+
+PROFILE_RUN_ID=${PROFILE_RUN_ID:-${RUN_ID:-"current-ascend-msprof-$(date -u +%Y%m%dT%H%M%SZ)"}}
+PROFILE_RUN_ROOT=${PROFILE_RUN_ROOT:-"$REPO_ROOT/.benchmarks/current-ascend-msprof"}
+PROFILE_RUN_DIR=${PROFILE_RUN_DIR:-"$PROFILE_RUN_ROOT/$PROFILE_RUN_ID"}
+MSPROF_RAW_DIR=${MSPROF_RAW_DIR:-"$PROFILE_RUN_DIR/msprof_raw"}
+BENCHMARK_RESULT_DIR=${BENCHMARK_RESULT_DIR:-"$PROFILE_RUN_DIR/benchmark"}
+MSPROF_LOG_FILE=${MSPROF_LOG_FILE:-"$PROFILE_RUN_DIR/msprof.log"}
+WORKLOAD_WRAPPER=${WORKLOAD_WRAPPER:-"$PROFILE_RUN_DIR/run_benchmark_under_msprof.sh"}
+RUN_META_FILE=${RUN_META_FILE:-"$PROFILE_RUN_DIR/run_meta.env"}
+
+bool_true() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_shell_var() {
+  local name=$1
+  local value=$2
+  printf '%s=' "$name"
+  printf '%q\n' "$value"
+}
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+  echo "Spec file not found: $SPEC_FILE" >&2
+  exit 2
+fi
+
+if [[ ! -x "$RUNNER_SCRIPT" ]]; then
+  echo "Runner script is not executable: $RUNNER_SCRIPT" >&2
+  exit 2
+fi
+
+if ! bool_true "$DRY_RUN" && ! command -v "$MSPROF_EXECUTABLE" >/dev/null 2>&1; then
+  echo "$MSPROF_EXECUTABLE not found; activate the Ascend profiler environment first." >&2
+  exit 2
+fi
+
+mkdir -p "$PROFILE_RUN_DIR" "$MSPROF_RAW_DIR" "$BENCHMARK_RESULT_DIR"
+
+cat > "$WORKLOAD_WRAPPER" <<EOF
+#!/bin/bash
+set -euo pipefail
+export RUN_ID=$(printf '%q' "$PROFILE_RUN_ID")
+export RESULT_DIR=\${RESULT_DIR:-$(printf '%q' "$BENCHMARK_RESULT_DIR")}
+exec $(printf '%q' "$RUNNER_SCRIPT") $(printf '%q' "$SPEC_FILE")
+EOF
+chmod +x "$WORKLOAD_WRAPPER"
+
+{
+  write_shell_var profile_run_id "$PROFILE_RUN_ID"
+  write_shell_var profile_run_dir "$PROFILE_RUN_DIR"
+  write_shell_var spec_file "$SPEC_FILE"
+  write_shell_var config_file "$CONFIG_FILE"
+  write_shell_var runner_script "$RUNNER_SCRIPT"
+  write_shell_var benchmark_result_dir "$BENCHMARK_RESULT_DIR"
+  write_shell_var msprof_executable "$MSPROF_EXECUTABLE"
+  write_shell_var msprof_flags "$MSPROF_FLAGS"
+  write_shell_var msprof_raw_dir "$MSPROF_RAW_DIR"
+  write_shell_var msprof_log_file "$MSPROF_LOG_FILE"
+  write_shell_var workload_wrapper "$WORKLOAD_WRAPPER"
+  write_shell_var created_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$RUN_META_FILE"
+
+read -r -a msprof_args <<< "$MSPROF_FLAGS"
+msprof_command=(
+  "$MSPROF_EXECUTABLE"
+  "--output=$MSPROF_RAW_DIR"
+  "--application=$WORKLOAD_WRAPPER"
+  "${msprof_args[@]}"
+)
+
+echo "profile_run_dir: $PROFILE_RUN_DIR"
+echo "msprof_raw_dir: $MSPROF_RAW_DIR"
+echo "benchmark_result_dir: $BENCHMARK_RESULT_DIR"
+echo "+ ${msprof_command[*]} > $MSPROF_LOG_FILE 2>&1"
+
+if ! bool_true "$DRY_RUN"; then
+  if "${msprof_command[@]}" >"$MSPROF_LOG_FILE" 2>&1; then
+    :
+  else
+    status=$?
+    echo "msprof run failed with exit code $status. Last log lines:" >&2
+    tail -n 80 "$MSPROF_LOG_FILE" >&2 || true
+    exit "$status"
+  fi
+fi
+
+echo "msprof log: $MSPROF_LOG_FILE"
+echo "msprof raw output: $MSPROF_RAW_DIR"
+
+# Optional offline TraceLoom analysis, run outside this benchmark repository:
+#
+#   traceloom analysis "$MSPROF_RAW_DIR" --out-dir "$PROFILE_RUN_DIR/analysis"
+#
+# Add TraceLoom-specific device filters or analysis limits in that command, not
+# in this benchmark runner.


### PR DESCRIPTION
## Summary

Adds a convenience wrapper for collecting current Ascend same-spec benchmark runs with `msprof`.

The benchmark repository only produces raw profiler artifacts. TraceLoom analysis is documented as a separate offline command instead of being invoked by this wrapper.

## Changes

- Add `scripts/run-current-ascend-same-spec-msprof.sh`.
- Add `scripts/run-current-ascend-same-spec-msprof.env` for default `msprof` settings.
- Wrap the existing `run-current-ascend-same-spec.sh` workload via `msprof --output=<run>/msprof_raw --application=<wrapper>`.
- Emit a stable run layout with `msprof_raw/`, `benchmark/`, `msprof.log`, and `run_meta.env`.
- Normalize the spec path before generating the workload wrapper, so relative spec paths still work when `msprof` launches the application from another cwd.
- Ignore the runner's local `.cache/` directory.
- Document usage, output layout, config overrides, and optional offline TraceLoom analysis in `README.md`.

## Validation

- `bash -n scripts/run-current-ascend-same-spec-msprof.sh`
- `bash -n scripts/run-current-ascend-same-spec.sh`
- `DRY_RUN=1 PROFILE_RUN_DIR=/tmp/vllm-hust-benchmark-msprof-final-check bash scripts/run-current-ascend-same-spec-msprof.sh .benchmarks/msprof-smoke/spec.json`
- `git diff --check`

Real smoke run on `vllm0.13` container:

- Ran `scripts/run-current-ascend-same-spec-msprof.sh` against a reduced same-spec smoke spec on NPU 6.
- Benchmark completed 2 requests with 0 failures.
- `msprof` exported `msprof_raw/PROF_000001_20260527181708647_AEGCRAGHBQIOOLCC`.
- TraceLoom analyzed the generated `msprof_raw` directory with `python3 -m traceloom analysis ... --devices 6` and produced `analysis/summary.md`, `compute_anchor_loop_costs.csv`, and `compute_anchor_node_metrics.csv`.
