### PR TITLE
feat: add perfgate spec registry resolver

### DIFF
--- a/docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json
@@ -1,0 +1,53 @@
+{
+  "id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
+  "label": "Performance gate Ascend ShareGPT online baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-sharegpt-online",
+    "label": "Performance Gate Ascend ShareGPT Online",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "sharegpt-online",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000,
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "sharegpt",
+    "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+    "num_prompts": 8,
+    "request_rate": 1,
+    "max_concurrency": 4,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -1,0 +1,14 @@
+{
+  "entries": [
+    {
+      "scenario": "random-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "sharegpt-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json"
+    }
+  ]
+}

--- a/src/vllm_hust_benchmark/perfgate_specs.py
+++ b/src/vllm_hust_benchmark/perfgate_specs.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from vllm_hust_benchmark.registry import get_scenario
+
+
+@dataclass(frozen=True)
+class PerfgateSpecEntry:
+    scenario: str
+    hardware_chip_model: str
+    spec_file: str
+
+
+def _normalize_scenario(value: str) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_chip_model(value: str) -> str:
+    return str(value or "").strip().upper()
+
+
+def _load_default_registry_payload() -> dict[str, Any]:
+    with (
+        resources.files("vllm_hust_benchmark.data")
+        .joinpath("perfgate_spec_registry.json")
+        .open("r", encoding="utf-8") as handle
+    ):
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("perfgate spec registry must be a JSON object")
+    return payload
+
+
+def _load_registry_payload(registry_file: Path | None = None) -> dict[str, Any]:
+    if registry_file is None:
+        return _load_default_registry_payload()
+    payload = json.loads(registry_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{registry_file}: perfgate spec registry must be a JSON object")
+    return payload
+
+
+def _validate_spec_file_path(spec_file: str) -> None:
+    path = Path(spec_file)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"perfgate spec file must be repo-relative: {spec_file}")
+    if not spec_file.endswith(".json"):
+        raise ValueError(f"perfgate spec file must be a JSON file: {spec_file}")
+
+
+def load_perfgate_spec_registry(
+    registry_file: Path | None = None,
+) -> tuple[PerfgateSpecEntry, ...]:
+    payload = _load_registry_payload(registry_file)
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, list):
+        raise ValueError("perfgate spec registry must contain an entries array")
+
+    entries: list[PerfgateSpecEntry] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            raise ValueError("perfgate spec registry entries must be objects")
+
+        scenario = _normalize_scenario(raw_entry.get("scenario", ""))
+        hardware_chip_model = _normalize_chip_model(
+            str(raw_entry.get("hardware_chip_model", ""))
+        )
+        spec_file = str(raw_entry.get("spec_file") or "").strip()
+        if not scenario:
+            raise ValueError("perfgate spec registry entry is missing scenario")
+        if not hardware_chip_model:
+            raise ValueError(
+                "perfgate spec registry entry is missing hardware_chip_model"
+            )
+        if not spec_file:
+            raise ValueError("perfgate spec registry entry is missing spec_file")
+
+        try:
+            get_scenario(scenario)
+        except KeyError as exc:
+            raise ValueError(
+                f"perfgate spec registry references unknown scenario: {scenario}"
+            ) from exc
+
+        _validate_spec_file_path(spec_file)
+
+        key = (scenario, hardware_chip_model)
+        if key in seen:
+            raise ValueError(
+                "duplicate perfgate spec registry entry for "
+                f"scenario={scenario}, hardware_chip_model={hardware_chip_model}"
+            )
+        seen.add(key)
+        entries.append(
+            PerfgateSpecEntry(
+                scenario=scenario,
+                hardware_chip_model=hardware_chip_model,
+                spec_file=spec_file,
+            )
+        )
+
+    return tuple(entries)
+
+
+def _load_spec_payload(spec_path: Path) -> dict[str, Any]:
+    payload = json.loads(spec_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{spec_path}: perfgate spec must be a JSON object")
+    return payload
+
+
+def _validate_resolved_spec(
+    entry: PerfgateSpecEntry,
+    *,
+    repo_root: Path,
+) -> Path:
+    spec_path = (repo_root / entry.spec_file).resolve()
+    resolved_repo_root = repo_root.resolve()
+    if not spec_path.is_relative_to(resolved_repo_root):
+        raise ValueError(f"resolved perfgate spec escapes repo root: {entry.spec_file}")
+    if not spec_path.is_file():
+        raise ValueError(f"perfgate spec file not found: {spec_path}")
+
+    spec = _load_spec_payload(spec_path)
+    spec_id = str(spec.get("id") or "").strip()
+    spec_scenario = _normalize_scenario(str(spec.get("scenario") or ""))
+    spec_chip = _normalize_chip_model(str(spec.get("hardware_chip_model") or ""))
+    if not spec_id:
+        raise ValueError(f"{spec_path}: perfgate spec is missing required field: id")
+    if spec_scenario != entry.scenario:
+        raise ValueError(
+            f"{spec_path}: scenario mismatch; registry={entry.scenario}, "
+            f"spec={spec_scenario}"
+        )
+    if spec_chip != entry.hardware_chip_model:
+        raise ValueError(
+            f"{spec_path}: hardware_chip_model mismatch; "
+            f"registry={entry.hardware_chip_model}, spec={spec_chip}"
+        )
+    return spec_path
+
+
+def format_supported_pairs(entries: tuple[PerfgateSpecEntry, ...]) -> str:
+    pairs = sorted(
+        f"{entry.scenario}/{entry.hardware_chip_model}" for entry in entries
+    )
+    return ", ".join(pairs)
+
+
+def resolve_perfgate_spec_file(
+    *,
+    scenario: str,
+    hardware_chip_model: str,
+    repo_root: Path | None = None,
+    registry_file: Path | None = None,
+) -> Path:
+    normalized_scenario = _normalize_scenario(scenario)
+    normalized_chip = _normalize_chip_model(hardware_chip_model)
+    if not normalized_scenario:
+        raise ValueError("scenario is required")
+    if not normalized_chip:
+        raise ValueError("hardware_chip_model is required")
+
+    entries = load_perfgate_spec_registry(registry_file)
+    for entry in entries:
+        if (
+            entry.scenario == normalized_scenario
+            and entry.hardware_chip_model == normalized_chip
+        ):
+            if repo_root is None:
+                return Path(entry.spec_file)
+            return _validate_resolved_spec(entry, repo_root=repo_root)
+
+    supported = format_supported_pairs(entries)
+    raise ValueError(
+        "No perfgate spec registered for "
+        f"scenario={normalized_scenario}, hardware_chip_model={normalized_chip}. "
+        f"Supported pairs: {supported}"
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve a perfgate spec file from scenario and hardware chip.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    resolve_parser = subparsers.add_parser("resolve")
+    resolve_parser.add_argument("--scenario", required=True)
+    resolve_parser.add_argument("--hardware-chip-model", required=True)
+    resolve_parser.add_argument("--repo-root", type=Path)
+    resolve_parser.add_argument("--registry-file", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.command == "resolve":
+            spec_file = resolve_perfgate_spec_file(
+                scenario=args.scenario,
+                hardware_chip_model=args.hardware_chip_model,
+                repo_root=args.repo_root,
+                registry_file=args.registry_file,
+            )
+            print(spec_file)
+            return 0
+    except (OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+    print(f"unsupported command: {args.command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -5,6 +5,7 @@ from vllm_hust_benchmark.official_baselines import get_canonical_submission_dir
 from vllm_hust_benchmark.official_baselines import get_primary_metric_name_for_benchmark_type
 from vllm_hust_benchmark.official_baselines import has_canonical_run
 from vllm_hust_benchmark.official_baselines import select_canonical_candidate
+from vllm_hust_benchmark.same_spec import build_same_spec_payload
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -40,6 +41,33 @@ def test_perfgate_ascend_smoke_spec_is_available_for_ci() -> None:
     assert spec["server_parameters"]["max_model_len"] == 256
     assert spec["client_parameters"]["input_len"] == 64
     assert spec["client_parameters"]["output_len"] == 16
+
+
+def test_perfgate_sharegpt_online_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-sharegpt-online-qwen25-3b-910b2"
+    assert spec["scenario"] == "sharegpt-online"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert "max_model_len" not in spec["server_parameters"]
+    assert spec["client_parameters"]["dataset_name"] == "sharegpt"
+    assert (
+        spec["client_parameters"]["dataset_path"]
+        == "ShareGPT_V3_unfiltered_cleaned_split.json"
+    )
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert same_spec["scenario"] == "sharegpt-online"
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "sharegpt"
 
 
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vllm_hust_benchmark import perfgate_specs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_registry(path: Path, entries: list[dict[str, str]]) -> None:
+    path.write_text(json.dumps({"entries": entries}), encoding="utf-8")
+
+
+def test_resolve_random_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="random-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-qwen25-3b-910b2.json"
+    ).resolve()
+
+
+def test_resolve_sharegpt_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="sharegpt-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json"
+    ).resolve()
+
+
+def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="random-online",
+        hardware_chip_model="910b2",
+    )
+
+    assert spec_path == Path(
+        "docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json"
+    )
+
+
+def test_resolve_rejects_unsupported_pair() -> None:
+    try:
+        perfgate_specs.resolve_perfgate_spec_file(
+            scenario="visionarena-online",
+            hardware_chip_model="910B2",
+            repo_root=REPO_ROOT,
+        )
+    except ValueError as error:
+        message = str(error)
+        assert "No perfgate spec registered" in message
+        assert "random-online/910B2" in message
+        assert "sharegpt-online/910B2" in message
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected unsupported pair to fail")
+
+
+def test_registry_rejects_duplicate_entries(tmp_path: Path) -> None:
+    registry_file = tmp_path / "registry.json"
+    entry = {
+        "scenario": "random-online",
+        "hardware_chip_model": "910B2",
+        "spec_file": "docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json",
+    }
+    _write_registry(registry_file, [entry, entry])
+
+    try:
+        perfgate_specs.load_perfgate_spec_registry(registry_file)
+    except ValueError as error:
+        assert "duplicate perfgate spec registry entry" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected duplicate registry entry to fail")
+
+
+def test_resolve_rejects_missing_spec_file(tmp_path: Path) -> None:
+    registry_file = tmp_path / "registry.json"
+    _write_registry(
+        registry_file,
+        [
+            {
+                "scenario": "random-online",
+                "hardware_chip_model": "910B2",
+                "spec_file": "docs/official-baselines/missing.json",
+            }
+        ],
+    )
+
+    try:
+        perfgate_specs.resolve_perfgate_spec_file(
+            scenario="random-online",
+            hardware_chip_model="910B2",
+            repo_root=REPO_ROOT,
+            registry_file=registry_file,
+        )
+    except ValueError as error:
+        assert "perfgate spec file not found" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected missing spec file to fail")
+
+
+def test_resolve_rejects_spec_scenario_mismatch(tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.json"
+    registry_file = tmp_path / "registry.json"
+    spec_file.write_text(
+        json.dumps(
+            {
+                "id": "test-spec",
+                "scenario": "sharegpt-online",
+                "hardware_chip_model": "910B2",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_registry(
+        registry_file,
+        [
+            {
+                "scenario": "random-online",
+                "hardware_chip_model": "910B2",
+                "spec_file": spec_file.name,
+            }
+        ],
+    )
+
+    try:
+        perfgate_specs.resolve_perfgate_spec_file(
+            scenario="random-online",
+            hardware_chip_model="910B2",
+            repo_root=tmp_path,
+            registry_file=registry_file,
+        )
+    except ValueError as error:
+        assert "scenario mismatch" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected spec scenario mismatch to fail")
+
+
+def test_resolve_rejects_spec_chip_mismatch(tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.json"
+    registry_file = tmp_path / "registry.json"
+    spec_file.write_text(
+        json.dumps(
+            {
+                "id": "test-spec",
+                "scenario": "random-online",
+                "hardware_chip_model": "910B3",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_registry(
+        registry_file,
+        [
+            {
+                "scenario": "random-online",
+                "hardware_chip_model": "910B2",
+                "spec_file": spec_file.name,
+            }
+        ],
+    )
+
+    try:
+        perfgate_specs.resolve_perfgate_spec_file(
+            scenario="random-online",
+            hardware_chip_model="910B2",
+            repo_root=tmp_path,
+            registry_file=registry_file,
+        )
+    except ValueError as error:
+        assert "hardware_chip_model mismatch" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected spec chip mismatch to fail")
+
+
+def test_resolve_rejects_missing_spec_id(tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.json"
+    registry_file = tmp_path / "registry.json"
+    spec_file.write_text(
+        json.dumps(
+            {
+                "scenario": "random-online",
+                "hardware_chip_model": "910B2",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_registry(
+        registry_file,
+        [
+            {
+                "scenario": "random-online",
+                "hardware_chip_model": "910B2",
+                "spec_file": spec_file.name,
+            }
+        ],
+    )
+
+    try:
+        perfgate_specs.resolve_perfgate_spec_file(
+            scenario="random-online",
+            hardware_chip_model="910B2",
+            repo_root=tmp_path,
+            registry_file=registry_file,
+        )
+    except ValueError as error:
+        assert "missing required field: id" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected missing spec id to fail")
+
+
+def test_cli_resolve_prints_one_absolute_path(capsys) -> None:
+    exit_code = perfgate_specs.main(
+        [
+            "resolve",
+            "--scenario",
+            "sharegpt-online",
+            "--hardware-chip-model",
+            "910B2",
+            "--repo-root",
+            str(REPO_ROOT),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert captured.out.splitlines() == [
+        str(
+            (
+                REPO_ROOT
+                / "docs"
+                / "official-baselines"
+                / "perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json"
+            ).resolve()
+        )
+    ]
+
+
+def test_cli_resolve_failure_uses_stderr(capsys) -> None:
+    exit_code = perfgate_specs.main(
+        [
+            "resolve",
+            "--scenario",
+            "visionarena-online",
+            "--hardware-chip-model",
+            "910B2",
+            "--repo-root",
+            str(REPO_ROOT),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "No perfgate spec registered" in captured.err


### PR DESCRIPTION
## Summary

  Add the first shared perfgate spec registry/resolver for the multi-scenario performance gate rollout.

  This PR adds:

  - a lightweight `sharegpt-online` 910B2 perfgate spec
  - a shared `(scenario, hardware_chip_model) -> spec_file` registry
  - a resolver CLI/API in `vllm_hust_benchmark.perfgate_specs`
  - tests for successful resolution, validation failures, and CLI output behavior

  This PR only changes `vllm-hust-benchmark`. It does not change downstream workflow behavior yet. `vllm-hust` and `vllm-ascend-hust` will
  consume this resolver in follow-up PRs.

  Related tracker: #38

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  Ran:

  ```bash
  PYTHONPATH=src pytest tests/test_perfgate_specs.py tests/test_official_baselines.py tests/test_same_spec.py tests/test_registry.py
  git diff --check
  python3 -m py_compile src/vllm_hust_benchmark/perfgate_specs.py

  Result:

  34 passed

  Manual smoke checks:

  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario random-online --hardware-chip-model 910B2 --repo-root "$PWD"
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario sharegpt-online --hardware-chip-model 910B2 --repo-root "$PWD"

  ## Risks

  - This PR does not enable sharegpt-online in downstream workflows yet; follow-up PRs are required in vllm-hust and vllm-ascend-hust.
  - sharegpt-online should run in report-only mode first before any blocking gate decision.
  - Full local pytest was not run successfully on macOS because existing shell/Linux-specific tests require Linux/bash runtime behavior.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.