### PR TITLE
fix(ci): harden Ascend same-spec startup reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,59 +13,10 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    env:
-      BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
     steps:
-      - name: Require GitHub SSH checkout key
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
-            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
-            exit 1
-          fi
-
-      - name: Configure GitHub SSH
-        shell: bash
-        run: |
-          set -euo pipefail
-          ssh_dir="$HOME/.ssh"
-          config_file="$ssh_dir/config"
-          key_file="$ssh_dir/github_actions"
-
-          if [[ ! -d "$ssh_dir" ]]; then
-            mkdir -p "$ssh_dir"
-          fi
-          chmod 700 "$ssh_dir"
-
-          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$key_file"
-          chmod 600 "$key_file"
-
-          config_block="$(cat <<'EOF'
-          Host github.com
-            HostName github.com
-            User git
-            IdentityFile ~/.ssh/github_actions
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
-          )"
-
-          if [[ ! -f "$config_file" ]]; then
-            printf '%s\n' "$config_block" > "$config_file"
-          elif ! grep -Fq 'Host github.com' "$config_file" \
-            || ! grep -Fq 'HostName github.com' "$config_file" \
-            || ! grep -Fq 'IdentityFile ~/.ssh/github_actions' "$config_file"; then
-            printf '\n%s\n' "$config_block" >> "$config_file"
-          fi
-
-          chmod 600 "$config_file"
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
-          ssh-strict: false
           persist-credentials: false
 
       - name: Setup Python

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -61,6 +61,7 @@ SERVER_START_RETRY_DELAY_SECONDS=${SERVER_START_RETRY_DELAY_SECONDS:-10}
 SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}
 SERVER_LOG_PROGRESS_INTERVAL_SECONDS=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS:-120}
 SERVER_LOG_PROGRESS_TAIL_LINES=${SERVER_LOG_PROGRESS_TAIL_LINES:-40}
+READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
@@ -785,15 +786,24 @@ assert_target_port_available() {
 probe_server_ready() {
   local host=$1
   local port=$2
+  local verbose=${3:-0}
   local ready_path
+  local url
+  local curl_output
   local ready_paths=(
     "/health"
+    "/ping"
     "/v1/models"
   )
 
   for ready_path in "${ready_paths[@]}"; do
-    if curl -fsS "http://${host}:${port}${ready_path}" >/dev/null 2>&1; then
+    url="http://${host}:${port}${ready_path}"
+    if curl --noproxy "*" -fsS --connect-timeout 2 --max-time "$READY_PROBE_TIMEOUT_SECONDS" "$url" >/dev/null 2>&1; then
       return 0
+    fi
+    if [[ "$verbose" == "1" ]]; then
+      curl_output="$(curl --noproxy "*" -fsS --connect-timeout 2 --max-time "$READY_PROBE_TIMEOUT_SECONDS" "$url" 2>&1 >/dev/null || true)"
+      echo "[same-spec-current] readiness probe failed: ${url}${curl_output:+ (${curl_output})}" >&2
     fi
   done
 
@@ -858,6 +868,7 @@ wait_for_server() {
       next_status_at=$((waited + status_interval_sec))
     fi
     if (( waited >= next_log_progress_at )); then
+      probe_server_ready "$host" "$port" 1 || true
       if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
         echo "---- same-spec server log progress at ${waited}s: ${SERVER_STDOUT_LOG} (last ${SERVER_LOG_PROGRESS_TAIL_LINES} lines) ----" >&2
         print_server_log_tail "$SERVER_STDOUT_LOG" "$SERVER_LOG_PROGRESS_TAIL_LINES"

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -56,11 +56,15 @@ RUN_ID=${RUN_ID:-"current-ascend-same-spec-$(date -u +%Y%m%dT%H%M%SZ)"}
 READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-600}
 READY_STATUS_INTERVAL_SECONDS=${READY_STATUS_INTERVAL_SECONDS:-30}
 CLIENT_READY_CHECK_TIMEOUT_SECONDS=${CLIENT_READY_CHECK_TIMEOUT_SECONDS:-$READY_TIMEOUT_SECONDS}
-SERVER_START_RETRIES=${SERVER_START_RETRIES:-3}
+# Workflow callers own node-level retries. Keep this runner single-attempt by
+# default so nested orchestration cannot multiply retries.
+SERVER_START_RETRIES=${SERVER_START_RETRIES:-1}
 SERVER_START_RETRY_DELAY_SECONDS=${SERVER_START_RETRY_DELAY_SECONDS:-10}
 SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}
 SERVER_LOG_PROGRESS_INTERVAL_SECONDS=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS:-120}
 SERVER_LOG_PROGRESS_TAIL_LINES=${SERVER_LOG_PROGRESS_TAIL_LINES:-40}
