### PR TITLE
fix: restore official baseline eager fallback

### DIFF
--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -817,7 +817,7 @@ run_client_command() {
     throughput|latency)
       prepare_offline_benchmark_runtime || return $?
 
-      run_offline_client_command "$CLIENT_ARGS"
+      run_offline_client_command_with_aclgraph_fallback
       ;;
     *)
       echo "Unsupported benchmark type for official baseline runner: $BENCHMARK_TYPE" >&2
@@ -833,6 +833,53 @@ run_offline_client_command() {
     python "$VLLM_CLI_COMPAT" bench "$BENCHMARK_TYPE" \
     --output-json "$RAW_RESULT_FILE" \
     $effective_client_args
+}
+
+append_enforce_eager_flag() {
+  local client_args=${1:-}
+
+  if [[ "$client_args" == *"--enforce-eager"* ]]; then
+    printf '%s\n' "$client_args"
+    return 0
+  fi
+
+  if [[ -n "$client_args" ]]; then
+    printf '%s --enforce-eager\n' "$client_args"
+  else
+    printf '%s\n' "--enforce-eager"
+  fi
+}
+
+run_offline_client_command_with_aclgraph_fallback() {
+  local failure_log=""
+  local runner_status=0
+  local eager_client_args=""
+
+  failure_log=$(mktemp "${TMPDIR:-/tmp}/official-baseline-offline-client-XXXXXX.log")
+  : > "$failure_log"
+
+  if run_offline_client_command "$CLIENT_ARGS" \
+    > >(tee -a "$failure_log") \
+    2> >(tee -a "$failure_log" >&2); then
+    rm -f "$failure_log"
+    return 0
+  fi
+  runner_status=$?
+
+  if ! grep -Fq "weak_ref_tensor" "$failure_log"; then
+    rm -f "$failure_log"
+    return "$runner_status"
+  fi
+
+  eager_client_args=$(append_enforce_eager_flag "$CLIENT_ARGS")
+  if [[ "$eager_client_args" == "$CLIENT_ARGS" ]]; then
+    rm -f "$failure_log"
+    return "$runner_status"
+  fi
+
+  echo "[goal-baseline] observed weak_ref_tensor failure during ${BENCHMARK_TYPE} benchmark; retrying with --enforce-eager" >&2
+  rm -f "$failure_log"
+  run_offline_client_command "$eager_client_args"
 }
 
 prepare_offline_benchmark_runtime() {
@@ -1048,8 +1095,15 @@ ensure_runtime_dataset_available() {
 }
 
 normalized_server_parameters_json() {
+  local force_eager_server=0
+
+  if should_force_eager_for_server_benchmark; then
+    force_eager_server=1
+  fi
+
   PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
     SAME_SPEC_FILE="$SAME_SPEC_FILE" \
+    OFFICIAL_FORCE_EAGER_SERVER="$force_eager_server" \
     "$HOST_PYTHON_BIN" - <<'PY'
 import json
 import os
@@ -1059,6 +1113,8 @@ from vllm_hust_benchmark.official_runtime_inputs import normalize_server_paramet
 
 payload = json.loads(Path(os.environ["SAME_SPEC_FILE"]).read_text(encoding="utf-8"))
 normalized = normalize_server_parameters(payload["resolved_server_parameters"])
+if os.environ.get("OFFICIAL_FORCE_EAGER_SERVER") == "1":
+    normalized["enforce_eager"] = ""
 print(
     json.dumps(
     normalized,
@@ -1070,6 +1126,12 @@ PY
 }
 
 normalized_client_parameters_json() {
+  local force_eager_offline=0
+
+  if should_force_eager_for_offline_benchmark; then
+    force_eager_offline=1
+  fi
+
   PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
     SAME_SPEC_FILE="$SAME_SPEC_FILE" \
     BENCHMARK_TYPE="$BENCHMARK_TYPE" \
@@ -1077,6 +1139,7 @@ normalized_client_parameters_json() {
     OFFICIAL_VLLM_WORKTREE="$OFFICIAL_VLLM_WORKTREE" \
     BENCHMARK_REPO="$REPO_ROOT" \
     OFFICIAL_BENCHMARK_DATASET_ROOT="$OFFICIAL_BENCHMARK_DATASET_ROOT" \
+    OFFICIAL_FORCE_EAGER_OFFLINE="$force_eager_offline" \
     "$HOST_PYTHON_BIN" - <<'PY'
 import json
 import os
@@ -1095,6 +1158,7 @@ print(
             vllm_worktree=os.environ.get("OFFICIAL_VLLM_WORKTREE"),
             benchmark_repo=os.environ.get("BENCHMARK_REPO"),
             dataset_cache_root=os.environ.get("OFFICIAL_BENCHMARK_DATASET_ROOT"),
+            force_eager=os.environ.get("OFFICIAL_FORCE_EAGER_OFFLINE") == "1",
         ),
         separators=(",", ":"),
         ensure_ascii=True,
@@ -1362,6 +1426,85 @@ PY
   fi
 
   printf '%s' "unknown"
+}
+
+official_runtime_supports_aclgraph_weak_ref_tensor() {
+  local probe_status=0
+
+  set +e
+  run_in_official_runtime_python "$OFFICIAL_RUNTIME_PYTHONPATH" <<'PY' >/dev/null 2>&1
+import torch
+
+has_namespace = hasattr(torch.ops, "_C_ascend")
+has_weak_ref = has_namespace and hasattr(torch.ops._C_ascend, "weak_ref_tensor")
+
+raise SystemExit(0 if has_weak_ref else 3)
+PY
+  probe_status=$?
+  set -e
+
+  if [[ "$probe_status" -eq 0 ]]; then
+    return 0
+  fi
+
+  if [[ "$probe_status" -eq 3 ]]; then
+    return 1
+  fi
+
+  echo "[goal-baseline] failed to probe official ACL graph weak_ref_tensor support (status=${probe_status}); leaving graph mode unchanged" >&2
+  return 2
+}
+
+should_force_eager_for_offline_benchmark() {
+  local probe_status=0
+
+  case "${BENCHMARK_TYPE:-}" in
+    throughput|latency)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  official_runtime_supports_aclgraph_weak_ref_tensor
+  probe_status=$?
+
+  if [[ "$probe_status" -eq 0 ]]; then
+    return 1
+  fi
+
+  if [[ "$probe_status" -eq 1 ]]; then
+    echo "[goal-baseline] official runtime lacks torch.ops._C_ascend.weak_ref_tensor; forcing --enforce-eager for ${BENCHMARK_TYPE} benchmark" >&2
+    return 0
+  fi
+
+  return 1
+}
+
+should_force_eager_for_server_benchmark() {
+  local probe_status=0
+
+  case "${BENCHMARK_TYPE:-}" in
+    serve)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  official_runtime_supports_aclgraph_weak_ref_tensor
+  probe_status=$?
+
+  if [[ "$probe_status" -eq 0 ]]; then
+    return 1
+  fi
+
+  if [[ "$probe_status" -eq 1 ]]; then
+    echo "[goal-baseline] official runtime lacks torch.ops._C_ascend.weak_ref_tensor; forcing --enforce-eager for serve benchmark server" >&2
+    return 0
+  fi
+
+  return 1
 }
 
 server_log_indicates_resource_busy() {


### PR DESCRIPTION

  ## Summary

  Restore the official baseline runner fallback for Ascend runtimes that do not provide `torch.ops._C_ascend.weak_ref_tensor`.

  The current `main` branch fails existing tests in `tests/test_prepare_official_env_script.py` because the runner no longer exposes the eager
  fallback helpers expected by the test suite. This also blocks unrelated documentation-only PRs, such as #39.

  This PR restores the fallback path so offline benchmarks retry with `--enforce-eager` when they fail with a `weak_ref_tensor` error, and serve
  benchmarks inject `enforce_eager` when the official runtime lacks weak-ref tensor support.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - `bash -n scripts/run-official-ascend-goal-baseline.sh`
  - `git diff --check`

  Attempted the failing pytest cases locally, but local macOS shell behavior around `source <(awk ...)` did not match CI reliably. The fix
  restores the expected Linux CI code path and should be validated by GitHub Actions.

  ## Risks

  This changes official baseline runner behavior for runtimes missing `weak_ref_tensor` support. The intended behavior is to use `--enforce-
  eager` only for the affected throughput/latency retry path or serve server parameters, while leaving graph mode unchanged when the probe
  succeeds.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [ ] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.