### PR TITLE
feat: add prefix repetition perfgate spec

### DIFF
--- a/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
@@ -1,0 +1,56 @@
+{
+  "id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
+  "label": "Performance gate Ascend prefix repetition online baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-prefix-repetition-online",
+    "label": "Performance Gate Ascend Prefix Repetition Online",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "prefix-repetition-online",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "enable_prefix_caching": "",
+    "host": "0.0.0.0",
+    "port": 8000,
+    "dtype": "bfloat16",
+    "max_model_len": 1280,
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "prefix_repetition",
+    "num_prompts": 8,
+    "input_len": 1024,
+    "output_len": 64,
+    "request_rate": 1,
+    "max_concurrency": 4,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -9,6 +9,11 @@
       "scenario": "sharegpt-online",
       "hardware_chip_model": "910B2",
       "spec_file": "docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "prefix-repetition-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json"
     }
   ]
 }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -70,6 +70,43 @@ def test_perfgate_sharegpt_online_spec_is_available_for_ci() -> None:
     assert same_spec["resolved_client_parameters"]["dataset_name"] == "sharegpt"
 
 
+def test_perfgate_prefix_repetition_online_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2"
+    assert spec["scenario"] == "prefix-repetition-online"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["enable_prefix_caching"] == ""
+    assert spec["server_parameters"]["max_model_len"] == 1280
+    assert spec["client_parameters"]["dataset_name"] == "prefix_repetition"
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert spec["client_parameters"]["input_len"] == 1024
+    assert spec["client_parameters"]["output_len"] == 64
+    assert same_spec["scenario"] == "prefix-repetition-online"
+    assert (
+        same_spec["resolved_client_parameters"]["prefix_repetition_prefix_len"]
+        == 768
+    )
+    assert (
+        same_spec["resolved_client_parameters"]["prefix_repetition_suffix_len"]
+        == 256
+    )
+    assert (
+        same_spec["resolved_client_parameters"]["prefix_repetition_output_len"]
+        == 64
+    )
+
+
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
     canonical_dir = tmp_path / _spec()["id"]
     canonical_dir.mkdir(parents=True)

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -43,6 +43,21 @@ def test_resolve_sharegpt_online_perfgate_spec() -> None:
     ).resolve()
 
 
+def test_resolve_prefix_repetition_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="prefix-repetition-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json"
+    ).resolve()
+
+
 def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
     spec_path = perfgate_specs.resolve_perfgate_spec_file(
         scenario="random-online",
@@ -64,6 +79,7 @@ def test_resolve_rejects_unsupported_pair() -> None:
     except ValueError as error:
         message = str(error)
         assert "No perfgate spec registered" in message
+        assert "prefix-repetition-online/910B2" in message
         assert "random-online/910B2" in message
         assert "sharegpt-online/910B2" in message
     else:  # pragma: no cover - assertion guard


### PR DESCRIPTION
## Summary

  Add benchmark-side perfgate coverage for `prefix-repetition-online`.

  This PR adds a lightweight 910B2 perfgate spec for `prefix-repetition-online` and registers it in the shared perfgate spec registry.
  After downstream workflows consume the shared resolver, this scenario can be selected by `(scenario, hardware_chip_model)` without
  adding per-scenario spec paths in `vllm-hust` or `vllm-ascend-hust`.

  This is benchmark-only preparation:
  - adds the perfgate spec
  - adds the registry entry
  - adds resolver/spec tests
  - does not modify downstream workflows
  - does not enable a blocking gate

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m pytest tests/test_perfgate_specs.py tests/test_official_baselines.py tests/test_same_spec.py tests/
  test_registry.py tests/test_cli.py tests/test_sync_official_baseline_snapshots_to_github.py

  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve \
    --scenario prefix-repetition-online \
    --hardware-chip-model 910B2 \
    --repo-root .

  git diff --check

  Result:

  75 passed

  ## Risks

  This PR only prepares the benchmark-side spec and registry entry. It does not modify vllm-hust or vllm-ascend-hust workflows and does
  not enable this scenario as a blocking gate.

  End-to-end downstream validation should be done after the shared resolver workflow changes are merged, especially on the Ascend side.

  No hardware benchmark run was executed for this PR.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.