### PR TITLE
Feat/perfgate phase4 aggregation verification

### DIFF
--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -934,6 +934,7 @@ def main(argv: list[str] | None = None) -> int:
                 source_dir=Path(args.source_dir).resolve(),
                 output_dir=output_dir,
                 execute=args.execute,
+                reject_pr_preview_sources=getattr(args, "publish_hf", False),
             )
         except ValueError as error:
             print(str(error), file=sys.stderr)
@@ -974,6 +975,7 @@ def main(argv: list[str] | None = None) -> int:
                 source_dir=source_dir,
                 output_dir=None,
                 execute=args.execute,
+                reject_pr_preview_sources=True,
             )
             if rc != 0:
                 return rc

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1228,6 +1228,70 @@ def _upload_existing_snapshots(
     return 0
 
 
+PR_PREVIEW_GITHUB_EVENTS = frozenset({"pull_request", "pull_request_target"})
+
+
+def _artifact_has_pr_preview_metadata(artifact: Mapping[str, Any]) -> bool:
+    metadata = artifact.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+
+    github_event_name = str(metadata.get("github_event_name") or "").strip()
+    if github_event_name in PR_PREVIEW_GITHUB_EVENTS:
+        return True
+
+    github_pr_number = metadata.get("github_pr_number")
+    if github_pr_number is not None and str(github_pr_number).strip():
+        return True
+
+    github_pr_url = str(metadata.get("github_pr_url") or "").strip()
+    return bool(github_pr_url)
+
+
+def _validate_formal_submission_sources(submission_dirs: Sequence[Path]) -> bool:
+    for submission_dir in submission_dirs:
+        try:
+            artifact_paths = iter_submission_artifact_paths(submission_dir)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(
+                f"invalid submission manifest in {submission_dir}: {exc}",
+                file=sys.stderr,
+            )
+            return False
+
+        known_artifact_paths = set(artifact_paths)
+        for artifact_path in sorted(submission_dir.rglob("run_leaderboard.json")):
+            if artifact_path not in known_artifact_paths:
+                artifact_paths.append(artifact_path)
+
+        for artifact_path in artifact_paths:
+            try:
+                payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                print(
+                    f"invalid submission artifact {artifact_path}: {exc}",
+                    file=sys.stderr,
+                )
+                return False
+            if not isinstance(payload, Mapping):
+                print(
+                    f"invalid submission artifact {artifact_path}: payload must be a JSON object",
+                    file=sys.stderr,
+                )
+                return False
+
+            if _artifact_has_pr_preview_metadata(payload):
+                print(
+                    "PR preview benchmark artifacts cannot be published through "
+                    "the formal leaderboard aggregation path: "
+                    f"{artifact_path}",
+                    file=sys.stderr,
+                )
+                return False
+
+    return True
+
+
 def sync_submission_to_huggingface(
     *,
     layout: RepoLayout,
@@ -1242,17 +1306,6 @@ def sync_submission_to_huggingface(
     allow_existing_only: bool = False,
     skip_aggregation: bool = False,
 ) -> int:
-    try:
-        from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
-        from vllm_hust_benchmark.hf_publisher import _create_commit_on_branch
-    except ImportError:
-        print(
-            "huggingface_hub is required for HF submission sync. Install with: "
-            "pip install 'vllm-hust-benchmark[publish]'",
-            file=sys.stderr,
-        )
-        return 2
-
     if submission_dirs is None:
         normalized_submission_dirs: list[Path] = []
     elif isinstance(submission_dirs, Path):
@@ -1271,6 +1324,20 @@ def sync_submission_to_huggingface(
         if not submission_dir.is_dir():
             print(f"submission directory not found: {submission_dir}", file=sys.stderr)
             return 2
+
+    if not _validate_formal_submission_sources(normalized_submission_dirs):
+        return 2
+
+    try:
+        from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+        from vllm_hust_benchmark.hf_publisher import _create_commit_on_branch
+    except ImportError:
+        print(
+            "huggingface_hub is required for HF submission sync. Install with: "
+            "pip install 'vllm-hust-benchmark[publish]'",
+            file=sys.stderr,
+        )
+        return 2
 
     resolved_token = _resolve_hf_token(token)
     api = HfApi(token=resolved_token)

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -510,7 +510,13 @@ def aggregate_to_website(
     source_dir: Path,
     output_dir: Path | None = None,
     execute: bool,
+    reject_pr_preview_sources: bool = False,
 ) -> int:
+    if reject_pr_preview_sources and not _validate_formal_submission_sources(
+        [source_dir]
+    ):
+        return 2
+
     destination = output_dir or layout.website_repo / "data"
     command = [
         sys.executable,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -684,6 +684,64 @@ def test_publish_website_without_execute_prints_aggregate_command(
     assert f"--source-dir {source_dir}" in captured.out
 
 
+def test_publish_hf_aggregate_first_rejects_pr_preview_source(
+    capsys, monkeypatch, tmp_path: Path
+) -> None:
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=tmp_path / "vllm-hust-benchmark",
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=tmp_path / "vllm-hust-website",
+    )
+    (layout.website_repo / "scripts").mkdir(parents=True)
+    (layout.website_repo / "scripts" / "aggregate_results.py").write_text(
+        "print('ok')\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(cli_module, "resolve_repo_layout", lambda: layout)
+    monkeypatch.setattr(cli_module, "validate_repo_layout", lambda _layout: None)
+
+    source_dir = tmp_path / "exports"
+    source_dir.mkdir()
+    (source_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+                "metadata": {
+                    "github_event_name": "pull_request",
+                    "github_pr_number": 99,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    upload_called = False
+
+    def fake_upload_to_huggingface(**kwargs):
+        nonlocal upload_called
+        upload_called = True
+        return 0
+
+    monkeypatch.setattr(cli_module, "upload_to_huggingface", fake_upload_to_huggingface)
+
+    exit_code = main(
+        [
+            "publish-hf",
+            "--aggregate-first",
+            "--source-dir",
+            str(source_dir),
+            "--repo-id",
+            "owner/repo",
+            "--execute",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert upload_called is False
+    assert "PR preview benchmark artifacts cannot be published" in captured.err
+
+
 def test_sync_submission_to_hf_accepts_multiple_submission_dirs(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -388,6 +388,47 @@ def test_aggregate_to_website_without_execute_prints_command(
     assert "--output-dir" in captured.out
 
 
+def test_aggregate_to_website_rejects_pr_preview_sources_when_requested(
+    capsys, tmp_path: Path
+) -> None:
+    website_repo = tmp_path / "vllm-hust-website"
+    (website_repo / "scripts").mkdir(parents=True)
+    (website_repo / "scripts" / "aggregate_results.py").write_text(
+        "print('ok')\n", encoding="utf-8"
+    )
+
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=tmp_path / "vllm-hust-benchmark",
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=website_repo,
+    )
+    source_dir = tmp_path / "exports"
+    source_dir.mkdir()
+    (source_dir / "run_leaderboard.json").write_text(
+        json.dumps(
+            {
+                "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+                "metadata": {"github_event_name": "pull_request"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = aggregate_to_website(
+        layout=layout,
+        source_dir=source_dir,
+        execute=False,
+        reject_pr_preview_sources=True,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "PR preview benchmark artifacts cannot be published" in captured.err
+    assert "aggregate_results.py" not in captured.out
+
+
 def test_validate_aggregated_leaderboard_outputs_rejects_single_engine_distribution(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1022,6 +1022,54 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
     assert "submissions-auto/submission-a/run_leaderboard.json" in uploaded_paths
 
 
+def test_sync_submission_to_huggingface_rejects_local_pr_preview_submission(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    layout = RepoLayout(
+        workspace_root=tmp_path,
+        benchmark_repo=tmp_path / "vllm-hust-benchmark",
+        vllm_hust_repo=tmp_path / "vllm-hust",
+        website_repo=tmp_path / "vllm-hust-website",
+    )
+
+    submission_dir = tmp_path / "submission-pr-preview"
+    submission_dir.mkdir()
+    artifact = {
+        "model": {"name": "Qwen/Qwen2.5-14B-Instruct"},
+        "metadata": {
+            "github_event_name": "pull_request",
+            "github_pr_number": 99,
+            "github_pr_url": "https://github.com/vLLM-HUST/vllm-hust/pull/99",
+        },
+    }
+    (submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(artifact) + "\n", encoding="utf-8"
+    )
+
+    aggregate_called = False
+
+    def fake_aggregate_to_website(*, layout, source_dir, output_dir, execute):
+        nonlocal aggregate_called
+        aggregate_called = True
+        return 0
+
+    monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
+
+    exit_code = sync_submission_to_huggingface(
+        layout=layout,
+        submission_dirs=submission_dir,
+        aggregate_output_dir=tmp_path / "aggregated",
+        repo_id="owner/repo",
+        submissions_prefix="submissions-auto",
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert aggregate_called is False
+    assert "PR preview benchmark artifacts cannot be published" in captured.err
+    assert "submission-pr-preview/run_leaderboard.json" in captured.err
+
+
 def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
 ## Summary

  Implement Phase 4 aggregation safety checks for the perfgate scenario rollout.

  This PR prevents PR preview benchmark artifacts from entering formal leaderboard aggregation and publication paths. It adds PR-preview
  metadata detection for local submission artifacts before formal HF sync / publish aggregation runs, while keeping local-only website
  aggregation available for development checks.

  Covered paths:
  - `sync-submission-to-hf`
  - `publish-website --publish-hf`
  - `publish-hf --aggregate-first`

  This addresses the Phase 4 requirement to keep PR preview data separated from formal benchmark aggregation.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m pytest tests/test_integration.py tests/test_cli.py tests/test_sync_official_baseline_snapshots_to_github.py
  python3 -m py_compile src/vllm_hust_benchmark/integration.py src/vllm_hust_benchmark/cli.py
  git diff --check

  Result:

  75 passed

  ## Risks

  This PR only guards formal publication/aggregation paths. Pure local publish-website aggregation remains allowed for development
  preview.

  Remaining Phase 4 checks still need to be done after CI / PR validation:

  - confirm main benchmark artifacts aggregate by scenario
  - confirm website display distinguishes random-online and sharegpt-online

  No hardware-specific benchmark run was executed for this PR.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.