### PR TITLE
feat: add random latency perfgate spec

### DIFF
--- a/docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json
@@ -1,0 +1,47 @@
+{
+  "id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
+  "label": "Performance gate Ascend random latency baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-random-latency",
+    "label": "Performance Gate Ascend Random Latency",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "random-latency",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "dtype": "bfloat16",
+    "max_model_len": 1280,
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "input_len": 1024,
+    "output_len": 128,
+    "batch_size": 1,
+    "num_iters_warmup": 1,
+    "num_iters": 3
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -14,6 +14,11 @@
       "scenario": "prefix-repetition-online",
       "hardware_chip_model": "910B2",
       "spec_file": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "random-latency",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json"
     }
   ]
 }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -107,6 +107,35 @@ def test_perfgate_prefix_repetition_online_spec_is_available_for_ci() -> None:
     )
 
 
+def test_perfgate_random_latency_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-random-latency-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-random-latency-qwen25-3b-910b2"
+    assert spec["scenario"] == "random-latency"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["max_model_len"] == 1280
+    assert spec["server_parameters"]["max_num_seqs"] == 1
+    assert spec["client_parameters"]["input_len"] == 1024
+    assert spec["client_parameters"]["output_len"] == 128
+    assert spec["client_parameters"]["batch_size"] == 1
+    assert spec["client_parameters"]["num_iters_warmup"] == 1
+    assert spec["client_parameters"]["num_iters"] == 3
+    assert same_spec["scenario"] == "random-latency"
+    assert same_spec["resolved_client_parameters"]["input_len"] == 1024
+    assert same_spec["resolved_client_parameters"]["output_len"] == 128
+    assert same_spec["resolved_client_parameters"]["batch_size"] == 1
+
+
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
     canonical_dir = tmp_path / _spec()["id"]
     canonical_dir.mkdir(parents=True)

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -58,6 +58,21 @@ def test_resolve_prefix_repetition_online_perfgate_spec() -> None:
     ).resolve()
 
 
+def test_resolve_random_latency_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="random-latency",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-random-latency-qwen25-3b-910b2.json"
+    ).resolve()
+
+
 def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
     spec_path = perfgate_specs.resolve_perfgate_spec_file(
         scenario="random-online",
@@ -80,6 +95,7 @@ def test_resolve_rejects_unsupported_pair() -> None:
         message = str(error)
         assert "No perfgate spec registered" in message
         assert "prefix-repetition-online/910B2" in message
+        assert "random-latency/910B2" in message
         assert "random-online/910B2" in message
         assert "sharegpt-online/910B2" in message
     else:  # pragma: no cover - assertion guard


### PR DESCRIPTION
## Summary

  Add benchmark-side perfgate coverage for `random-latency`.

  This PR adds a lightweight 910B2 perfgate spec for `random-latency` and registers it in the shared perfgate spec registry. The spec
  keeps the latency workload shape while using the smaller Qwen2.5-3B BF16 configuration for PR/report-mode practicality.

  This is benchmark-only preparation:
  - adds the perfgate spec
  - adds the registry entry
  - adds resolver/spec tests
  - does not modify downstream workflows
  - does not enable a blocking gate

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve \
    --scenario random-latency \
    --hardware-chip-model 910B2 \
    --repo-root .

  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve \
    --spec-file docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json \
    --output-file /tmp/random-latency-same-spec.json

  PYTHONPATH=src python3 -m pytest \
    tests/test_perfgate_specs.py \
    tests/test_official_baselines.py \
    tests/test_same_spec.py \
    tests/test_registry.py \
    tests/test_cli.py \
    tests/test_sync_official_baseline_snapshots_to_github.py

  git -C vllm-hust-benchmark diff --check

  Result:

  78 passed

  ## Risks

  This PR only prepares the benchmark-side spec and registry entry. It does not modify vllm-hust or vllm-ascend-hust workflows and does
  not enable this scenario as a blocking gate.

  End-to-end downstream validation should be done after the shared resolver workflow changes are merged, especially on the Ascend side.

  No hardware benchmark run was executed for this PR.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.