### PR TITLE
fix(ci): use public checkout for HF sync

### DIFF
--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -37,61 +37,12 @@ permissions:
 jobs:
   upload-to-hf:
     runs-on: ubuntu-latest
-    env:
-      BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}
 
     steps:
-      - name: Require GitHub SSH checkout key
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
-            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
-            exit 1
-          fi
-
-      - name: Configure GitHub SSH
-        shell: bash
-        run: |
-          set -euo pipefail
-          ssh_dir="$HOME/.ssh"
-          config_file="$ssh_dir/config"
-          key_file="$ssh_dir/github_actions"
-
-          if [[ ! -d "$ssh_dir" ]]; then
-            mkdir -p "$ssh_dir"
-          fi
-          chmod 700 "$ssh_dir"
-
-          printf '%s\n' '${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}' > "$key_file"
-          chmod 600 "$key_file"
-
-          config_block="$(cat <<'EOF'
-          Host github.com
-            HostName github.com
-            User git
-            IdentityFile ~/.ssh/github_actions
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
-          )"
-
-          if [[ ! -f "$config_file" ]]; then
-            printf '%s\n' "$config_block" > "$config_file"
-          elif ! grep -Fq 'Host github.com' "$config_file" \
-            || ! grep -Fq 'HostName github.com' "$config_file" \
-            || ! grep -Fq 'IdentityFile ~/.ssh/github_actions' "$config_file"; then
-            printf '\n%s\n' "$config_block" >> "$config_file"
-          fi
-
-          chmod 600 "$config_file"
-
       - name: Checkout benchmark repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
-          ssh-strict: false
           persist-credentials: false
 
       - name: Checkout vllm-hust repo
@@ -99,8 +50,6 @@ jobs:
         with:
           repository: vLLM-HUST/vllm-hust
           path: vllm-hust
-          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
-          ssh-strict: false
           persist-credentials: false
 
       - name: Checkout website repo (for aggregate script and schema)
@@ -109,8 +58,6 @@ jobs:
           repository: vLLM-HUST/vllm-hust-website
           ref: ${{ env.VLLM_HUST_WEBSITE_REF }}
           path: vllm-hust-website
-          ssh-key: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY }}
-          ssh-strict: false
           persist-credentials: false
 
       - name: Set up Python

--- a/tests/test_workflow_ssh_config.py
+++ b/tests/test_workflow_ssh_config.py
@@ -5,7 +5,6 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PUBLISH_WORKFLOW_PATHS = [
-    ".github/workflows/push-to-hf.yml",
     ".github/workflows/run-official-ascend-baselines.yml",
 ]
 
@@ -17,6 +16,20 @@ def test_pull_request_ci_uses_public_checkout_without_ssh_secret() -> None:
 
     assert "uses: actions/checkout@v4" in workflow_text
     assert "persist-credentials: false" in workflow_text
+    assert "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY" not in workflow_text
+    assert "BENCHMARK_CHECKOUT_USE_SSH" not in workflow_text
+    assert "Require GitHub SSH checkout key" not in workflow_text
+    assert "Configure GitHub SSH" not in workflow_text
+    assert "ssh-key:" not in workflow_text
+
+
+def test_hf_upload_uses_public_checkout_without_ssh_secret() -> None:
+    workflow_text = (REPO_ROOT / ".github/workflows/push-to-hf.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert workflow_text.count("uses: actions/checkout@v4") == 3
+    assert workflow_text.count("persist-credentials: false") == 3
     assert "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY" not in workflow_text
     assert "BENCHMARK_CHECKOUT_USE_SSH" not in workflow_text
     assert "Require GitHub SSH checkout key" not in workflow_text


### PR DESCRIPTION
## 问题

主干的 Hugging Face 同步工作流在 checkout 前强制要求 `VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY`。当前仓库没有配置该 secret，导致每次主干更新都在第一步退出，GitHub 快照已经更新而 HF 仍停留在旧数据。

失败运行：<https://github.com/vLLM-HUST/vllm-hust-benchmark/actions/runs/29734241882>

## 修改

- 三个公开仓库使用 `actions/checkout` 的 HTTPS 默认路径。
- 移除 HF 同步工作流对 SSH key 的无条件检查和 SSH 配置。
- 保留 `persist-credentials: false`；HF 写入仍只使用 `DATASET_WRITE_TOKEN`。
- 增加测试，防止上传工作流再次引入 SSH secret 依赖。

## 验证

- `uv run --frozen python -m pytest -q tests`
- 结果：221 passed
- `git diff --check`

合入后需确认 Upload Benchmark Results to HuggingFace 成功，并逐字节核对 GitHub 与 HF 的四份排行榜快照。