### PR TITLE
feat: add text scenario perfgate specs

### DIFF
--- a/docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json
@@ -1,0 +1,53 @@
+{
+  "id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
+  "label": "Performance gate Ascend agent research online baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-agent-research-online",
+    "label": "Performance Gate Ascend Agent Research Online",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "agent-research-online",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000,
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "openai-chat",
+    "endpoint": "/v1/chat/completions",
+    "dataset_name": "custom",
+    "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+    "num_prompts": 8,
+    "request_rate": 1,
+    "max_concurrency": 4,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json
@@ -1,0 +1,54 @@
+{
+  "id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
+  "label": "Performance gate Ascend InstructCoder online baseline for Qwen2.5-Coder-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-instructcoder-online",
+    "label": "Performance Gate Ascend InstructCoder Online",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "instructcoder-online",
+  "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000,
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "hf",
+    "dataset_path": "likaixin/InstructCoder",
+    "no_stream": true,
+    "num_prompts": 8,
+    "request_rate": 1,
+    "max_concurrency": 4,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json
@@ -1,0 +1,46 @@
+{
+  "id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
+  "label": "Performance gate Ascend sonnet throughput baseline for Qwen2.5-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-sonnet-throughput",
+    "label": "Performance Gate Ascend Sonnet Throughput",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "sonnet-throughput",
+  "model": "Qwen/Qwen2.5-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "dataset_name": "sonnet",
+    "dataset_path": "benchmarks/sonnet.txt",
+    "num_prompts": 8,
+    "num_warmups": 0
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -19,6 +19,21 @@
       "scenario": "random-latency",
       "hardware_chip_model": "910B2",
       "spec_file": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "sonnet-throughput",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "instructcoder-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json"
+    },
+    {
+      "scenario": "agent-research-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json"
     }
   ]
 }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -136,6 +136,85 @@ def test_perfgate_random_latency_spec_is_available_for_ci() -> None:
     assert same_spec["resolved_client_parameters"]["batch_size"] == 1
 
 
+def test_perfgate_sonnet_throughput_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2"
+    assert spec["scenario"] == "sonnet-throughput"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["dtype"] == "bfloat16"
+    assert spec["client_parameters"]["dataset_name"] == "sonnet"
+    assert spec["client_parameters"]["dataset_path"] == "benchmarks/sonnet.txt"
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert same_spec["scenario"] == "sonnet-throughput"
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "sonnet"
+
+
+def test_perfgate_instructcoder_online_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2"
+    assert spec["scenario"] == "instructcoder-online"
+    assert spec["model"] == "Qwen/Qwen2.5-Coder-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["dtype"] == "bfloat16"
+    assert spec["client_parameters"]["dataset_name"] == "hf"
+    assert spec["client_parameters"]["dataset_path"] == "likaixin/InstructCoder"
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert spec["client_parameters"]["no_stream"] is True
+    assert same_spec["scenario"] == "instructcoder-online"
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "hf"
+    assert same_spec["resolved_client_parameters"]["num_prompts"] == 8
+
+
+def test_perfgate_agent_research_online_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-agent-research-online-qwen25-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-agent-research-online-qwen25-3b-910b2"
+    assert spec["scenario"] == "agent-research-online"
+    assert spec["model"] == "Qwen/Qwen2.5-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["dtype"] == "bfloat16"
+    assert spec["client_parameters"]["backend"] == "openai-chat"
+    assert spec["client_parameters"]["dataset_name"] == "custom"
+    assert (
+        spec["client_parameters"]["dataset_path"]
+        == "scripts/traces/evoscientist-workload-custom.jsonl"
+    )
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert same_spec["scenario"] == "agent-research-online"
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "custom"
+    assert same_spec["resolved_client_parameters"]["num_prompts"] == 8
+
+
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
     canonical_dir = tmp_path / _spec()["id"]
     canonical_dir.mkdir(parents=True)

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -73,6 +73,51 @@ def test_resolve_random_latency_perfgate_spec() -> None:
     ).resolve()
 
 
+def test_resolve_sonnet_throughput_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="sonnet-throughput",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json"
+    ).resolve()
+
+
+def test_resolve_instructcoder_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="instructcoder-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json"
+    ).resolve()
+
+
+def test_resolve_agent_research_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="agent-research-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-agent-research-online-qwen25-3b-910b2.json"
+    ).resolve()
+
+
 def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
     spec_path = perfgate_specs.resolve_perfgate_spec_file(
         scenario="random-online",
@@ -94,10 +139,13 @@ def test_resolve_rejects_unsupported_pair() -> None:
     except ValueError as error:
         message = str(error)
         assert "No perfgate spec registered" in message
+        assert "agent-research-online/910B2" in message
+        assert "instructcoder-online/910B2" in message
         assert "prefix-repetition-online/910B2" in message
         assert "random-latency/910B2" in message
         assert "random-online/910B2" in message
         assert "sharegpt-online/910B2" in message
+        assert "sonnet-throughput/910B2" in message
     else:  # pragma: no cover - assertion guard
         raise AssertionError("expected unsupported pair to fail")
 


### PR DESCRIPTION
## Summary

  Add benchmark-side perfgate coverage for three text scenarios:

  - `sonnet-throughput`
  - `instructcoder-online`
  - `agent-research-online`

  This PR adds lightweight 910B2 perfgate specs and registers them in the shared perfgate spec registry, so downstream workflows can
  resolve these scenarios through the existing shared resolver.

  This is benchmark-only case onboarding:
  - adds perfgate spec files
  - adds registry entries
  - adds resolver/spec tests
  - does not modify downstream workflows
  - does not enable new blocking gates by itself
  - does not generate formal leaderboard data

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario sonnet-throughput --hardware-chip-model 910B2 --repo-
  root .
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario instructcoder-online --hardware-chip-model 910B2 --repo-
  root .
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario agent-research-online --hardware-chip-model 910B2
  --repo-root .

  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve --spec-file docs/official-baselines/perfgate-ascend-sonnet-throughput-
  qwen25-3b-910b2.json --output-file /tmp/sonnet-throughput-same-spec.json
  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve --spec-file docs/official-baselines/perfgate-ascend-instructcoder-
  online-qwen25-coder-3b-910b2.json --output-file /tmp/instructcoder-online-same-spec.json
  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve --spec-file docs/official-baselines/perfgate-ascend-agent-research-
  online-qwen25-3b-910b2.json --output-file /tmp/agent-research-online-same-spec.json

  PYTHONPATH=src python3 -m pytest tests/test_perfgate_specs.py tests/test_official_baselines.py tests/test_same_spec.py tests/
  test_registry.py tests/test_cli.py tests/test_sync_official_baseline_snapshots_to_github.py

  git -C vllm-hust-benchmark diff --check origin/main...HEAD

  Result: 84 passed.

  ## Risks

  Runtime execution still depends on Ascend runner availability, model/data availability, and downstream workflow readiness.

  This PR may need a small rebase if another perfgate registry PR merges first, because registry/test files are shared.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.