### PR TITLE
Fix snapshot-only publication to Hugging Face

### DIFF
--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -169,13 +169,16 @@ jobs:
           backfill_existing_only = os.environ.get("BACKFILL_EXISTING_ONLY", "").lower() == "true"
           manual_submission_dirs = os.environ.get("MANUAL_SUBMISSION_DIRS", "")
           submissions_root = Path("submissions")
+          snapshot_root = Path("leaderboard-data/snapshots")
 
-          def collect_submission_dirs_from_diff(diff_args: list[str]) -> list[str]:
+          def collect_changed_paths(diff_args: list[str]) -> list[Path]:
               diff_output = subprocess.check_output(diff_args, text=True)
+              return [Path(raw_path.strip()) for raw_path in diff_output.splitlines() if raw_path.strip()]
+
+          def collect_submission_dirs(changed_paths: list[Path]) -> list[str]:
               resolved_dirs: list[str] = []
               seen: set[str] = set()
-              for raw_path in diff_output.splitlines():
-                  path = Path(raw_path.strip())
+              for path in changed_paths:
                   if len(path.parts) < 2 or path.parts[0] != "submissions":
                       continue
                   candidate = submissions_root / path.parts[1]
@@ -188,6 +191,7 @@ jobs:
               return resolved_dirs
 
           submission_dirs: list[str] = []
+          changed_paths: list[Path] = []
           if backfill_existing_only:
               print("Backfill existing-only mode enabled; skipping local submission directory resolution.")
           elif manual_submission_dirs.strip():
@@ -206,18 +210,41 @@ jobs:
                           seen.add(resolved)
                           submission_dirs.append(resolved)
           elif event_name == "push" and before_sha and current_sha and before_sha != "0000000000000000000000000000000000000000":
-              diff_args = ["git", "diff", "--name-only", before_sha, current_sha, "--", "submissions"]
+              diff_args = [
+                  "git",
+                  "diff",
+                  "--name-only",
+                  before_sha,
+                  current_sha,
+                  "--",
+                  "submissions",
+                  str(snapshot_root),
+              ]
               try:
-                  submission_dirs = collect_submission_dirs_from_diff(diff_args)
+                  changed_paths = collect_changed_paths(diff_args)
               except subprocess.CalledProcessError:
-                  fallback_args = ["git", "diff", "--name-only", "origin/main...HEAD", "--", "submissions"]
+                  fallback_args = [
+                      "git",
+                      "diff",
+                      "--name-only",
+                      "origin/main...HEAD",
+                      "--",
+                      "submissions",
+                      str(snapshot_root),
+                  ]
                   print(
                       f"Unable to diff push range {before_sha}..{current_sha}; "
                       "falling back to origin/main...HEAD."
                   )
-                  submission_dirs = collect_submission_dirs_from_diff(fallback_args)
+                  changed_paths = collect_changed_paths(fallback_args)
+              submission_dirs = collect_submission_dirs(changed_paths)
           else:
               submission_dirs = [str(path.parent.resolve()) for path in sorted(submissions_root.rglob("leaderboard_manifest.json"))]
+
+          snapshots_changed = any(
+              path == snapshot_root or snapshot_root in path.parents
+              for path in changed_paths
+          )
 
           print("Submission dirs to sync:")
           for item in submission_dirs:
@@ -225,6 +252,7 @@ jobs:
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"count={len(submission_dirs)}\n")
+              fh.write(f"snapshots_changed={'true' if snapshots_changed else 'false'}\n")
               fh.write("dirs<<EOF\n")
               for item in submission_dirs:
                   fh.write(item + "\n")
@@ -236,12 +264,13 @@ jobs:
           MANUAL_SUBMISSION_DIRS: ${{ github.event.inputs.submission_dirs }}
 
       - name: Sync submissions into HF leaderboard snapshots
