### PR TITLE
fix(perfgate): reject invalid central baselines

### DIFF
--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -13,6 +13,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from vllm_hust_benchmark.same_spec import compute_resolved_spec_hash
+
 
 BASELINE_SCHEMA_VERSION = "perfgate-baseline/v1"
 SUPPORTED_SCENARIOS = frozenset({"random-online"})
@@ -22,7 +24,7 @@ SUPPORTED_TARGET_REPOSITORIES = {
 }
 SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 SAFE_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
-REQUIRED_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms")
+REQUIRED_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms", "error_rate")
 DEFAULT_BASELINE_BRANCH = "benchmark-baselines"
 DEFAULT_WRITER_NAME = "vLLM-HUST Baseline Writer"
 DEFAULT_WRITER_EMAIL = "baseline-writer@vllm-hust.local"
@@ -172,7 +174,11 @@ def _validate_metrics(payload: dict[str, Any], *, source: Path) -> None:
         except (TypeError, ValueError):
             invalid.append(name)
             continue
-        if not math.isfinite(number) or number < 0:
+        if (
+            not math.isfinite(number)
+            or number < 0
+            or (name == "error_rate" and number != 0)
+        ):
             invalid.append(name)
     if invalid:
         raise ValueError(f"{source}: invalid required metrics: {', '.join(invalid)}")
@@ -241,6 +247,17 @@ def validate_artifact(
     actual_scenario = str(same_spec.get("scenario") or "").strip()
     actual_spec_id = str(same_spec.get("spec_id") or "").strip()
     actual_spec_hash = str(same_spec.get("resolved_spec_hash") or "").strip().lower()
+    try:
+        computed_spec_hash = compute_resolved_spec_hash(same_spec)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"{source}: invalid resolved same-spec payload: {error}"
+        ) from error
+    if actual_spec_hash != computed_spec_hash:
+        raise ValueError(
+            "baseline resolved spec hash mismatch: "
+            f"declared {actual_spec_hash or 'unset'}, computed {computed_spec_hash}"
+        )
     expected = (identity.scenario, identity.spec_id, identity.spec_hash)
     actual = (actual_scenario, actual_spec_id, actual_spec_hash)
     if actual != expected:
