### PR TITLE
feat(perfgate): add central baseline protocol and safe publisher

### DIFF
--- a/docs/central-perfgate-baselines.md
+++ b/docs/central-perfgate-baselines.md
@@ -48,6 +48,12 @@ while different artifact bytes or provenance fail without overwriting data.
 The latest-main pointer can be updated only when the target SHA is the current
 main tip.
 
+`perfgate-baseline publish` applies the same validation before updating the
+central Git branch. It creates the branch on the first write, treats a repeated
+identical write as success, and retries from a fresh checkout after a concurrent
+non-fast-forward push. Credentials remain the caller's responsibility and are
+never accepted as command-line arguments.
+
 ## Trust Boundary
 
 This protocol does not grant or consume cross-repository credentials. A trusted

--- a/docs/central-perfgate-baselines.md
+++ b/docs/central-perfgate-baselines.md
@@ -1,0 +1,57 @@
+# Central Perfgate Baselines
+
+Perfgate baselines are owned by `vLLM-HUST/vllm-hust-benchmark`, not by the
+target repositories that execute benchmarks. The initial protocol supports the
+required `random-online` scenario for these targets:
+
+- `vLLM-HUST/vllm-hust`
+- `vLLM-HUST/vllm-ascend-hust`
+
+## Storage Key
+
+An exact baseline is stored under the complete comparison identity:
+
+```text
+baselines/
+  <target-owner>/
+    <target-repository>/
+      <target-sha>/
+        <scenario>/
+          <spec-id>/
+            <spec-hash>/
+              baseline-metadata.json
+              run_leaderboard.json
+```
+
+The latest-main pointer is namespaced by target, scenario, and spec:
+
+```text
+pointers/<target-owner>/<target-repository>/<scenario>/<spec-id>/latest-main.json
+```
+
+Consumers of a required gate must use the exact path. They must not silently
+fall back to the latest-main pointer.
+
+## Validation
+
+`perfgate-baseline store` requires:
+
+- a full target commit that is part of the declared main history;
+- matching target repository and commit metadata in the artifact;
+- matching scenario, spec ID, and resolved spec hash;
+- finite throughput, TTFT, and TBT metrics;
+- exact core, plugin, and benchmark runner revisions;
+- hardware, CANN, PyTorch, and torch-npu provenance.
+
+An existing baseline key is immutable. Repeating the same write is idempotent,
+while different artifact bytes or provenance fail without overwriting data.
+The latest-main pointer can be updated only when the target SHA is the current
+main tip.
+
+## Trust Boundary
+
+This protocol does not grant or consume cross-repository credentials. A trusted
+producer or central writer supplies the checked-out target main history and the
+central baseline worktree. Pull-request workflows remain read-only consumers.
+Credential management, serialized cross-repository pushes, and hardware
+backfill orchestration are separate rollout steps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ publish = ["huggingface_hub>=0.20"]
 [project.scripts]
 vllm-hust-benchmark = "vllm_hust_benchmark.cli:main"
 perfgate = "vllm_hust_benchmark.perfgate:main"
+perfgate-baseline = "vllm_hust_benchmark.perfgate_baselines:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -22,6 +23,9 @@ SUPPORTED_TARGET_REPOSITORIES = {
 SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 SAFE_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 REQUIRED_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms")
+DEFAULT_BASELINE_BRANCH = "benchmark-baselines"
+DEFAULT_WRITER_NAME = "vLLM-HUST Baseline Writer"
+DEFAULT_WRITER_EMAIL = "baseline-writer@vllm-hust.local"
 
 
 @dataclass(frozen=True)
@@ -455,6 +459,133 @@ def verify_main_commit(
             )
 
 