-        if: ${{ steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true' || github.event.inputs.skip_aggregation == 'true' }}
+        id: sync-hf
+        if: ${{ steps.resolve-submissions.outputs.count != '0' || steps.resolve-submissions.outputs.snapshots_changed == 'true' || github.event.inputs.backfill_existing_only == 'true' || github.event.inputs.skip_aggregation == 'true' }}
         env:
           HF_TOKEN: ${{ secrets.DATASET_WRITE_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           BACKFILL_EXISTING_ONLY: ${{ github.event.inputs.backfill_existing_only || 'false' }}
-          SKIP_AGGREGATION: ${{ github.event.inputs.skip_aggregation || 'false' }}
+          SKIP_AGGREGATION: ${{ github.event.inputs.skip_aggregation == 'true' || (steps.resolve-submissions.outputs.count == '0' && steps.resolve-submissions.outputs.snapshots_changed == 'true') }}
           VLLM_HUST_REPO: ${{ github.workspace }}/vllm-hust
           VLLM_HUST_WEBSITE_REPO: ${{ github.workspace }}/vllm-hust-website
         run: |
@@ -286,6 +315,70 @@ jobs:
             --execute \
             "${extra_args[@]}"
 
+      - name: Verify HF snapshots match GitHub canonical snapshots
+        if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}
+        env:
+          HF_TOKEN: ${{ secrets.DATASET_WRITE_TOKEN }}
+        run: |
+          python - << 'PYEOF'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          from huggingface_hub import HfApi, hf_hub_download
+
+          repo_id = "intellistream/vllm-hust-benchmark-results"
+          snapshot_dir = Path("leaderboard-data/snapshots")
+          snapshot_files = (
+              "leaderboard_single.json",
+              "leaderboard_multi.json",
+              "leaderboard_compare.json",
+              "last_updated.json",
+          )
+
+          api = HfApi()
+          revision = api.dataset_info(repo_id=repo_id, revision="main").sha
+          failures = []
+
+          for file_name in snapshot_files:
+              local_path = snapshot_dir / file_name
+              remote_path = Path(
+                  hf_hub_download(
+                      repo_id=repo_id,
+                      repo_type="dataset",
+                      filename=file_name,
+                      revision=revision,
+                      force_download=True,
+                  )
+              )
+              local_bytes = local_path.read_bytes()
+              remote_bytes = remote_path.read_bytes()
+              local_sha = hashlib.sha256(local_bytes).hexdigest()
+              remote_sha = hashlib.sha256(remote_bytes).hexdigest()
+
+              payload = json.loads(remote_bytes)
+              if isinstance(payload, list):
+                  summary = f"entries={len(payload)}"
+              elif "group_count" in payload:
+                  summary = f"groups={payload['group_count']}"
+              else:
+                  summary = f"last_updated={payload.get('last_updated')}"
+
+              print(
+                  f"{file_name}: {summary}, github_sha256={local_sha}, "
+                  f"hf_sha256={remote_sha}, hf_revision={revision}"
+              )
+              if local_bytes != remote_bytes:
+                  failures.append(file_name)
+
+          if failures:
+              raise SystemExit(
+                  "HF snapshot verification failed for: " + ", ".join(failures)
+              )
+
+          print("HF snapshots match GitHub canonical snapshots byte-for-byte.")
+          PYEOF
+
       - name: Dry run summary
         if: ${{ github.event.inputs.dry_run == 'true' && (steps.resolve-submissions.outputs.count != '0' || github.event.inputs.backfill_existing_only == 'true') }}
         run: |
@@ -293,5 +386,5 @@ jobs:
           ls -lh /tmp/leaderboard-data/
 
       - name: No submissions to sync
-        if: ${{ steps.resolve-submissions.outputs.count == '0' && github.event.inputs.backfill_existing_only != 'true' }}
+        if: ${{ steps.resolve-submissions.outputs.count == '0' && steps.resolve-submissions.outputs.snapshots_changed != 'true' && github.event.inputs.backfill_existing_only != 'true' && github.event.inputs.skip_aggregation != 'true' }}
         run: echo "No submission directories matched this event; nothing to upload."

--- a/tests/test_push_to_hf_workflow.py
+++ b/tests/test_push_to_hf_workflow.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/push-to-hf.yml"
+
+
+def test_snapshot_only_push_uploads_canonical_snapshots_to_hf() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert 'snapshot_root = Path("leaderboard-data/snapshots")' in workflow_text
+    assert "fh.write(f\"snapshots_changed={'true' if snapshots_changed else 'false'}\\n\")" in workflow_text
+    assert "steps.resolve-submissions.outputs.snapshots_changed == 'true'" in workflow_text
+    assert (
+        "steps.resolve-submissions.outputs.count == '0' && "
+        "steps.resolve-submissions.outputs.snapshots_changed == 'true'"
+    ) in workflow_text
+    assert "Verify HF snapshots match GitHub canonical snapshots" in workflow_text
+    assert "HF snapshots match GitHub canonical snapshots byte-for-byte." in workflow_text
+
+
+def test_submission_push_keeps_the_aggregation_path() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "steps.resolve-submissions.outputs.count != '0'" in workflow_text
+    assert 'if [[ "$SKIP_AGGREGATION" != "true" ]]; then' in workflow_text
+    assert 'submission_args+=(--submission-dir "$submission_dir")' in workflow_text


### PR DESCRIPTION
## What changed

- detect `leaderboard-data/snapshots/**` changes in the HF publish workflow
- upload the checked-in canonical snapshots when a push changes snapshots without adding a submission
- keep the existing aggregation path for pushes that contain new submissions
- read the resulting HF revision back and require all four snapshot files to match GitHub byte-for-byte
- add workflow regression coverage for both paths

## Root cause

The workflow ran on every push to `main`, but its push resolver only examined `submissions/**`. Snapshot-only updates therefore produced a successful no-op and left the HF dataset behind GitHub.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` — 209 passed
- workflow YAML parsed successfully
- `git diff --check`
- recovery run [29693768627](https://github.com/vLLM-HUST/vllm-hust-benchmark/actions/runs/29693768627) uploaded the four canonical snapshot files
- branch verification run [29693983024](https://github.com/vLLM-HUST/vllm-hust-benchmark/actions/runs/29693983024) read HF revision `0bd4bc11bb88963b7074fc4afc8b57c370614fe7` back and confirmed all four files match GitHub byte-for-byte (`single=110`, `multi=36`, `compare groups=19`)