@@ -307,6 +324,20 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     )
 
 
+def _reject_symlink_components(
+    repository_root: Path, relative_path: PurePosixPath
+) -> None:
+    if repository_root.is_symlink():
+        raise ValueError(
+            f"central baseline repository root is a symlink: {repository_root}"
+        )
+    current = repository_root
+    for component in relative_path.parts:
+        current = current / component
+        if current.is_symlink():
+            raise ValueError(f"central baseline path contains a symlink: {current}")
+
+
 def store_baseline(
     repository_root: Path,
     source: Path,
@@ -319,9 +350,13 @@ def store_baseline(
     provenance = normalize_provenance(provenance)
     validate_artifact(source, identity, provenance)
 
-    destination_dir = repository_root / baseline_relative_dir(identity)
+    relative_dir = baseline_relative_dir(identity)
+    _reject_symlink_components(repository_root, relative_dir)
+    destination_dir = repository_root / relative_dir
     destination = destination_dir / "run_leaderboard.json"
     manifest = destination_dir / "baseline-metadata.json"
+    _reject_symlink_components(repository_root, relative_dir / "run_leaderboard.json")
+    _reject_symlink_components(repository_root, relative_dir / "baseline-metadata.json")
     artifact_sha256 = _sha256(source)
     expected_manifest = _manifest_payload(
         identity, provenance, artifact_sha256=artifact_sha256
@@ -346,7 +381,9 @@ def store_baseline(
         _write_json(manifest, expected_manifest)
 
     if update_latest_pointer:
-        pointer = repository_root / latest_pointer_relative_path(identity)
+        pointer_relative_path = latest_pointer_relative_path(identity)
+        _reject_symlink_components(repository_root, pointer_relative_path)
+        pointer = repository_root / pointer_relative_path
         _write_json(
             pointer,
             {
@@ -364,7 +401,10 @@ def load_manifest(
     repository_root: Path, identity: BaselineIdentity
 ) -> tuple[Path, BaselineProvenance]:
     identity = normalize_identity(identity)
-    baseline_dir = repository_root / baseline_relative_dir(identity)
+    relative_dir = baseline_relative_dir(identity)
+    _reject_symlink_components(repository_root, relative_dir / "run_leaderboard.json")
+    _reject_symlink_components(repository_root, relative_dir / "baseline-metadata.json")
+    baseline_dir = repository_root / relative_dir
     artifact = baseline_dir / "run_leaderboard.json"
     manifest_path = baseline_dir / "baseline-metadata.json"
     if not artifact.is_file() or not manifest_path.is_file():

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -14,7 +14,29 @@ TARGET_SHA = "1" * 40
 PLUGIN_SHA = "2" * 40
 BENCHMARK_SHA = "3" * 40
 SPEC_ID = "perfgate-ascend-qwen25-3b-910b2"
-SPEC_HASH = "a" * 64
+SAME_SPEC_PAYLOAD = {
+    "schema_version": "benchmark-same-spec/v1",
+    "spec_id": "perfgate-ascend-qwen25-3b-910b2",
+    "scenario": "random-online",
+    "model": "Qwen/Qwen2.5-3B-Instruct",
+    "model_parameters": "3B",
+    "model_precision": "BF16",
+    "model_quantization": "",
+    "hardware_vendor": "Ascend",
+    "hardware_chip_model": "910B2",
+    "chip_count": 1,
+    "node_count": 1,
+    "resolved_server_parameters": {
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_model_len": 4096,
+    },
+    "resolved_client_parameters": {
+        "num_prompts": 8,
+        "request_rate": "inf",
+    },
+}
+SPEC_HASH = perfgate_baselines.compute_resolved_spec_hash(SAME_SPEC_PAYLOAD)
 
 
 def _identity(**overrides: str) -> perfgate_baselines.BaselineIdentity:
@@ -50,6 +72,7 @@ def _write_artifact(
     *,
     identity: perfgate_baselines.BaselineIdentity | None = None,
     throughput: float = 100.0,
+    error_rate: float | None = 0.0,
 ) -> None:
     identity = perfgate_baselines.normalize_identity(identity or _identity())
     engine_sha = (
@@ -62,17 +85,19 @@ def _write_artifact(
         if identity.target_repository == "vLLM-HUST/vllm-ascend-hust"
         else PLUGIN_SHA
     )
+    metrics = {
+        "throughput_tps": throughput,
+        "ttft_ms": 50.0,
+        "tbt_ms": 10.0,
+    }
+    if error_rate is not None:
+        metrics["error_rate"] = error_rate
     path.write_text(
         json.dumps(
             {
-                "metrics": {
-                    "throughput_tps": throughput,
-                    "ttft_ms": 50.0,
-                    "tbt_ms": 10.0,
-                },
+                "metrics": metrics,
                 "same_spec": {
-                    "scenario": identity.scenario,
-                    "spec_id": identity.spec_id,
+                    **SAME_SPEC_PAYLOAD,
                     "resolved_spec_hash": identity.spec_hash,
                 },
                 "metadata": {
@@ -218,6 +243,65 @@ def test_store_rejects_spec_and_companion_mismatch(tmp_path: Path) -> None:
             _identity(),
             _provenance(vllm_ascend_hust_sha="4" * 40),
         )
+
+
+@pytest.mark.parametrize("error_rate", [None, 0.01, 1.0])
+def test_validate_artifact_rejects_missing_or_nonzero_error_rate(
+    tmp_path: Path, error_rate: float | None
+) -> None:
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact, error_rate=error_rate)
+
+    with pytest.raises(ValueError, match="invalid required metrics: error_rate"):
+        perfgate_baselines.validate_artifact(artifact, _identity(), _provenance())
+
+
+def test_validate_artifact_recomputes_resolved_spec_hash(tmp_path: Path) -> None:
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    payload["same_spec"]["resolved_server_parameters"]["max_num_seqs"] = 32
+    artifact.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="resolved spec hash mismatch"):
+        perfgate_baselines.validate_artifact(artifact, _identity(), _provenance())
+
+
+def test_store_rejects_symlinked_baselines_directory(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (central / "baselines").symlink_to(victim, target_is_directory=True)
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    with pytest.raises(ValueError, match="contains a symlink"):
+        perfgate_baselines.store_baseline(central, artifact, _identity(), _provenance())
+    assert list(victim.iterdir()) == []
+
+
+def test_store_rejects_symlinked_latest_pointer(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    perfgate_baselines.store_baseline(central, artifact, _identity(), _provenance())
+    pointer = central / perfgate_baselines.latest_pointer_relative_path(_identity())
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    victim = tmp_path / "victim.json"
+    victim.write_text("preserve me\n", encoding="utf-8")
+    pointer.symlink_to(victim)
+
+    with pytest.raises(ValueError, match="contains a symlink"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(),
+            _provenance(),
+            update_latest_pointer=True,
+        )
+    assert victim.read_text(encoding="utf-8") == "preserve me\n"
 
 
 def test_fetch_rejects_missing_exact_baseline(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- require central perfgate artifacts to report a finite zero error rate
- recompute the resolved same-spec hash instead of trusting the artifact's declared value
- reject symlinks in baseline storage, manifests, and latest-main pointers before reading or writing

## Reproduction

On benchmark main after #66, `validate_artifact()` accepted an artifact with `error_rate=1.0` whose declared `resolved_spec_hash` disagreed with `compute_resolved_spec_hash()`. The central baseline branch has not been bootstrapped, so this fix should land before the first publication.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` — 243 passed
- Ruff check and format check passed for both changed files
- Python compileall and `git diff --check` passed
- regression tests verify missing/nonzero error rate rejection, post-export same-spec mutation rejection, and no-write behavior for symlinked baseline directories and latest pointers

This is an integrity fix; it makes no serving-performance claim.
