### PR TITLE
Feat/perfgate visionarena registry

### DIFF
--- a/docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json
@@ -1,0 +1,57 @@
+{
+  "id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
+  "label": "Performance gate Ascend VisionArena online baseline for Qwen2.5-VL-3B on 910B2",
+  "baseline_target": {
+    "id": "perfgate-ascend-visionarena-online",
+    "label": "Performance Gate Ascend VisionArena Online",
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "vllm_ref": "main",
+    "vllm_ascend_ref": "main"
+  },
+  "scenario": "visionarena-online",
+  "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+  "model_parameters": "3B",
+  "model_precision": "BF16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "limit_mm_per_prompt": {
+      "image": 1
+    },
+    "host": "0.0.0.0",
+    "port": 8000,
+    "dtype": "bfloat16",
+    "max_num_seqs": 1
+  },
+  "client_parameters": {
+    "backend": "openai-chat",
+    "endpoint": "/v1/chat/completions",
+    "dataset_name": "hf",
+    "dataset_path": "lmarena-ai/VisionArena-Chat",
+    "hf_split": "train",
+    "num_prompts": 8,
+    "request_rate": 1,
+    "max_concurrency": 4,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm-hust",
+    "engine_version": "main",
+    "submitter": "vllm-hust-perfgate",
+    "baseline_engine": "vllm-hust",
+    "github_repository": "vLLM-HUST/vllm-hust",
+    "github_ref": "main",
+    "git_commit": null,
+    "data_source": "vllm-hust-ci-perfgate-same-spec"
+  }
+}

--- a/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
+++ b/src/vllm_hust_benchmark/data/perfgate_spec_registry.json
@@ -19,6 +19,11 @@
       "scenario": "random-latency",
       "hardware_chip_model": "910B2",
       "spec_file": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json"
+    },
+    {
+      "scenario": "visionarena-online",
+      "hardware_chip_model": "910B2",
+      "spec_file": "docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json"
     }
   ]
 }

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -136,6 +136,38 @@ def test_perfgate_random_latency_spec_is_available_for_ci() -> None:
     assert same_spec["resolved_client_parameters"]["batch_size"] == 1
 
 
+def test_perfgate_visionarena_online_spec_is_available_for_ci() -> None:
+    spec_file = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json"
+    )
+    spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    same_spec = build_same_spec_payload(spec)
+
+    assert spec["id"] == "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2"
+    assert spec["scenario"] == "visionarena-online"
+    assert spec["model"] == "Qwen/Qwen2.5-VL-3B-Instruct"
+    assert spec["model_parameters"] == "3B"
+    assert spec["model_precision"] == "BF16"
+    assert spec["hardware_chip_model"] == "910B2"
+    assert spec["server_parameters"]["dtype"] == "bfloat16"
+    assert spec["server_parameters"]["limit_mm_per_prompt"] == {"image": 1}
+    assert spec["client_parameters"]["backend"] == "openai-chat"
+    assert spec["client_parameters"]["endpoint"] == "/v1/chat/completions"
+    assert spec["client_parameters"]["dataset_name"] == "hf"
+    assert spec["client_parameters"]["dataset_path"] == "lmarena-ai/VisionArena-Chat"
+    assert spec["client_parameters"]["hf_split"] == "train"
+    assert spec["client_parameters"]["num_prompts"] == 8
+    assert same_spec["scenario"] == "visionarena-online"
+    assert same_spec["resolved_server_parameters"]["limit_mm_per_prompt"] == {
+        "image": 1
+    }
+    assert same_spec["resolved_client_parameters"]["dataset_name"] == "hf"
+    assert same_spec["resolved_client_parameters"]["num_prompts"] == 8
+
+
 def test_has_canonical_run_requires_matching_spec_id_and_submitter(tmp_path: Path) -> None:
     canonical_dir = tmp_path / _spec()["id"]
     canonical_dir.mkdir(parents=True)

--- a/tests/test_perfgate_specs.py
+++ b/tests/test_perfgate_specs.py
@@ -73,6 +73,21 @@ def test_resolve_random_latency_perfgate_spec() -> None:
     ).resolve()
 
 
+def test_resolve_visionarena_online_perfgate_spec() -> None:
+    spec_path = perfgate_specs.resolve_perfgate_spec_file(
+        scenario="visionarena-online",
+        hardware_chip_model="910B2",
+        repo_root=REPO_ROOT,
+    )
+
+    assert spec_path == (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json"
+    ).resolve()
+
+
 def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
     spec_path = perfgate_specs.resolve_perfgate_spec_file(
         scenario="random-online",
@@ -87,7 +102,7 @@ def test_resolve_without_repo_root_returns_repo_relative_path() -> None:
 def test_resolve_rejects_unsupported_pair() -> None:
     try:
         perfgate_specs.resolve_perfgate_spec_file(
-            scenario="visionarena-online",
+            scenario="sonnet-throughput",
             hardware_chip_model="910B2",
             repo_root=REPO_ROOT,
         )
@@ -98,6 +113,7 @@ def test_resolve_rejects_unsupported_pair() -> None:
         assert "random-latency/910B2" in message
         assert "random-online/910B2" in message
         assert "sharegpt-online/910B2" in message
+        assert "visionarena-online/910B2" in message
     else:  # pragma: no cover - assertion guard
         raise AssertionError("expected unsupported pair to fail")
 
@@ -288,7 +304,7 @@ def test_cli_resolve_failure_uses_stderr(capsys) -> None:
         [
             "resolve",
             "--scenario",
-            "visionarena-online",
+            "sonnet-throughput",
             "--hardware-chip-model",
             "910B2",
             "--repo-root",


### PR DESCRIPTION
## Summary

  Add benchmark-side perfgate coverage for the `visionarena-online` multimodal scenario.

  This PR adds a lightweight 910B2 perfgate spec for `visionarena-online` using `Qwen/Qwen2.5-VL-3B-Instruct`, and registers it in the
  shared perfgate spec registry so downstream workflows can resolve it through the existing shared resolver.

  This is benchmark-only case onboarding:
  - adds the `visionarena-online` perfgate spec
  - adds the registry entry
  - adds resolver/spec tests
  - does not modify downstream workflows
  - does not enable a new blocking gate by itself
  - does not generate formal leaderboard data

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_specs resolve --scenario visionarena-online --hardware-chip-model 910B2 --repo-
  root .

  PYTHONPATH=src python3 -m vllm_hust_benchmark.same_spec resolve --spec-file docs/official-baselines/perfgate-ascend-visionarena-online-
  qwen25-vl-3b-910b2.json --output-file /tmp/visionarena-online-same-spec.json

  PYTHONPATH=src python3 -m pytest tests/test_perfgate_specs.py tests/test_official_baselines.py tests/test_same_spec.py tests/
  test_registry.py tests/test_cli.py tests/test_sync_official_baseline_snapshots_to_github.py

  git -C vllm-hust-benchmark diff --check

  Result: 88 passed.

  ## Risks

  Runtime execution still depends on Ascend runner availability, model/data availability, and multimodal serving compatibility for Qwen/
  Qwen2.5-VL-3B-Instruct.

  This PR validates spec/registry/resolver behavior locally, but does not run the full Ascend hardware benchmark.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.