### PR TITLE
feat: add --skip-aggregation flag to sync-submission-to-hf

### DIFF
--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -23,6 +23,10 @@ on:
         description: 'Optional vllm-hust-website ref to use for aggregation/schema checkout'
         type: string
         required: false
+      skip_aggregation:
+        description: 'Skip re-aggregation and directly upload existing leaderboard-data/snapshots/ files'
+        type: boolean
+        default: false
 
 env:
   VLLM_HUST_WEBSITE_REF: ${{ github.event.inputs.website_ref || vars.VLLM_HUST_WEBSITE_REF || 'main' }}
@@ -221,11 +225,12 @@ jobs:
           MANUAL_SUBMISSION_DIRS: ${{ github.event.inputs.submission_dirs }}
 
       - name: Sync submissions into HF leaderboard snapshots
-        if: ${{ steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true' }}
+        if: ${{ steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true' || github.event.inputs.skip_aggregation == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.DATASET_WRITE_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           BACKFILL_EXISTING_ONLY: ${{ github.event.inputs.backfill_existing_only || 'false' }}
+          SKIP_AGGREGATION: ${{ github.event.inputs.skip_aggregation || 'false' }}
           VLLM_HUST_REPO: ${{ github.workspace }}/vllm-hust
           VLLM_HUST_WEBSITE_REPO: ${{ github.workspace }}/vllm-hust-website
         run: |
@@ -241,22 +246,29 @@ jobs:
           if [[ "$BACKFILL_EXISTING_ONLY" == "true" ]]; then
             extra_args+=(--existing-only)
           fi
+          if [[ "$SKIP_AGGREGATION" == "true" ]]; then
+            extra_args+=(--skip-aggregation)
+          fi
 
           submission_args=()
-          while IFS= read -r submission_dir; do
-            [[ -z "$submission_dir" ]] && continue
-            echo "=== queueing $submission_dir ==="
-            submission_args+=(--submission-dir "$submission_dir")
-          done <<< "${{ steps.resolve-submissions.outputs.dirs }}"
+          if [[ "$SKIP_AGGREGATION" != "true" ]]; then
+            while IFS= read -r submission_dir; do
+              [[ -z "$submission_dir" ]] && continue
+              echo "=== queueing $submission_dir ==="
+              submission_args+=(--submission-dir "$submission_dir")
+            done <<< "${{ steps.resolve-submissions.outputs.dirs }}"
 
-          if [[ ${#submission_args[@]} -eq 0 && "$BACKFILL_EXISTING_ONLY" != "true" ]]; then
-            echo "No submission directories resolved; nothing to sync."
-            exit 0
+            if [[ ${#submission_args[@]} -eq 0 && "$BACKFILL_EXISTING_ONLY" != "true" ]]; then
+              echo "No submission directories resolved; nothing to sync."
+              exit 0
+            fi
+          else
+            echo "=== skip-aggregation mode: uploading existing snapshots directly ==="
           fi
 
           PYTHONPATH=src python -m vllm_hust_benchmark.cli sync-submission-to-hf \
             "${submission_args[@]}" \
-            --aggregate-output-dir /tmp/leaderboard-data \
+            --aggregate-output-dir leaderboard-data/snapshots \
             --repo-id intellistream/vllm-hust-benchmark-results \
             --submissions-prefix submissions-auto \
             --commit-message "chore: sync benchmark submission and leaderboard data from ${GITHUB_REF} @ ${GITHUB_SHA::8}" \

--- a/docs/LEADERBOARD_HANDOFF.md
+++ b/docs/LEADERBOARD_HANDOFF.md
@@ -485,6 +485,31 @@ PYTHONPATH=src python -m vllm_hust_benchmark.cli sync-submission-to-hf \
   --execute
 ```
 
+**默认行为**：上述命令会从 submissions 目录重新聚合生成 snapshots，然后上传到 HF。这是日常使用的标准流程。
+
+### 11.3.1 跳过聚合直接上传（特殊场景）
+
+当需要将 HF write side 精确同步到某个已知的 snapshots 集合时（例如与 read side 数据保持一致），可以使用 `--skip-aggregation` 标志：
+
+```bash
+PYTHONPATH=src python -m vllm_hust_benchmark.cli sync-submission-to-hf \
+  --aggregate-output-dir leaderboard-data/snapshots \
+  --repo-id intellistream/vllm-hust-benchmark-results \
+  --skip-aggregation \
+  --execute
+```
+
+**使用场景**：
+- HF write side 数据与 read side 不一致，需要强制同步
+- 已知 `leaderboard-data/snapshots/` 中的数据是正确的，需要直接上传
+- 不想因 submissions 集合差异导致聚合结果变化
+
+**注意事项**：
+- 此标志会跳过 submissions 下载/合并步骤
+- 此标志会跳过聚合步骤
+- 直接上传 `--aggregate-output-dir` 指定的目录中的 snapshot 文件
+- **仅在特殊场景使用**，日常同步请使用默认流程
+
 ### 11.4 常见排障切入点
 
 | 症状 | 第一检查点 |

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -540,6 +540,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sync_submission_parser.add_argument("--dry-run", action="store_true")
     sync_submission_parser.add_argument("--execute", action="store_true")
+    sync_submission_parser.add_argument(
+        "--skip-aggregation",
+        action="store_true",
+        help="Skip re-aggregation and directly upload existing leaderboard-data/snapshots/ files. "
+        "Use this to sync HF write side to match a known-good snapshot set without re-running aggregation.",
+    )
 
     submit_parser = subparsers.add_parser(
         "submit",
@@ -987,7 +993,8 @@ def main(argv: list[str] | None = None) -> int:
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2
-        if not args.execute:
+        skip_aggregation = getattr(args, "skip_aggregation", False)
+        if not args.execute and not skip_aggregation:
             print(
                 "sync-submission-to-hf requires --execute because it regenerates local snapshots before upload",
                 file=sys.stderr,
@@ -1012,6 +1019,7 @@ def main(argv: list[str] | None = None) -> int:
             ),
             dry_run=getattr(args, "dry_run", False),
             allow_existing_only=getattr(args, "existing_only", False),
+            skip_aggregation=skip_aggregation,
         )
 
     if args.command == "submit":

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1241,6 +1241,81 @@ def _resolve_hf_token(token: str | None) -> str | None:
     )
 
 
+def _upload_existing_snapshots(
+    *,
+    api,
+    repo_id: str,
+    branch: str,
+    aggregate_output_dir: Path,
+    commit_message: str,
+    dry_run: bool,
+) -> int:
+    """Directly upload existing leaderboard snapshots without re-aggregation.
+
+    Used by --skip-aggregation to sync HF write side to match a known-good
+    snapshot set (e.g. the read-side data) without re-running aggregation
+    from submissions.
+    """
+    try:
+        from huggingface_hub import CommitOperationAdd
+        from vllm_hust_benchmark.hf_publisher import _create_commit_on_branch
+    except ImportError:
+        print(
+            "huggingface_hub is required for HF submission sync. Install with: "
+            "pip install 'vllm-hust-benchmark[publish]'",
+            file=sys.stderr,
+        )
+        return 2
+
+    aggregate_files = [
+        "leaderboard_single.json",
+        "leaderboard_multi.json",
+        "leaderboard_compare.json",
+        "last_updated.json",
+    ]
+
+    operations: list[CommitOperationAdd] = []
+    planned_paths: list[str] = []
+
+    for file_name in aggregate_files:
+        local_file = aggregate_output_dir / file_name
+        if not local_file.is_file():
+            print(f"missing aggregated output: {local_file}", file=sys.stderr)
+            return 2
+        operations.append(
+            CommitOperationAdd(path_in_repo=file_name, path_or_fileobj=local_file)
+        )
+        planned_paths.append(file_name)
+
+    if dry_run:
+        print(
+            f"[dry-run] Would upload {len(planned_paths)} snapshot file(s) to {repo_id}@{branch}:"
+        )
+        for repo_path in planned_paths:
+            print(f"  {repo_path}")
+        return 0
+
+    print(f"Uploading {len(planned_paths)} snapshot file(s) to {repo_id}@{branch}...")
+
+    try:
+        api.repo_info(repo_id=repo_id, repo_type="dataset")
+    except Exception:
+        api.create_repo(
+            repo_id=repo_id, repo_type="dataset", private=True, exist_ok=True
+        )
+
+    _create_commit_on_branch(
+        api,
+        repo_id=repo_id,
+        repo_type="dataset",
+        branch=branch,
+        operations=operations,
+        commit_message=commit_message,
+    )
+    print("Upload complete.")
+    return 0
+
+
 def sync_submission_to_huggingface(
     *,
     layout: RepoLayout,
@@ -1253,6 +1328,7 @@ def sync_submission_to_huggingface(
     commit_message: str = "chore: sync benchmark submission and leaderboard data",
     dry_run: bool = False,
     allow_existing_only: bool = False,
+    skip_aggregation: bool = False,
 ) -> int:
     try:
         from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
@@ -1272,9 +1348,9 @@ def sync_submission_to_huggingface(
     else:
         normalized_submission_dirs = list(submission_dirs)
 
-    if not normalized_submission_dirs and not allow_existing_only:
+    if not normalized_submission_dirs and not allow_existing_only and not skip_aggregation:
         print(
-            "at least one submission directory is required unless --existing-only is set",
+            "at least one submission directory is required unless --existing-only or --skip-aggregation is set",
             file=sys.stderr,
         )
         return 2
@@ -1288,6 +1364,18 @@ def sync_submission_to_huggingface(
     api = HfApi(token=resolved_token)
     normalized_prefix = submissions_prefix.strip("/")
     repo_prefix = f"{normalized_prefix}/" if normalized_prefix else ""
+
+    # When --skip-aggregation is set, directly upload existing snapshots
+    # without re-aggregating from submissions.
+    if skip_aggregation:
+        return _upload_existing_snapshots(
+            api=api,
+            repo_id=repo_id,
+            branch=branch,
+            aggregate_output_dir=aggregate_output_dir,
+            commit_message=commit_message,
+            dry_run=dry_run,
+        )
 
     with tempfile.TemporaryDirectory(prefix="vllm-hust-hf-sync-") as temp_dir:
         temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary

Add a new `--skip-aggregation` flag to `sync-submission-to-hf` that bypasses submission re-aggregation and directly uploads existing `leaderboard-data/snapshots/` files to HuggingFace.

## Problem

The current workflow re-aggregates from submissions before uploading, which can produce different results than the read-side data due to submission set differences. This makes it impossible to sync the HF write side to exactly match the read side.

## Solution

The new `--skip-aggregation` flag:
- Skips submission download/merge steps
- Skips the aggregation step
- Directly uploads existing snapshot files from `leaderboard-data/snapshots/`

## Changes

| File | Change |
|------|--------|
| `src/vllm_hust_benchmark/cli.py` | Add `--skip-aggregation` argument |
| `src/vllm_hust_benchmark/integration.py` | Add `_upload_existing_snapshots()` helper |
| `.github/workflows/push-to-hf.yml` | Add `skip_aggregation` workflow input |

## Usage

### CLI
```bash
python -m vllm_hust_benchmark.cli sync-submission-to-hf \
  --aggregate-output-dir leaderboard-data/snapshots \
  --repo-id intellistream/vllm-hust-benchmark-results \
  --skip-aggregation --execute
```

### Workflow
Run `push-to-hf.yml` with `skip_aggregation: true` to directly upload existing snapshots.

## Testing

- [ ] Dry run: `--skip-aggregation --dry-run --execute`
- [ ] Full upload: `--skip-aggregation --execute`

Co-authored-by: Qoder Agent