+SERVER_LOG_OOM_CHECK_INTERVAL_SECONDS=${SERVER_LOG_OOM_CHECK_INTERVAL_SECONDS:-2}
+CLIENT_SERVER_MONITOR_INTERVAL_SECONDS=${CLIENT_SERVER_MONITOR_INTERVAL_SECONDS:-1}
 READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}
 NPU_OOM_EXIT_CODE=87
 SERVER_PID=""
@@ -881,6 +885,7 @@ wait_for_server() {
   local log_progress_interval_sec=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS}
   local next_status_at=0
   local next_log_progress_at=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS}
+  local next_oom_check_at=0
 
   if (( status_interval_sec <= 0 )); then
     status_interval_sec=30
@@ -890,6 +895,15 @@ wait_for_server() {
   fi
 
   while (( waited < timeout_sec )); do
+    if (( waited >= next_oom_check_at )); then
+      if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]] \
+        && server_log_indicates_npu_oom "$SERVER_STDOUT_LOG"; then
+        echo "Detected Ascend NPU out of memory while waiting for current same-spec startup; refusing to retry" >&2
+        return "$NPU_OOM_EXIT_CODE"
+      fi
+      next_oom_check_at=$((waited + SERVER_LOG_OOM_CHECK_INTERVAL_SECONDS))
+    fi
+
     if [[ -n "${SERVER_PID:-}" ]] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
       echo "Current same-spec server exited before becoming ready" >&2
       if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