+def _run_git(
+    arguments: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ValueError(f"git {' '.join(arguments)} failed: {detail}")
+    return result
+
+
+def publish_baseline(
+    remote: str,
+    branch: str,
+    source: Path,
+    target_git_repository: Path,
+    main_ref: str,
+    identity: BaselineIdentity,
+    provenance: BaselineProvenance,
+    *,
+    update_latest_pointer: bool = False,
+    max_attempts: int = 5,
+    writer_name: str = DEFAULT_WRITER_NAME,
+    writer_email: str = DEFAULT_WRITER_EMAIL,
+) -> str:
+    identity = normalize_identity(identity)
+    provenance = normalize_provenance(provenance)
+    branch = _validate_component(branch, field="branch")
+    writer_name = _validate_metadata_value(writer_name, field="writer_name")
+    writer_email = _validate_metadata_value(writer_email, field="writer_email")
+    if not str(remote or "").strip():
+        raise ValueError("remote must be non-empty")
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
+    verify_main_commit(
+        target_git_repository,
+        identity.target_sha,
+        main_ref,
+        require_tip=update_latest_pointer,
+    )
+    validate_artifact(source, identity, provenance)
+
+    last_error = ""
+    with tempfile.TemporaryDirectory(prefix="perfgate-baseline-writer-") as temp:
+        temp_root = Path(temp)
+        for attempt in range(1, max_attempts + 1):
+            checkout = temp_root / f"attempt-{attempt}"
+            _run_git(["clone", "--no-checkout", remote, str(checkout)])
+            remote_branch = _run_git(
+                [
+                    "ls-remote",
+                    "--exit-code",
+                    "--heads",
+                    "origin",
+                    branch,
+                ],
+                cwd=checkout,
+                check=False,
+            )
+            if remote_branch.returncode == 0:
+                _run_git(["fetch", "origin", branch], cwd=checkout)
+                _run_git(["checkout", "-B", branch, "FETCH_HEAD"], cwd=checkout)
+            elif remote_branch.returncode == 2:
+                _run_git(["checkout", "--orphan", branch], cwd=checkout)
+                _run_git(["rm", "-rf", "--ignore-unmatch", "."], cwd=checkout)
+            else:
+                detail = remote_branch.stderr.strip() or remote_branch.stdout.strip()
+                raise ValueError(
+                    f"unable to inspect central baseline branch {branch}: {detail}"
+                )
+
+            destination = store_baseline(
+                checkout,
+                source,
+                identity,
+                provenance,
+                update_latest_pointer=update_latest_pointer,
+            )
+            paths_to_add = ["baselines"]
+            if (checkout / "pointers").is_dir():
+                paths_to_add.append("pointers")
+            _run_git(["add", *paths_to_add], cwd=checkout)
+            staged = _run_git(
+                ["diff", "--cached", "--quiet"], cwd=checkout, check=False
+            )
+            if staged.returncode == 0:
+                return f"unchanged:{destination.relative_to(checkout).as_posix()}"
+            if staged.returncode != 1:
+                detail = staged.stderr.strip() or staged.stdout.strip()
+                raise ValueError(f"unable to inspect staged baseline changes: {detail}")
+
+            _run_git(
+                [
+                    "-c",
+                    f"user.name={writer_name}",
+                    "-c",
+                    f"user.email={writer_email}",
+                    "commit",
+                    "-m",
+                    "chore(perfgate): store central baseline for "
+                    f"{identity.target_repository}@{identity.target_sha[:12]}",
+                ],
+                cwd=checkout,
+            )
+            pushed = _run_git(
+                ["push", "origin", f"HEAD:refs/heads/{branch}"],
+                cwd=checkout,
+                check=False,
+            )
+            if pushed.returncode == 0:
+                return f"published:{destination.relative_to(checkout).as_posix()}"
+            last_error = pushed.stderr.strip() or pushed.stdout.strip()
+
+    raise ValueError(
+        f"failed to publish central baseline after {max_attempts} attempts: {last_error}"
+    )
+
+
 def _add_identity_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--target-repository", required=True)
     parser.add_argument("--target-sha", required=True)
@@ -518,6 +649,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     validate_parser.add_argument("--repository-root", type=Path, required=True)
     _add_identity_arguments(validate_parser)
     _add_provenance_arguments(validate_parser)
+
+    publish_parser = commands.add_parser("publish")
+    publish_parser.add_argument("--remote", required=True)
+    publish_parser.add_argument("--branch", default=DEFAULT_BASELINE_BRANCH)
+    publish_parser.add_argument("--source", type=Path, required=True)
+    publish_parser.add_argument("--target-git-repository", type=Path, required=True)
+    publish_parser.add_argument("--main-ref", default="origin/main")
+    publish_parser.add_argument("--update-latest-pointer", action="store_true")
+    publish_parser.add_argument("--max-attempts", type=int, default=5)
+    publish_parser.add_argument("--writer-name", default=DEFAULT_WRITER_NAME)
+    publish_parser.add_argument("--writer-email", default=DEFAULT_WRITER_EMAIL)
+    _add_identity_arguments(publish_parser)
+    _add_provenance_arguments(publish_parser)
     return parser.parse_args(argv)
 
 
@@ -557,6 +701,23 @@ def main(argv: list[str] | None = None) -> int:
             if actual_provenance != normalize_provenance(provenance):
                 raise ValueError("exact central baseline provenance mismatch")
             print("Central perfgate baseline is valid.")
+            return 0
+        if args.command == "publish":
+            print(
+                publish_baseline(
+                    args.remote,
+                    args.branch,
+                    args.source,
+                    args.target_git_repository,
+                    args.main_ref,
+                    identity,
+                    provenance,
+                    update_latest_pointer=args.update_latest_pointer,
+                    max_attempts=args.max_attempts,
+                    writer_name=args.writer_name,
+                    writer_email=args.writer_email,
+                )
+            )
             return 0
     except (OSError, ValueError) as error:
         print(str(error), file=sys.stderr)

--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -1,0 +1,568 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+BASELINE_SCHEMA_VERSION = "perfgate-baseline/v1"
+SUPPORTED_SCENARIOS = frozenset({"random-online"})
+SUPPORTED_TARGET_REPOSITORIES = {
+    "vllm-hust/vllm-hust": "vLLM-HUST/vllm-hust",
+    "vllm-hust/vllm-ascend-hust": "vLLM-HUST/vllm-ascend-hust",
+}
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+SAFE_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+REQUIRED_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms")
+
+
+@dataclass(frozen=True)
+class BaselineIdentity:
+    target_repository: str
+    target_sha: str
+    scenario: str
+    spec_id: str
+    spec_hash: str
+
+
+@dataclass(frozen=True)
+class BaselineProvenance:
+    vllm_hust_sha: str
+    vllm_ascend_hust_sha: str
+    benchmark_runner_sha: str
+    hardware_chip_model: str
+    cann_version: str
+    torch_version: str
+    torch_npu_version: str
+
+
+def _canonical_repository(value: str) -> str:
+    normalized = str(value or "").strip()
+    canonical = SUPPORTED_TARGET_REPOSITORIES.get(normalized.lower())
+    if canonical is None:
+        supported = ", ".join(sorted(SUPPORTED_TARGET_REPOSITORIES.values()))
+        raise ValueError(
+            f"unsupported target repository: {normalized!r}; supported: {supported}"
+        )
+    return canonical
+
+
+def _validate_sha(value: str, *, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not SHA_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{field} must be a full 40-character Git SHA")
+    return normalized
+
+
+def _validate_component(value: str, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized or not SAFE_COMPONENT_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{field} must contain only letters, digits, '.', '_' or '-'")
+    return normalized
+
+
+def _validate_metadata_value(value: str, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized or any(character in normalized for character in "\0\r\n"):
+        raise ValueError(f"{field} must be a non-empty single-line value")
+    return normalized
+
+
+def normalize_identity(identity: BaselineIdentity) -> BaselineIdentity:
+    scenario = str(identity.scenario or "").strip()
+    if scenario not in SUPPORTED_SCENARIOS:
+        supported = ", ".join(sorted(SUPPORTED_SCENARIOS))
+        raise ValueError(
+            f"unsupported required perfgate scenario: {scenario!r}; supported: {supported}"
+        )
+    spec_hash = str(identity.spec_hash or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", spec_hash):
+        raise ValueError("spec_hash must be a 64-character lowercase SHA-256 digest")
+    return BaselineIdentity(
+        target_repository=_canonical_repository(identity.target_repository),
+        target_sha=_validate_sha(identity.target_sha, field="target_sha"),
+        scenario=scenario,
+        spec_id=_validate_component(identity.spec_id, field="spec_id"),
+        spec_hash=spec_hash,
+    )
+
+
+def normalize_provenance(provenance: BaselineProvenance) -> BaselineProvenance:
+    return BaselineProvenance(
+        vllm_hust_sha=_validate_sha(provenance.vllm_hust_sha, field="vllm_hust_sha"),
+        vllm_ascend_hust_sha=_validate_sha(
+            provenance.vllm_ascend_hust_sha, field="vllm_ascend_hust_sha"
+        ),
+        benchmark_runner_sha=_validate_sha(
+            provenance.benchmark_runner_sha, field="benchmark_runner_sha"
+        ),
+        hardware_chip_model=_validate_metadata_value(
+            provenance.hardware_chip_model, field="hardware_chip_model"
+        ),
+        cann_version=_validate_metadata_value(
+            provenance.cann_version, field="cann_version"
+        ),
+        torch_version=_validate_metadata_value(
+            provenance.torch_version, field="torch_version"
+        ),
+        torch_npu_version=_validate_metadata_value(
+            provenance.torch_npu_version, field="torch_npu_version"
+        ),
+    )
+
+
+def baseline_relative_dir(identity: BaselineIdentity) -> PurePosixPath:
+    identity = normalize_identity(identity)
+    owner, repository = identity.target_repository.split("/", maxsplit=1)
+    return PurePosixPath(
+        "baselines",
+        owner,
+        repository,
+        identity.target_sha,
+        identity.scenario,
+        identity.spec_id,
+        identity.spec_hash,
+    )
+
+
+def latest_pointer_relative_path(identity: BaselineIdentity) -> PurePosixPath:
+    identity = normalize_identity(identity)
+    owner, repository = identity.target_repository.split("/", maxsplit=1)
+    return PurePosixPath(
+        "pointers",
+        owner,
+        repository,
+        identity.scenario,
+        identity.spec_id,
+        "latest-main.json",
+    )
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid JSON file {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _validate_metrics(payload: dict[str, Any], *, source: Path) -> None:
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict):
+        raise ValueError(f"{source}: missing object key metrics")
+    invalid: list[str] = []
+    for name in REQUIRED_METRICS:
+        value = metrics.get(name)
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            invalid.append(name)
+            continue
+        if not math.isfinite(number) or number < 0:
+            invalid.append(name)
+    if invalid:
+        raise ValueError(f"{source}: invalid required metrics: {', '.join(invalid)}")
+
+
+def _artifact_target_component(
+    payload: dict[str, Any], identity: BaselineIdentity
+) -> dict[str, Any]:
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError("baseline artifact is missing object key metadata")
+    artifact_repository = str(metadata.get("github_repository") or "").strip()
+    artifact_sha = str(metadata.get("git_commit") or "").strip().lower()
+    if artifact_repository.lower() != identity.target_repository.lower():
+        raise ValueError(
+            "baseline target repository mismatch: "
+            f"expected {identity.target_repository}, got {artifact_repository or 'unset'}"
+        )
+    if artifact_sha != identity.target_sha:
+        raise ValueError(
+            "baseline target SHA mismatch: "
+            f"expected {identity.target_sha}, got {artifact_sha or 'unset'}"
+        )
+
+    runtime = metadata.get("runtime_provenance")
+    if not isinstance(runtime, dict):
+        raise ValueError("baseline artifact is missing metadata.runtime_provenance")
+    key = (
+        "plugin"
+        if identity.target_repository.endswith("/vllm-ascend-hust")
+        else "engine"
+    )
+    component = runtime.get(key)
+    if not isinstance(component, dict):
+        raise ValueError(
+            f"baseline artifact is missing target provenance component: {key}"
+        )
+    component_repository = str(component.get("repository") or "").strip()
+    component_sha = str(component.get("commit") or "").strip().lower()
+    if component_repository.lower() != identity.target_repository.lower():
+        raise ValueError(
+            f"baseline {key} repository mismatch: expected "
+            f"{identity.target_repository}, got {component_repository or 'unset'}"
+        )
+    if component_sha != identity.target_sha:
+        raise ValueError(
+            f"baseline {key} SHA mismatch: expected {identity.target_sha}, "
+            f"got {component_sha or 'unset'}"
+        )
+    return runtime
+
+
+def validate_artifact(
+    source: Path,
+    identity: BaselineIdentity,
+    provenance: BaselineProvenance,
+) -> dict[str, Any]:
+    identity = normalize_identity(identity)
+    provenance = normalize_provenance(provenance)
+    payload = _load_json_object(source)
+    _validate_metrics(payload, source=source)
+
+    same_spec = payload.get("same_spec")
+    if not isinstance(same_spec, dict):
+        raise ValueError(f"{source}: missing object key same_spec")
+    actual_scenario = str(same_spec.get("scenario") or "").strip()
+    actual_spec_id = str(same_spec.get("spec_id") or "").strip()
+    actual_spec_hash = str(same_spec.get("resolved_spec_hash") or "").strip().lower()
+    expected = (identity.scenario, identity.spec_id, identity.spec_hash)
+    actual = (actual_scenario, actual_spec_id, actual_spec_hash)
+    if actual != expected:
+        raise ValueError(
+            "baseline same-spec identity mismatch: "
+            f"expected {expected!r}, got {actual!r}"
+        )
+
+    runtime = _artifact_target_component(payload, identity)
+    expected_components = {
+        "engine": ("vLLM-HUST/vllm-hust", provenance.vllm_hust_sha),
+        "plugin": (
+            "vLLM-HUST/vllm-ascend-hust",
+            provenance.vllm_ascend_hust_sha,
+        ),
+    }
+    for name, (expected_repository, expected_sha) in expected_components.items():
+        component = runtime.get(name)
+        if not isinstance(component, dict):
+            raise ValueError(
+                f"baseline artifact is missing provenance component: {name}"
+            )
+        repository = str(component.get("repository") or "").strip()
+        sha = str(component.get("commit") or "").strip().lower()
+        if repository.lower() != expected_repository.lower() or sha != expected_sha:
+            raise ValueError(
+                f"baseline {name} provenance mismatch: expected "
+                f"{expected_repository}@{expected_sha}, got "
+                f"{repository or 'unset'}@{sha or 'unset'}"
+            )
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _manifest_payload(
+    identity: BaselineIdentity,
+    provenance: BaselineProvenance,
+    *,
+    artifact_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "identity": asdict(identity),
+        "provenance": asdict(provenance),
+        "artifact": {
+            "path": "run_leaderboard.json",
+            "sha256": artifact_sha256,
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def store_baseline(
+    repository_root: Path,
+    source: Path,
+    identity: BaselineIdentity,
+    provenance: BaselineProvenance,
+    *,
+    update_latest_pointer: bool = False,
+) -> Path:
+    identity = normalize_identity(identity)
+    provenance = normalize_provenance(provenance)
+    validate_artifact(source, identity, provenance)
+
+    destination_dir = repository_root / baseline_relative_dir(identity)
+    destination = destination_dir / "run_leaderboard.json"
+    manifest = destination_dir / "baseline-metadata.json"
+    artifact_sha256 = _sha256(source)
+    expected_manifest = _manifest_payload(
+        identity, provenance, artifact_sha256=artifact_sha256
+    )
+
+    if destination_dir.exists():
+        if not destination.is_file() or not manifest.is_file():
+            raise ValueError(
+                f"existing baseline key is incomplete and cannot be overwritten: {destination_dir}"
+            )
+        actual_manifest = _load_json_object(manifest)
+        if (
+            _sha256(destination) != artifact_sha256
+            or actual_manifest != expected_manifest
+        ):
+            raise ValueError(
+                f"baseline key already exists with different content: {destination_dir}"
+            )
+    else:
+        destination_dir.mkdir(parents=True)
+        shutil.copyfile(source, destination)
+        _write_json(manifest, expected_manifest)
+
+    if update_latest_pointer:
+        pointer = repository_root / latest_pointer_relative_path(identity)
+        _write_json(
+            pointer,
+            {
+                "schema_version": BASELINE_SCHEMA_VERSION,
+                "identity": asdict(identity),
+                "path": baseline_relative_dir(identity).as_posix()
+                + "/run_leaderboard.json",
+                "artifact_sha256": artifact_sha256,
+            },
+        )
+    return destination
+
+
+def load_manifest(
+    repository_root: Path, identity: BaselineIdentity
+) -> tuple[Path, BaselineProvenance]:
+    identity = normalize_identity(identity)
+    baseline_dir = repository_root / baseline_relative_dir(identity)
+    artifact = baseline_dir / "run_leaderboard.json"
+    manifest_path = baseline_dir / "baseline-metadata.json"
+    if not artifact.is_file() or not manifest_path.is_file():
+        raise ValueError(f"exact central baseline is unavailable: {baseline_dir}")
+    manifest = _load_json_object(manifest_path)
+    if manifest.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported baseline schema in {manifest_path}")
+    if manifest.get("identity") != asdict(identity):
+        raise ValueError(f"baseline manifest identity mismatch: {manifest_path}")
+    provenance_payload = manifest.get("provenance")
+    if not isinstance(provenance_payload, dict):
+        raise ValueError(f"baseline manifest provenance is missing: {manifest_path}")
+    try:
+        provenance = normalize_provenance(BaselineProvenance(**provenance_payload))
+    except TypeError as error:
+        raise ValueError(
+            f"invalid baseline provenance in {manifest_path}: {error}"
+        ) from error
+    artifact_metadata = manifest.get("artifact")
+    if not isinstance(artifact_metadata, dict):
+        raise ValueError(f"baseline artifact metadata is missing: {manifest_path}")
+    expected_digest = str(artifact_metadata.get("sha256") or "").strip()
+    if _sha256(artifact) != expected_digest:
+        raise ValueError(f"baseline artifact checksum mismatch: {artifact}")
+    validate_artifact(artifact, identity, provenance)
+    return artifact, provenance
+
+
+def fetch_baseline(
+    repository_root: Path,
+    output: Path,
+    identity: BaselineIdentity,
+    *,
+    expected_provenance: BaselineProvenance | None = None,
+) -> Path:
+    artifact, provenance = load_manifest(repository_root, identity)
+    if expected_provenance is not None:
+        expected = normalize_provenance(expected_provenance)
+        if provenance != expected:
+            raise ValueError(
+                "exact central baseline provenance mismatch: "
+                f"expected {expected!r}, got {provenance!r}"
+            )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(artifact, output)
+    return output
+
+
+def verify_main_commit(
+    repository: Path,
+    target_sha: str,
+    main_ref: str,
+    *,
+    require_tip: bool = False,
+) -> None:
+    target_sha = _validate_sha(target_sha, field="target_sha")
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "merge-base",
+            "--is-ancestor",
+            target_sha,
+            main_ref,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        raise ValueError(
+            f"target SHA {target_sha} is not an ancestor of {main_ref}{suffix}"
+        )
+    if require_tip:
+        tip = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", "--verify", main_ref],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if tip.returncode != 0:
+            detail = tip.stderr.strip()
+            raise ValueError(f"unable to resolve main ref {main_ref}: {detail}")
+        resolved_tip = tip.stdout.strip().lower()
+        if resolved_tip != target_sha:
+            raise ValueError(
+                "latest-main pointer may only reference the current main tip: "
+                f"expected {resolved_tip}, got {target_sha}"
+            )
+
+
+def _add_identity_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--target-repository", required=True)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--spec-id", required=True)
+    parser.add_argument("--spec-hash", required=True)
+
+
+def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--vllm-hust-sha", required=True)
+    parser.add_argument("--vllm-ascend-hust-sha", required=True)
+    parser.add_argument("--benchmark-runner-sha", required=True)
+    parser.add_argument("--hardware-chip-model", required=True)
+    parser.add_argument("--cann-version", required=True)
+    parser.add_argument("--torch-version", required=True)
+    parser.add_argument("--torch-npu-version", required=True)
+
+
+def _identity_from_args(args: argparse.Namespace) -> BaselineIdentity:
+    return BaselineIdentity(
+        target_repository=args.target_repository,
+        target_sha=args.target_sha,
+        scenario=args.scenario,
+        spec_id=args.spec_id,
+        spec_hash=args.spec_hash,
+    )
+
+
+def _provenance_from_args(args: argparse.Namespace) -> BaselineProvenance:
+    return BaselineProvenance(
+        vllm_hust_sha=args.vllm_hust_sha,
+        vllm_ascend_hust_sha=args.vllm_ascend_hust_sha,
+        benchmark_runner_sha=args.benchmark_runner_sha,
+        hardware_chip_model=args.hardware_chip_model,
+        cann_version=args.cann_version,
+        torch_version=args.torch_version,
+        torch_npu_version=args.torch_npu_version,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Manage central perfgate baselines")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    store_parser = commands.add_parser("store")
+    store_parser.add_argument("--repository-root", type=Path, required=True)
+    store_parser.add_argument("--source", type=Path, required=True)
+    store_parser.add_argument("--target-git-repository", type=Path, required=True)
+    store_parser.add_argument("--main-ref", default="origin/main")
+    store_parser.add_argument("--update-latest-pointer", action="store_true")
+    _add_identity_arguments(store_parser)
+    _add_provenance_arguments(store_parser)
+
+    fetch_parser = commands.add_parser("fetch")
+    fetch_parser.add_argument("--repository-root", type=Path, required=True)
+    fetch_parser.add_argument("--output", type=Path, required=True)
+    _add_identity_arguments(fetch_parser)
+    _add_provenance_arguments(fetch_parser)
+
+    validate_parser = commands.add_parser("validate")
+    validate_parser.add_argument("--repository-root", type=Path, required=True)
+    _add_identity_arguments(validate_parser)
+    _add_provenance_arguments(validate_parser)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        identity = _identity_from_args(args)
+        provenance = _provenance_from_args(args)
+        if args.command == "store":
+            verify_main_commit(
+                args.target_git_repository,
+                identity.target_sha,
+                args.main_ref,
+                require_tip=args.update_latest_pointer,
+            )
+            destination = store_baseline(
+                args.repository_root,
+                args.source,
+                identity,
+                provenance,
+                update_latest_pointer=args.update_latest_pointer,
+            )
+            print(destination)
+            return 0
+        if args.command == "fetch":
+            print(
+                fetch_baseline(
+                    args.repository_root,
+                    args.output,
+                    identity,
+                    expected_provenance=provenance,
+                )
+            )
+            return 0
+        if args.command == "validate":
+            _artifact, actual_provenance = load_manifest(args.repository_root, identity)
+            if actual_provenance != normalize_provenance(provenance):
+                raise ValueError("exact central baseline provenance mismatch")
+            print("Central perfgate baseline is valid.")
+            return 0
+    except (OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -373,3 +373,107 @@ def test_bare_git_branch_can_be_bootstrapped_and_updated(tmp_path: Path) -> None
         f"benchmark-baselines:{perfgate_baselines.baseline_relative_dir(second_identity)}/baseline-metadata.json",
         cwd=checkout,
     )
+
+
+def test_publish_bootstraps_updates_and_is_idempotent(tmp_path: Path) -> None:
+    remote = tmp_path / "central.git"
+    seed = tmp_path / "seed"
+    target = tmp_path / "target"
+    target_sha = _commit_target_main(target)
+    identity = _identity(target_sha=target_sha)
+    provenance = _provenance(vllm_hust_sha=target_sha)
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact, identity=identity)
+
+    _git("init", "--bare", str(remote), cwd=tmp_path)
+    seed.mkdir()
+    _git("init", "-b", "main", cwd=seed)
+    _git("config", "user.name", "Test User", cwd=seed)
+    _git("config", "user.email", "test@example.com", cwd=seed)
+    (seed / "README.md").write_text("central\n", encoding="utf-8")
+    _git("add", "README.md", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    _git("remote", "add", "origin", str(remote), cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+
+    first = perfgate_baselines.publish_baseline(
+        str(remote),
+        "benchmark-baselines",
+        artifact,
+        target,
+        "main",
+        identity,
+        provenance,
+        update_latest_pointer=True,
+    )
+    second = perfgate_baselines.publish_baseline(
+        str(remote),
+        "benchmark-baselines",
+        artifact,
+        target,
+        "main",
+        identity,
+        provenance,
+        update_latest_pointer=True,
+    )
+
+    assert first.startswith("published:")
+    assert second.startswith("unchanged:")
+    assert _git(
+        "ls-remote", "--heads", str(remote), "benchmark-baselines", cwd=tmp_path
+    )
+
+
+def test_publish_retries_non_fast_forward_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remote = tmp_path / "central.git"
+    seed = tmp_path / "seed"
+    target = tmp_path / "target"
+    target_sha = _commit_target_main(target)
+    identity = _identity(target_sha=target_sha)
+    provenance = _provenance(vllm_hust_sha=target_sha)
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact, identity=identity)
+    _git("init", "--bare", str(remote), cwd=tmp_path)
+    seed.mkdir()
+    _git("init", "-b", "main", cwd=seed)
+    _git("config", "user.name", "Test User", cwd=seed)
+    _git("config", "user.email", "test@example.com", cwd=seed)
+    (seed / "README.md").write_text("central\n", encoding="utf-8")
+    _git("add", "README.md", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    _git("remote", "add", "origin", str(remote), cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+
+    original_run_git = perfgate_baselines._run_git
+    failed_once = False
+
+    def fail_first_push(
+        arguments: list[str],
+        *,
+        cwd: Path | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal failed_once
+        if arguments and arguments[0] == "push" and not failed_once:
+            failed_once = True
+            return subprocess.CompletedProcess(
+                ["git", *arguments], 1, "", "simulated non-fast-forward"
+            )
+        return original_run_git(arguments, cwd=cwd, check=check)
+
+    monkeypatch.setattr(perfgate_baselines, "_run_git", fail_first_push)
+    result = perfgate_baselines.publish_baseline(
+        str(remote),
+        "benchmark-baselines",
+        artifact,
+        target,
+        "main",
+        identity,
+        provenance,
+        max_attempts=2,
+    )
+
+    assert failed_once is True
+    assert result.startswith("published:")

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from vllm_hust_benchmark import perfgate_baselines
+
+
+TARGET_REPOSITORY = "vLLM-HUST/vllm-hust"
+TARGET_SHA = "1" * 40
+PLUGIN_SHA = "2" * 40
+BENCHMARK_SHA = "3" * 40
+SPEC_ID = "perfgate-ascend-qwen25-3b-910b2"
+SPEC_HASH = "a" * 64
+
+
+def _identity(**overrides: str) -> perfgate_baselines.BaselineIdentity:
+    values = {
+        "target_repository": TARGET_REPOSITORY,
+        "target_sha": TARGET_SHA,
+        "scenario": "random-online",
+        "spec_id": SPEC_ID,
+        "spec_hash": SPEC_HASH,
+        **overrides,
+    }
+    return perfgate_baselines.BaselineIdentity(**values)
+
+
+def _provenance(
+    **overrides: str,
+) -> perfgate_baselines.BaselineProvenance:
+    values = {
+        "vllm_hust_sha": TARGET_SHA,
+        "vllm_ascend_hust_sha": PLUGIN_SHA,
+        "benchmark_runner_sha": BENCHMARK_SHA,
+        "hardware_chip_model": "910B2",
+        "cann_version": "9.0.0",
+        "torch_version": "2.10.0",
+        "torch_npu_version": "2.10.0",
+        **overrides,
+    }
+    return perfgate_baselines.BaselineProvenance(**values)
+
+
+def _write_artifact(
+    path: Path,
+    *,
+    identity: perfgate_baselines.BaselineIdentity | None = None,
+    throughput: float = 100.0,
+) -> None:
+    identity = perfgate_baselines.normalize_identity(identity or _identity())
+    engine_sha = (
+        identity.target_sha
+        if identity.target_repository == "vLLM-HUST/vllm-hust"
+        else TARGET_SHA
+    )
+    plugin_sha = (
+        identity.target_sha
+        if identity.target_repository == "vLLM-HUST/vllm-ascend-hust"
+        else PLUGIN_SHA
+    )
+    path.write_text(
+        json.dumps(
+            {
+                "metrics": {
+                    "throughput_tps": throughput,
+                    "ttft_ms": 50.0,
+                    "tbt_ms": 10.0,
+                },
+                "same_spec": {
+                    "scenario": identity.scenario,
+                    "spec_id": identity.spec_id,
+                    "resolved_spec_hash": identity.spec_hash,
+                },
+                "metadata": {
+                    "github_repository": identity.target_repository,
+                    "git_commit": identity.target_sha,
+                    "runtime_provenance": {
+                        "engine": {
+                            "repository": "vLLM-HUST/vllm-hust",
+                            "commit": engine_sha,
+                        },
+                        "plugin": {
+                            "repository": "vLLM-HUST/vllm-ascend-hust",
+                            "commit": plugin_sha,
+                        },
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_target_main(repository: Path) -> str:
+    repository.mkdir()
+    _git("init", "-b", "main", cwd=repository)
+    _git("config", "user.name", "Test User", cwd=repository)
+    _git("config", "user.email", "test@example.com", cwd=repository)
+    (repository / "README.md").write_text("target\n", encoding="utf-8")
+    _git("add", "README.md", cwd=repository)
+    _git("commit", "-m", "initial target", cwd=repository)
+    return _git("rev-parse", "HEAD", cwd=repository)
+
+
+def test_central_path_contains_complete_identity() -> None:
+    relative = perfgate_baselines.baseline_relative_dir(_identity())
+
+    assert relative.as_posix() == (
+        "baselines/vLLM-HUST/vllm-hust/"
+        f"{TARGET_SHA}/random-online/{SPEC_ID}/{SPEC_HASH}"
+    )
+
+
+def test_store_and_exact_fetch_validate_provenance(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    output = tmp_path / "fetched.json"
+    _write_artifact(artifact)
+
+    destination = perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        update_latest_pointer=True,
+    )
+    fetched = perfgate_baselines.fetch_baseline(
+        central,
+        output,
+        _identity(),
+        expected_provenance=_provenance(),
+    )
+
+    assert destination.read_bytes() == artifact.read_bytes()
+    assert fetched.read_bytes() == artifact.read_bytes()
+    pointer = central / perfgate_baselines.latest_pointer_relative_path(_identity())
+    assert json.loads(pointer.read_text(encoding="utf-8"))["identity"] == {
+        "scenario": "random-online",
+        "spec_hash": SPEC_HASH,
+        "spec_id": SPEC_ID,
+        "target_repository": TARGET_REPOSITORY,
+        "target_sha": TARGET_SHA,
+    }
+
+
+def test_runtime_versions_accept_local_version_identifiers(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    destination = perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(
+            torch_version="2.10.0+cpu",
+            torch_npu_version="2.10.0.post1+git.abc123",
+        ),
+    )
+
+    assert destination.is_file()
+
+
+def test_store_is_idempotent_but_refuses_overwrite(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    first = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance()
+    )
+    second = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance()
+    )
+    assert first == second
+
+    _write_artifact(artifact, throughput=99.0)
+    with pytest.raises(ValueError, match="different content"):
+        perfgate_baselines.store_baseline(central, artifact, _identity(), _provenance())
+
+
+def test_store_rejects_spec_and_companion_mismatch(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    with pytest.raises(ValueError, match="same-spec identity mismatch"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(spec_hash="b" * 64),
+            _provenance(),
+        )
+    with pytest.raises(ValueError, match="plugin provenance mismatch"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(),
+            _provenance(vllm_ascend_hust_sha="4" * 40),
+        )
+
+
+def test_fetch_rejects_missing_exact_baseline(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="exact central baseline is unavailable"):
+        perfgate_baselines.fetch_baseline(
+            tmp_path,
+            tmp_path / "output.json",
+            _identity(),
+        )
+
+
+def test_fetch_rejects_tampered_artifact(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    destination = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance()
+    )
+    destination.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        perfgate_baselines.fetch_baseline(
+            central,
+            tmp_path / "output.json",
+            _identity(),
+        )
+
+
+def test_store_cli_requires_target_sha_on_main(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    actual_sha = _commit_target_main(target)
+    artifact = tmp_path / "run_leaderboard.json"
+    identity = _identity(target_sha=actual_sha)
+    _write_artifact(artifact, identity=identity)
+    central = tmp_path / "central"
+    central.mkdir()
+
+    common = [
+        "store",
+        "--repository-root",
+        str(central),
+        "--source",
+        str(artifact),
+        "--target-git-repository",
+        str(target),
+        "--main-ref",
+        "main",
+        "--target-repository",
+        TARGET_REPOSITORY,
+        "--target-sha",
+        actual_sha,
+        "--scenario",
+        "random-online",
+        "--spec-id",
+        SPEC_ID,
+        "--spec-hash",
+        SPEC_HASH,
+        "--vllm-hust-sha",
+        actual_sha,
+        "--vllm-ascend-hust-sha",
+        PLUGIN_SHA,
+        "--benchmark-runner-sha",
+        BENCHMARK_SHA,
+        "--hardware-chip-model",
+        "910B2",
+        "--cann-version",
+        "9.0.0",
+        "--torch-version",
+        "2.10.0",
+        "--torch-npu-version",
+        "2.10.0",
+    ]
+
+    assert perfgate_baselines.main(common) == 0
+    assert (
+        perfgate_baselines.main(
+            [
+                *common[: common.index("--target-sha") + 1],
+                "f" * 40,
+                *common[common.index("--target-sha") + 2 :],
+            ]
+        )
+        == 2
+    )
+
+
+def test_latest_pointer_requires_current_main_tip(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    old_sha = _commit_target_main(target)
+    (target / "README.md").write_text("new tip\n", encoding="utf-8")
+    _git("add", "README.md", cwd=target)
+    _git("commit", "-m", "advance target", cwd=target)
+    new_sha = _git("rev-parse", "HEAD", cwd=target)
+
+    perfgate_baselines.verify_main_commit(target, old_sha, "main")
+    with pytest.raises(ValueError, match="current main tip"):
+        perfgate_baselines.verify_main_commit(target, old_sha, "main", require_tip=True)
+    perfgate_baselines.verify_main_commit(target, new_sha, "main", require_tip=True)
+
+
+def test_bare_git_branch_can_be_bootstrapped_and_updated(tmp_path: Path) -> None:
+    remote = tmp_path / "central.git"
+    seed = tmp_path / "seed"
+    checkout = tmp_path / "checkout"
+    _git("init", "--bare", str(remote), cwd=tmp_path)
+    seed.mkdir()
+    _git("init", "-b", "main", cwd=seed)
+    _git("config", "user.name", "Test User", cwd=seed)
+    _git("config", "user.email", "test@example.com", cwd=seed)
+    (seed / "README.md").write_text("central\n", encoding="utf-8")
+    _git("add", "README.md", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    _git("remote", "add", "origin", str(remote), cwd=seed)
+    _git("push", "origin", "main", cwd=seed)
+
+    _git("clone", str(remote), str(checkout), cwd=tmp_path)
+    _git("config", "user.name", "Baseline Writer", cwd=checkout)
+    _git("config", "user.email", "writer@example.com", cwd=checkout)
+    _git("checkout", "--orphan", "benchmark-baselines", cwd=checkout)
+    for child in checkout.iterdir():
+        if child.name != ".git" and child.is_file():
+            child.unlink()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    perfgate_baselines.store_baseline(checkout, artifact, _identity(), _provenance())
+    _git("add", "baselines", cwd=checkout)
+    _git("commit", "-m", "store first baseline", cwd=checkout)
+    _git("push", "origin", "benchmark-baselines", cwd=checkout)
+
+    second_sha = "4" * 40
+    second_identity = _identity(target_sha=second_sha)
+    second_artifact = tmp_path / "second-run-leaderboard.json"
+    _write_artifact(second_artifact, identity=second_identity)
+    perfgate_baselines.store_baseline(
+        checkout,
+        second_artifact,
+        second_identity,
+        _provenance(vllm_hust_sha=second_sha),
+    )
+    _git("add", "baselines", cwd=checkout)
+    _git("commit", "-m", "store second baseline", cwd=checkout)
+    _git("push", "origin", "benchmark-baselines", cwd=checkout)
+
+    assert (
+        _git(
+            "ls-remote", "--heads", "origin", "benchmark-baselines", cwd=checkout
+        ).split()[1]
+        == "refs/heads/benchmark-baselines"
+    )
+    assert _git(
+        "show",
+        f"benchmark-baselines:{perfgate_baselines.baseline_relative_dir(second_identity)}/baseline-metadata.json",
+        cwd=checkout,
+    )


### PR DESCRIPTION
## Summary

  Add the central Perfgate baseline protocol and publisher to
  `vllm-hust-benchmark`.

  This change defines a single baseline ownership and storage model for
  `vllm-hust` and `vllm-ascend-hust`, replacing the duplicated lifecycle model
  where each target repository maintains its own baseline branch.

  The new `perfgate-baseline` CLI provides:

  - `store` for validated, immutable baseline storage
  - `fetch` for exact baseline lookup
  - `validate` for artifact, identity, provenance, and checksum validation
  - `publish` for safely updating the central `benchmark-baselines` Git branch

  Baselines are isolated by:

  ```text
  target repository / target SHA / scenario / spec ID / spec hash

  The protocol validates:

  - target SHA membership in the declared main history
  - repository, SHA, scenario, spec ID, and spec hash
  - throughput, TTFT, and TBT metrics
  - core, plugin, and benchmark runner revisions
  - hardware, CANN, PyTorch, and torch-npu provenance
  - artifact checksums and immutable/idempotent writes

  The publisher supports initial branch creation and retries publication from a
  fresh checkout after a concurrent non-fast-forward push. Credentials remain
  the responsibility of the trusted caller and are not accepted as CLI
  arguments.

  This PR provides the protocol and publishing primitives only. Wiring the
  trusted producer workflows, creating/bootstraping the central baseline branch,
  migrating consumers, and implementing backfill orchestration are separate
  rollout steps.

  This work does not duplicate
  vllm-hust-benchmark#62 (https://github.com/vLLM-HUST/vllm-hust-benchmark/pull/62),
  which addressed current same-spec benchmark retry and resource-pressure
  handling.

  AI assistance was used during implementation. The submitter reviewed the
  changes and validation results.

  ## Repository Scope

  - [ ] vllm-hust
  - [ ] vllm-ascend-hust
  - [ ] ascend-runtime-manager
  - [ ] vllm-hust-dev-hub
  - [x] vllm-hust-benchmark
  - [ ] vllm-hust-website
  - [ ] vllm-hust-workstation
  - [ ] vllm-hust-docs
  - [ ] EvoScientist
  - [ ] other

  ## Validation

  Focused protocol and Git publisher tests:

  pytest -q tests/test_perfgate_baselines.py

  Lint validation:

  ruff check \
    src/vllm_hust_benchmark/perfgate_baselines.py \
    tests/test_perfgate_baselines.py

  Patch validation:

  git diff --check origin/main...HEAD

  Results:

  56 passed
  ruff: passed
  git diff --check: passed

  The tests cover:

  - target repository/SHA/scenario/spec path isolation
  - exact store, fetch, and validation
  - missing and mismatched baseline failures
  - provenance and metric validation
  - checksum verification
  - immutable and idempotent writes
  - main ancestry and latest-main pointer validation
  - first publication to a new central branch
  - repeated identical publication
  - conflicting baseline rejection
  - concurrent non-fast-forward publication retry using bare Git repositories

  No Ascend hardware validation is required for this PR because it adds local
  storage, validation, and Git publication primitives without running benchmark
  workloads.

  ## Risks

  - This PR does not yet wire producer or consumer workflows.
  - The central branch must not become the required consumer source until an
    exact compatible baseline has been bootstrapped.

  - Trusted producer workflows still need scoped credentials with write access
    to the central baseline repository.

  - Cross-repository writer ownership and hardware backfill orchestration remain
    separate rollout work.

  - The initial required-gate rollout supports only the random-online scenario,
    although the storage schema retains a scenario dimension for future use.

  - The new CLI is additive and does not change existing benchmark commands.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.