### PR TITLE
feat: add sharegpt throughput perfgate spec

### DIFF
--- a/docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json
@@ -1,0 +1,46 @@
+{
+  "id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
+  "label": "Performance gate Ascend ShareGPT throughput baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-sharegpt-throughput",
+    "label": "Performance Gate Ascend ShareGPT Throughput",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "sharegpt-throughput",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "dataset_name": "sharegpt",
+    "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+    "num_prompts": 8,
+    "num_warmups": 0
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -19,6 +19,11 @@
       "scenario": "random-latency",
       "hardware_chip_model": "910B2",
       "spec_file": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "sharegpt-throughput",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json"
     }
   ]
 }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -136,6 +136,36 @@ def test_perfgate_random_latency_spec_is_available_for_ci() -> None:
     assert same_spec["resolved_client_parameters"]["batch_size"] == 1
 
 
+def test_perfgate_sharegpt_throughput_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2"
+    assert spec["scenario"] == "sharegpt-throughput"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["dtype"] == "bfloat16"
+    assert spec["server_parameters"]["max_num_seqs"] == 1
+    assert spec["client_parameters"]["dataset_name"] == "sharegpt"
+    assert (
+        spec["client_parameters"]["dataset_path"]
+        == "ShareGPT_V3_unfiltered_cleaned_split.json"
+    )
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert spec["client_parameters"]["num_warmups"] == 0
+    assert same_spec["scenario"] == "sharegpt-throughput"
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "sharegpt"
+    assert same_spec["resolved_client_parameters"]["num_prompts"] == 8
+
+
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
     canonical_dir = tmp_path / _spec()["id"]
     canonical_dir.mkdir(parents=True)

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -73,6 +73,21 @@ def test_resolve_random_latency_perfgate_spec() -> None:
     ).resolve()
 
 
+def test_resolve_sharegpt_throughput_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="sharegpt-throughput",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json"
+    ).resolve()
+
+
 def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
     spec_path = perfgate_specs.resolve_perfgate_spec_file(
         scenario="random-online",
@@ -98,6 +113,7 @@ def test_resolve_rejects_unsupported_pair() -> None:
         assert "random-latency/910B2" in message
         assert "random-online/910B2" in message
         assert "sharegpt-online/910B2" in message
+        assert "sharegpt-throughput/910B2" in message
     else:  # pragma: no cover - assertion guard
         raise AssertionError("expected unsupported pair to fail")
 


### PR DESCRIPTION
## Summary

  Add benchmark-side perfgate coverage for `sharegpt-throughput`.

  This PR adds a lightweight 910B2 perfgate spec for `sharegpt-throughput` and registers it in the shared perfgate spec registry. The spec
  keeps the ShareGPT throughput workload shape while using the smaller Qwen2.5-3B BF16 configuration for PR/report-mode practicality.

  This is benchmark-only preparation:
  - adds the perfgate spec
  - adds the registry entry
  - adds resolver/spec tests
  - does not modify downstream workflows
  - does not enable a blocking gate
  - does not generate formal leaderboard data

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve \
    --scenario sharegpt-throughput \
    --hardware-chip-model 910B2 \
    --repo-root .

  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve \
    --spec-file docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json \
    --output-file /tmp/sharegpt-throughput-same-spec.json

  PYTHONPATH=src python3 -m pytest \
    tests/test_perfgate_specs.py \
    tests/test_official_baselines.py \
    tests/test_same_spec.py \
    tests/test_registry.py \
    tests/test_cli.py \
    tests/test_sync_official_baseline_snapshots_to_github.py

  git -C vllm-hust-benchmark diff --check

  Result:

  80 passed

  ## Risks

  This PR only prepares the benchmark-side spec and registry entry. It does not modify vllm-hust or vllm-ascend-hust workflows and does
  not enable this scenario as a blocking gate.

  sharegpt-throughput depends on the ShareGPT dataset being available on the runner when this scenario is actually executed downstream.

  End-to-end downstream validation should be done in report-only/manual mode before deciding whether this scenario can become blocking.

  No hardware benchmark run was executed for this PR.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.