@@ -944,6 +958,43 @@ wait_for_server() {
     fi
   fi
   return 1
+}
+
+run_client_command_with_server_monitor() {
+  local client_pid
+  local client_status
+
+  if [[ "${BENCHMARK_TYPE:-}" != "serve" ]]; then
+    run_client_command
+    return $?
+  fi
+
+  run_client_command &
+  client_pid=$!
+
+  while kill -0 "$client_pid" 2>/dev/null; do
+    if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]] \
+      && server_log_indicates_npu_oom "$SERVER_STDOUT_LOG"; then
+      echo "Detected Ascend NPU out of memory while running the same-spec benchmark client" >&2
+      cleanup_managed_server || true
+      if command -v pkill >/dev/null 2>&1; then
+        pkill -TERM -P "$client_pid" >/dev/null 2>&1 || true
+      fi
+      kill -TERM "$client_pid" >/dev/null 2>&1 || true
+      wait "$client_pid" >/dev/null 2>&1 || true
+      return "$NPU_OOM_EXIT_CODE"
+    fi
+    sleep "$CLIENT_SERVER_MONITOR_INTERVAL_SECONDS"
+  done
+
+  wait "$client_pid"
+  client_status=$?
+  if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]] \
+    && server_log_indicates_npu_oom "$SERVER_STDOUT_LOG"; then
+    echo "Detected Ascend NPU out of memory during the same-spec benchmark client run" >&2
+    return "$NPU_OOM_EXIT_CODE"
+  fi
+  return "$client_status"
 }
 
 kill_server() {
@@ -1090,7 +1141,13 @@ elif [[ "${CURRENT_ALLOW_OFFLINE_EAGER_BENCHMARK:-0}" != "1" ]]; then
 	exit 86
 fi
 
-run_client_command
+set +e
+run_client_command_with_server_monitor
+client_status=$?
+set -e
+if [[ "$client_status" -ne 0 ]]; then
+  exit "$client_status"
+fi
 
 EXPORT_ARGS=(
   "$SCENARIO"

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -789,7 +789,8 @@ probe_server_ready() {
   local verbose=${3:-0}
   local ready_path
   local url
-  local curl_output
+  local probe_output
+  local probe_status
   local ready_paths=(
     "/health"
     "/ping"
@@ -798,12 +799,48 @@ probe_server_ready() {
 
   for ready_path in "${ready_paths[@]}"; do
     url="http://${host}:${port}${ready_path}"
-    if curl --noproxy "*" -fsS --connect-timeout 2 --max-time "$READY_PROBE_TIMEOUT_SECONDS" "$url" >/dev/null 2>&1; then
+    set +e
+    probe_output="$("$CURRENT_RUNTIME_PYTHON" - "$host" "$port" "$ready_path" "$READY_PROBE_TIMEOUT_SECONDS" <<'PY' 2>&1
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+path = sys.argv[3]
+timeout = float(sys.argv[4])
+
+try:
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        request = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+        )
+        sock.sendall(request.encode("ascii"))
+        response = sock.recv(256).decode("iso-8859-1", errors="replace")
+except Exception as exc:
+    print(f"{exc.__class__.__name__}: {exc}")
+    raise SystemExit(1)
+
+status_line = response.splitlines()[0] if response else ""
+parts = status_line.split()
+if len(parts) >= 2 and parts[1].isdigit() and 200 <= int(parts[1]) < 400:
+    print(status_line)
+    raise SystemExit(0)
+
+print(status_line or "empty response")
+raise SystemExit(1)
+PY
+)"
+    probe_status=$?
+    set -e
+    if [[ "$probe_status" -eq 0 ]]; then
       return 0
     fi
     if [[ "$verbose" == "1" ]]; then
-      curl_output="$(curl --noproxy "*" -fsS --connect-timeout 2 --max-time "$READY_PROBE_TIMEOUT_SECONDS" "$url" 2>&1 >/dev/null || true)"
-      echo "[same-spec-current] readiness probe failed: ${url}${curl_output:+ (${curl_output})}" >&2
+      echo "[same-spec-current] readiness probe failed: ${url}${probe_output:+ (${probe_output})}" >&2
     fi
   done
 

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -59,6 +59,8 @@ CLIENT_READY_CHECK_TIMEOUT_SECONDS=${CLIENT_READY_CHECK_TIMEOUT_SECONDS:-$READY_
 SERVER_START_RETRIES=${SERVER_START_RETRIES:-3}
 SERVER_START_RETRY_DELAY_SECONDS=${SERVER_START_RETRY_DELAY_SECONDS:-10}
 SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}
+SERVER_LOG_PROGRESS_INTERVAL_SECONDS=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS:-120}
+SERVER_LOG_PROGRESS_TAIL_LINES=${SERVER_LOG_PROGRESS_TAIL_LINES:-40}
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
@@ -808,9 +810,10 @@ server_log_indicates_node_env_failure() {
 
 print_server_log_tail() {
   local log_file=$1
+  local lines=${2:-$SERVER_LOG_TAIL_LINES}
 
   [[ -f "$log_file" ]] || return 0
-  tail -n "$SERVER_LOG_TAIL_LINES" "$log_file" >&2
+  tail -n "$lines" "$log_file" >&2
 }
 
 wait_for_server() {
@@ -819,10 +822,15 @@ wait_for_server() {
   local waited=0
   local timeout_sec=${READY_TIMEOUT_SECONDS}
   local status_interval_sec=${READY_STATUS_INTERVAL_SECONDS}
+  local log_progress_interval_sec=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS}
   local next_status_at=0
+  local next_log_progress_at=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS}
 
   if (( status_interval_sec <= 0 )); then
     status_interval_sec=30
+  fi
+  if (( log_progress_interval_sec <= 0 )); then
+    next_log_progress_at=$((timeout_sec + 1))
   fi
 
   while (( waited < timeout_sec )); do
@@ -848,6 +856,14 @@ wait_for_server() {
     if (( waited >= next_status_at )); then
       echo "[same-spec-current] waiting for current same-spec server at ${host}:${port} (${waited}s/${timeout_sec}s)" >&2
       next_status_at=$((waited + status_interval_sec))
+    fi
+    if (( waited >= next_log_progress_at )); then
+      if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
+        echo "---- same-spec server log progress at ${waited}s: ${SERVER_STDOUT_LOG} (last ${SERVER_LOG_PROGRESS_TAIL_LINES} lines) ----" >&2
+        print_server_log_tail "$SERVER_STDOUT_LOG" "$SERVER_LOG_PROGRESS_TAIL_LINES"
+        echo "---- end same-spec server log progress ----" >&2
+      fi
+      next_log_progress_at=$((waited + log_progress_interval_sec))
     fi
 
     sleep 1

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -58,6 +58,7 @@ READY_STATUS_INTERVAL_SECONDS=${READY_STATUS_INTERVAL_SECONDS:-30}
 CLIENT_READY_CHECK_TIMEOUT_SECONDS=${CLIENT_READY_CHECK_TIMEOUT_SECONDS:-$READY_TIMEOUT_SECONDS}
 SERVER_START_RETRIES=${SERVER_START_RETRIES:-3}
 SERVER_START_RETRY_DELAY_SECONDS=${SERVER_START_RETRY_DELAY_SECONDS:-10}
+SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
@@ -802,7 +803,14 @@ server_log_indicates_node_env_failure() {
 
   [[ -f "$log_file" ]] || return 1
 
-  grep -Eq "DrvMngGetConsoleLogLevel failed|dcmi model initialized failed|ret is -8020|drvRet=87|drvRetCode=87|ErrCode=507899|error code is 507899|rtGetDeviceCount|Can't get ascend_hal device count|driver error:internal error|Resource_Busy\(EL0005\)|The resources are busy|ERR99999 UNKNOWN applicaiton exception|ERR99999 UNKNOWN application exception" "$log_file"
+  grep -Eq "DrvMngGetConsoleLogLevel failed|dcmi model initialized failed|ret is -8020|drvRet=87|drvRetCode=87|ErrCode=507899|error code is 507899|rtGetDeviceCount|Can't get ascend_hal device count|driver error:internal error|Resource_Busy\(EL0005\)|The resources are busy" "$log_file"
+}
+
+print_server_log_tail() {
+  local log_file=$1
+
+  [[ -f "$log_file" ]] || return 0
+  tail -n "$SERVER_LOG_TAIL_LINES" "$log_file" >&2
 }
 
 wait_for_server() {
@@ -821,7 +829,7 @@ wait_for_server() {
     if [[ -n "${SERVER_PID:-}" ]] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
       echo "Current same-spec server exited before becoming ready" >&2
       if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
-        tail -n 40 "$SERVER_STDOUT_LOG" >&2
+        print_server_log_tail "$SERVER_STDOUT_LOG"
         if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
           echo "Detected Ascend node-level runtime failure during current same-spec startup" >&2
           return 86
@@ -848,7 +856,7 @@ wait_for_server() {
 
   echo "Timed out waiting for current same-spec server at ${host}:${port}" >&2
   if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
-    tail -n 40 "$SERVER_STDOUT_LOG" >&2
+    print_server_log_tail "$SERVER_STDOUT_LOG"
     if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
       echo "Detected Ascend node-level runtime failure while waiting for current same-spec startup" >&2
       return 86

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -62,6 +62,7 @@ SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}
 SERVER_LOG_PROGRESS_INTERVAL_SECONDS=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS:-120}
 SERVER_LOG_PROGRESS_TAIL_LINES=${SERVER_LOG_PROGRESS_TAIL_LINES:-40}
 READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}
+NPU_OOM_EXIT_CODE=87
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
@@ -855,6 +856,14 @@ server_log_indicates_node_env_failure() {
   grep -Eq "DrvMngGetConsoleLogLevel failed|dcmi model initialized failed|ret is -8020|drvRet=87|drvRetCode=87|ErrCode=507899|error code is 507899|rtGetDeviceCount|Can't get ascend_hal device count|driver error:internal error|Resource_Busy\(EL0005\)|The resources are busy" "$log_file"
 }
 
+server_log_indicates_npu_oom() {
+  local log_file=$1
+
+  [[ -f "$log_file" ]] || return 1
+
+  grep -Eiq "torch\.OutOfMemoryError|NPU out of memory|ACL_ERROR_RT_MEMORY_ALLOCATION|aclrtMalloc[^[:cntrl:]]*(failed|failure|error)|(failed|failure|unable)[^[:cntrl:]]*(allocate|allocation)[^[:cntrl:]]*(NPU|device)[ -]?memory" "$log_file"
+}
+
 print_server_log_tail() {
   local log_file=$1
   local lines=${2:-$SERVER_LOG_TAIL_LINES}
@@ -885,6 +894,10 @@ wait_for_server() {
       echo "Current same-spec server exited before becoming ready" >&2
       if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
         print_server_log_tail "$SERVER_STDOUT_LOG"
+        if server_log_indicates_npu_oom "$SERVER_STDOUT_LOG"; then
+          echo "Detected Ascend NPU out of memory; refusing to retry server startup" >&2
+          return "$NPU_OOM_EXIT_CODE"
+        fi
         if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
           echo "Detected Ascend node-level runtime failure during current same-spec startup" >&2
           return 86
@@ -921,6 +934,10 @@ wait_for_server() {
   echo "Timed out waiting for current same-spec server at ${host}:${port}" >&2
   if [[ -n "${SERVER_STDOUT_LOG:-}" && -f "$SERVER_STDOUT_LOG" ]]; then
     print_server_log_tail "$SERVER_STDOUT_LOG"
+    if server_log_indicates_npu_oom "$SERVER_STDOUT_LOG"; then
+      echo "Detected Ascend NPU out of memory; refusing to retry server startup" >&2
+      return "$NPU_OOM_EXIT_CODE"
+    fi
     if server_log_indicates_node_env_failure "$SERVER_STDOUT_LOG"; then
       echo "Detected Ascend node-level runtime failure while waiting for current same-spec startup" >&2
       return 86

--- a/src/vllm_hust_benchmark/same_spec.py
+++ b/src/vllm_hust_benchmark/same_spec.py
@@ -57,7 +57,10 @@ def _path_has_complete_indexed_weights(path: Path) -> bool:
         if not index_path.is_file():
             continue
 
-        payload = json.loads(index_path.read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(index_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
         weight_map = payload.get("weight_map") or {}
         if not isinstance(weight_map, dict) or not weight_map:
             continue
@@ -134,13 +137,17 @@ def runtime_model_path_has_required_artifacts(candidate: str | Path) -> bool:
     if not path.is_dir():
         return False
 
+    has_weight_index = any((path / name).is_file() for name in LOCAL_MODEL_INDEX_FILES)
+    has_weights = (
+        _path_has_complete_indexed_weights(path)
+        if has_weight_index
+        else _path_has_any_matching_file(path, LOCAL_MODEL_WEIGHT_PATTERNS)
+    )
+
     return (
         _path_has_any_matching_file(path, LOCAL_MODEL_CONFIG_FILES)
         and _path_has_any_matching_file(path, LOCAL_MODEL_TOKENIZER_PATTERNS)
-        and (
-            _path_has_any_matching_file(path, LOCAL_MODEL_WEIGHT_PATTERNS)
-            or _path_has_complete_indexed_weights(path)
-        )
+        and has_weights
     )
 
 

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -6,11 +6,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNNER = REPO_ROOT / "scripts/run-current-ascend-same-spec.sh"
 
 
-def _run_log_detector(function_name: str, tmp_path: Path, log_text: str) -> int:
-    script = RUNNER.read_text(encoding="utf-8")
+def _function_text(script: str, function_name: str) -> str:
     function_start = script.index(f"{function_name}()")
     function_end = script.index("\n}\n", function_start) + len("\n}\n")
-    detector = script[function_start:function_end]
+    return script[function_start:function_end]
+
+
+def _run_log_detector(function_name: str, tmp_path: Path, log_text: str) -> int:
+    script = RUNNER.read_text(encoding="utf-8")
+    detector = _function_text(script, function_name)
     log_file = tmp_path / "server.log"
     log_file.write_text(log_text, encoding="utf-8")
 
@@ -83,11 +87,88 @@ def test_current_same_spec_runner_treats_npu_oom_as_terminal() -> None:
     retry_block = retry_block[: retry_block.index("run_client_command")]
 
     assert "NPU_OOM_EXIT_CODE=87" in script
-    assert wait_block.count('return "$NPU_OOM_EXIT_CODE"') == 2
-    assert wait_block.count("server_log_indicates_npu_oom") == 2
+    assert wait_block.count('return "$NPU_OOM_EXIT_CODE"') >= 3
+    assert wait_block.count("server_log_indicates_npu_oom") >= 3
     assert "refusing to retry server startup" in wait_block
     assert '"$server_wait_status" -eq 86' in retry_block
     assert '"$server_wait_status" -eq "$NPU_OOM_EXIT_CODE"' not in retry_block
+
+
+def test_current_same_spec_runner_defaults_to_one_start_attempt() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert "SERVER_START_RETRIES=${SERVER_START_RETRIES:-1}" in script
+
+
+def test_wait_for_server_fails_while_live_server_logs_npu_oom(
+    tmp_path: Path,
+) -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    detector = _function_text(script, "server_log_indicates_npu_oom")
+    print_tail = _function_text(script, "print_server_log_tail")
+    wait_for_server = _function_text(script, "wait_for_server")
+    log_file = tmp_path / "server.log"
+    log_file.write_text("starting\n", encoding="utf-8")
+
+    harness = f"""#!/bin/bash
+set -u
+{detector}
+{print_tail}
+probe_server_ready() {{ return 1; }}
+{wait_for_server}
+NPU_OOM_EXIT_CODE=87
+READY_TIMEOUT_SECONDS=100
+READY_STATUS_INTERVAL_SECONDS=100
+SERVER_LOG_PROGRESS_INTERVAL_SECONDS=0
+SERVER_LOG_PROGRESS_TAIL_LINES=5
+SERVER_LOG_OOM_CHECK_INTERVAL_SECONDS=1
+SERVER_STDOUT_LOG="$1"
+SERVER_PID=$$
+sleep() {{ command sleep 0.01; }}
+(command sleep 0.03; echo 'torch.OutOfMemoryError: NPU exhausted' >> "$1") &
+wait_for_server 127.0.0.1 1
+"""
+    result = subprocess.run(
+        ["bash", "-c", harness, "bash", str(log_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 87
+    assert "out of memory while waiting" in result.stderr
+
+
+def test_client_monitor_returns_dedicated_exit_code_for_npu_oom(
+    tmp_path: Path,
+) -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    detector = _function_text(script, "server_log_indicates_npu_oom")
+    monitor = _function_text(script, "run_client_command_with_server_monitor")
+    log_file = tmp_path / "server.log"
+    log_file.write_text("ACL_ERROR_RT_MEMORY_ALLOCATION\n", encoding="utf-8")
+
+    harness = f"""#!/bin/bash
+set -u
+{detector}
+run_client_command() {{ command sleep 10; }}
+cleanup_managed_server() {{ return 0; }}
+{monitor}
+NPU_OOM_EXIT_CODE=87
+CLIENT_SERVER_MONITOR_INTERVAL_SECONDS=1
+BENCHMARK_TYPE=serve
+SERVER_STDOUT_LOG="$1"
+run_client_command_with_server_monitor
+"""
+    result = subprocess.run(
+        ["bash", "-c", harness, "bash", str(log_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 87
+    assert "while running" in result.stderr
 
 
 def test_current_same_spec_runner_prints_enough_server_log_context() -> None:

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -36,6 +36,19 @@ def test_current_same_spec_runner_prints_enough_server_log_context() -> None:
     script = RUNNER.read_text(encoding="utf-8")
 
     assert "SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}" in script
+    assert "SERVER_LOG_PROGRESS_INTERVAL_SECONDS=${SERVER_LOG_PROGRESS_INTERVAL_SECONDS:-120}" in script
+    assert "SERVER_LOG_PROGRESS_TAIL_LINES=${SERVER_LOG_PROGRESS_TAIL_LINES:-40}" in script
     assert "print_server_log_tail()" in script
     assert 'print_server_log_tail "$SERVER_STDOUT_LOG"' in script
     assert "tail -n 40" not in script
+
+
+def test_current_same_spec_runner_prints_server_log_progress_while_waiting() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    wait_block = script[script.index("wait_for_server()") :]
+    wait_block = wait_block[: wait_block.index("  echo \"Timed out waiting")]
+
+    assert "next_log_progress_at" in wait_block
+    assert "same-spec server log progress at" in wait_block
+    assert 'print_server_log_tail "$SERVER_STDOUT_LOG" "$SERVER_LOG_PROGRESS_TAIL_LINES"' in wait_block

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -63,6 +63,8 @@ def test_current_same_spec_runner_probe_bypasses_proxy_and_checks_ping() -> None
 
     assert "READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}" in script
     assert '"/ping"' in probe_block
-    assert 'curl --noproxy "*"' in probe_block
-    assert "--connect-timeout 2 --max-time" in probe_block
+    assert "socket.create_connection" in probe_block
+    assert "set +e" in probe_block
+    assert "set -e" in probe_block
     assert "readiness probe failed:" in probe_block
+    assert "curl " not in probe_block

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -1,8 +1,24 @@
+import subprocess
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNNER = REPO_ROOT / "scripts/run-current-ascend-same-spec.sh"
+
+
+def _run_log_detector(function_name: str, tmp_path: Path, log_text: str) -> int:
+    script = RUNNER.read_text(encoding="utf-8")
+    function_start = script.index(f"{function_name}()")
+    function_end = script.index("\n}\n", function_start) + len("\n}\n")
+    detector = script[function_start:function_end]
+    log_file = tmp_path / "server.log"
+    log_file.write_text(log_text, encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", "-c", f'{detector}\n{function_name} "$1"', "bash", str(log_file)],
+        check=False,
+    )
+    return result.returncode
 
 
 def test_current_same_spec_runner_preserves_wait_for_server_exit_code() -> None:
@@ -30,6 +46,48 @@ def test_current_same_spec_runner_does_not_retry_generic_engine_startup_wrapper(
     assert "ERR99999 UNKNOWN application exception" not in detector
     assert "rtGetDeviceCount" in detector
     assert "Resource_Busy" in detector
+
+
+def test_current_same_spec_runner_detects_explicit_npu_oom_patterns(tmp_path: Path) -> None:
+    messages = (
+        "torch.OutOfMemoryError: NPU exhausted",
+        "RuntimeError: NPU out of memory. Tried to allocate 2 GiB",
+        "runtime failed: ACL_ERROR_RT_MEMORY_ALLOCATION",
+        "Call aclrtMalloc failed, ret: 207001",
+        "Failed to allocate NPU device memory",
+    )
+
+    for message in messages:
+        assert _run_log_detector("server_log_indicates_npu_oom", tmp_path, message) == 0
+
+
+def test_current_same_spec_runner_does_not_classify_generic_error_as_oom(tmp_path: Path) -> None:
+    message = "ERR99999 UNKNOWN applicaiton exception: Engine core initialization failed"
+
+    assert _run_log_detector("server_log_indicates_npu_oom", tmp_path, message) != 0
+    assert _run_log_detector("server_log_indicates_node_env_failure", tmp_path, message) != 0
+
+
+def test_current_same_spec_runner_keeps_resource_busy_retryable(tmp_path: Path) -> None:
+    message = "RuntimeError: Resource_Busy(EL0005): The resources are busy"
+
+    assert _run_log_detector("server_log_indicates_node_env_failure", tmp_path, message) == 0
+    assert _run_log_detector("server_log_indicates_npu_oom", tmp_path, message) != 0
+
+
+def test_current_same_spec_runner_treats_npu_oom_as_terminal() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    wait_block = script[script.index("wait_for_server()") :]
+    wait_block = wait_block[: wait_block.index("resolved_dataset_path=")]
+    retry_block = script[script.index("for start_attempt in") :]
+    retry_block = retry_block[: retry_block.index("run_client_command")]
+
+    assert "NPU_OOM_EXIT_CODE=87" in script
+    assert wait_block.count('return "$NPU_OOM_EXIT_CODE"') == 2
+    assert wait_block.count("server_log_indicates_npu_oom") == 2
+    assert "refusing to retry server startup" in wait_block
+    assert '"$server_wait_status" -eq 86' in retry_block
+    assert '"$server_wait_status" -eq "$NPU_OOM_EXIT_CODE"' not in retry_block
 
 
 def test_current_same_spec_runner_prints_enough_server_log_context() -> None:

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -51,4 +51,18 @@ def test_current_same_spec_runner_prints_server_log_progress_while_waiting() -> 
 
     assert "next_log_progress_at" in wait_block
     assert "same-spec server log progress at" in wait_block
+    assert 'probe_server_ready "$host" "$port" 1 || true' in wait_block
     assert 'print_server_log_tail "$SERVER_STDOUT_LOG" "$SERVER_LOG_PROGRESS_TAIL_LINES"' in wait_block
+
+
+def test_current_same_spec_runner_probe_bypasses_proxy_and_checks_ping() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    probe_block = script[script.index("probe_server_ready()") :]
+    probe_block = probe_block[: probe_block.index("server_log_indicates_node_env_failure()")]
+
+    assert "READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}" in script
+    assert '"/ping"' in probe_block
+    assert 'curl --noproxy "*"' in probe_block
+    assert "--connect-timeout 2 --max-time" in probe_block
+    assert "readiness probe failed:" in probe_block

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -26,5 +26,16 @@ def test_current_same_spec_runner_does_not_retry_generic_engine_startup_wrapper(
     detector = detector[: detector.index("wait_for_server()")]
 
     assert "Engine core initialization failed" not in detector
+    assert "ERR99999 UNKNOWN applicaiton exception" not in detector
+    assert "ERR99999 UNKNOWN application exception" not in detector
     assert "rtGetDeviceCount" in detector
     assert "Resource_Busy" in detector
+
+
+def test_current_same_spec_runner_prints_enough_server_log_context() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert "SERVER_LOG_TAIL_LINES=${SERVER_LOG_TAIL_LINES:-200}" in script
+    assert "print_server_log_tail()" in script
+    assert 'print_server_log_tail "$SERVER_STDOUT_LOG"' in script
+    assert "tail -n 40" not in script

--- a/tests/test_same_spec.py
+++ b/tests/test_same_spec.py
@@ -128,12 +128,54 @@ def test_runtime_model_path_has_required_artifacts(tmp_path: Path) -> None:
     (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
     # _path_has_complete_indexed_weights requires index file + shard files referenced in weight_map
     index_file = model_dir / "model.safetensors.index.json"
-    shard_file = model_dir / "model-00001-of-00002.safetensors"
-    shard_file.touch()
+    first_shard = model_dir / "model-00001-of-00002.safetensors"
+    second_shard = model_dir / "model-00002-of-00002.safetensors"
+    first_shard.touch()
+    second_shard.touch()
     index_file.write_text(
-        json.dumps({"weight_map": {"model embedder": "model-00001-of-00002.safetensors"}}),
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.embed_tokens.weight": first_shard.name,
+                    "model.norm.weight": second_shard.name,
+                }
+            }
+        ),
         encoding="utf-8",
     )
+
+    assert runtime_model_path_has_required_artifacts(model_dir)
+
+
+def test_runtime_model_path_rejects_incomplete_indexed_weights(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{}", encoding="utf-8")
+    (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    (model_dir / "model-00001-of-00002.safetensors").touch()
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+                    "model.norm.weight": "model-00002-of-00002.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not runtime_model_path_has_required_artifacts(model_dir)
+
+
+def test_runtime_model_path_accepts_unindexed_single_file_weights(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{}", encoding="utf-8")
+    (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    (model_dir / "model.safetensors").touch()
 
     assert runtime_model_path_has_required_artifacts(model_dir)
 

--- a/tests/test_workflow_ssh_config.py
+++ b/tests/test_workflow_ssh_config.py
@@ -4,14 +4,27 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW_PATHS = [
-    ".github/workflows/ci.yml",
+PUBLISH_WORKFLOW_PATHS = [
     ".github/workflows/push-to-hf.yml",
     ".github/workflows/run-official-ascend-baselines.yml",
 ]
 
 
-@pytest.mark.parametrize("workflow_path", WORKFLOW_PATHS)
+def test_pull_request_ci_uses_public_checkout_without_ssh_secret() -> None:
+    workflow_text = (REPO_ROOT / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "uses: actions/checkout@v4" in workflow_text
+    assert "persist-credentials: false" in workflow_text
+    assert "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY" not in workflow_text
+    assert "BENCHMARK_CHECKOUT_USE_SSH" not in workflow_text
+    assert "Require GitHub SSH checkout key" not in workflow_text
+    assert "Configure GitHub SSH" not in workflow_text
+    assert "ssh-key:" not in workflow_text
+
+
+@pytest.mark.parametrize("workflow_path", PUBLISH_WORKFLOW_PATHS)
 def test_workflows_use_standard_github_ssh_without_overwriting_config(
     workflow_path: str,
 ) -> None:


### PR DESCRIPTION
## Summary

  Harden the Ascend current same-spec benchmark startup path and make failures faster and easier to diagnose.

  This change:

  - Rejects incomplete indexed Hugging Face model caches when any checkpoint shard referenced by the index is missing.
  - Stops treating generic `ERR99999` engine initialization errors as retryable node failures.
  - Preserves retries for explicit transient Ascend node and resource-busy failures.
  - Detects explicit NPU out-of-memory errors and exits immediately with a dedicated status instead of retrying server startup.
  - Prints periodic readiness diagnostics and server log progress during long startup waits.
  - Increases the final server log context printed on startup failure.
  - Replaces the `curl` readiness probe with a direct Python loopback socket probe, avoiding proxy settings and host `curl`/OpenSSL ABI
  conflicts.
  - Checks `/health`, `/ping`, and `/v1/models` for readiness.

  The OOM detector intentionally does not classify a generic `ERR99999` message as an out-of-memory or retryable failure.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  The following checks were run against the exact branch head:

  ```bash
  PYTHONPATH=src pytest -q \
    tests/test_same_spec.py \
    tests/test_current_same_spec_script.py

  bash -n scripts/run-current-ascend-same-spec.sh

  git diff --check

  Result:

  19 passed in 0.09s

  The tests cover:

  - Complete and incomplete indexed model caches.
  - Explicit Ascend NPU OOM signatures.
  - Terminal OOM handling without startup retries.
  - Retryable Ascend resource-busy failures.
  - Generic ERR99999 errors remaining non-retryable.
  - Readiness probing without curl or proxy use.
  - Periodic startup progress and expanded log output.

  A full Ascend hardware same-spec benchmark was not run locally.

  ## Risks

  - Ascend OOM detection is based on explicit known log signatures. New or undocumented runtime messages may require additional patterns.
  - The direct readiness probe implements the limited HTTP behavior needed for local vLLM loopback endpoints; it is not intended as a
    general-purpose HTTP client.

  - Incomplete indexed caches will now be rejected and may require model artifacts to be downloaded again.
  - Ascend hardware CI is still required to validate startup, cancellation, cache recovery, and OOM behavior on a real NPU runner.
  - This PR changes benchmark reliability and diagnostics only. It does not change published baseline values or user-facing vLLM behavior.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed. No documentation update is required because this is CI-only behavior.
  - [x] I noted the tests I ran, or clearly stated what I could not run.

  AI assistance was used while implementing and reviewing this change. All changed code and test results were reviewed by the submitter.