### PR TITLE
fix(leaderboard): separate prompt count from concurrency

### DIFF
--- a/leaderboard-data/snapshots/leaderboard_single.json
+++ b/leaderboard-data/snapshots/leaderboard_single.json
@@ -9362,7 +9362,7 @@
       "input_length": 4096,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "prefix_repetition"
     },
     "metrics": {
@@ -9522,7 +9522,7 @@
       "input_length": 4096,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "prefix_repetition"
     },
     "metrics": {
@@ -14863,7 +14863,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -15035,7 +15035,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -15207,7 +15207,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -15379,7 +15379,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -15551,7 +15551,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -16363,7 +16363,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -16535,7 +16535,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "random"
     },
     "metrics": {
@@ -19923,7 +19923,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20082,7 +20082,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20241,7 +20241,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20400,7 +20400,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20559,7 +20559,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20718,7 +20718,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -20877,7 +20877,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -21036,7 +21036,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -21195,7 +21195,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -21354,7 +21354,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -22743,7 +22743,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -23050,7 +23050,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -23204,7 +23204,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -23358,7 +23358,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sharegpt"
     },
     "metrics": {
@@ -24876,7 +24876,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {
@@ -25030,7 +25030,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {
@@ -25337,7 +25337,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {
@@ -25491,7 +25491,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {
@@ -25645,7 +25645,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {
@@ -25799,7 +25799,7 @@
       "input_length": 1024,
       "output_length": 256,
       "batch_size": null,
-      "concurrent_requests": 200,
+      "concurrent_requests": null,
       "dataset": "sonnet"
     },
     "metrics": {

--- a/scripts/backfill_single_gpu.py
+++ b/scripts/backfill_single_gpu.py
@@ -1631,9 +1631,6 @@ def submit_artifact(
         cmd += ["--output-length", str(params["output_length"])]
     if params.get("batch_size") is not None:
         cmd += ["--batch-size", str(params["batch_size"])]
-    if params.get("num_prompts") is not None:
-        cmd += ["--concurrent-requests", str(params["num_prompts"])]
-
     log(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
     subprocess.run(cmd, cwd=REPO_ROOT, check=True)
 

--- a/scripts/run_latest_benchmark.sh
+++ b/scripts/run_latest_benchmark.sh
@@ -30,13 +30,12 @@ mkdir -p "$BENCH_REPO/.benchmarks/runs"
 # ── 辅助函数 ──────────────────────────────────────────────────────────────
 submit_artifact() {
   local scenario=$1 result_file=$2 run_id=$3
-  local input_len=${4:-} output_len=${5:-} batch_size=${6:-} num_prompts=${7:-}
+  local input_len=${4:-} output_len=${5:-} batch_size=${6:-}
 
   local cmd_args=()
   [[ -n "$input_len"   ]] && cmd_args+=(--input-length "$input_len")
   [[ -n "$output_len"  ]] && cmd_args+=(--output-length "$output_len")
   [[ -n "$batch_size"  ]] && cmd_args+=(--batch-size "$batch_size")
-  [[ -n "$num_prompts" ]] && cmd_args+=(--concurrent-requests "$num_prompts")
 
   echo ">>> Submitting $scenario → submissions/$run_id/"
   cd "$BENCH_REPO"
@@ -102,7 +101,7 @@ $PY -m vllm.entrypoints.cli.main bench throughput \
   --num-prompts 200 \
   --output-json "$RESULT_DIR/throughput.json" 2>&1 | tee "$RESULT_DIR/bench.log"
 
-submit_artifact sharegpt-throughput "$RESULT_DIR/throughput.json" "$RUN_ID" "" "" "" 200
+submit_artifact sharegpt-throughput "$RESULT_DIR/throughput.json" "$RUN_ID"
 
 # ── 3. sonnet-throughput ────────────────────────────────────────────────
 echo ""
@@ -120,7 +119,7 @@ $PY -m vllm.entrypoints.cli.main bench throughput \
   --num-prompts 200 \
   --output-json "$RESULT_DIR/throughput.json" 2>&1 | tee "$RESULT_DIR/bench.log"
 
-submit_artifact sonnet-throughput "$RESULT_DIR/throughput.json" "$RUN_ID" "" "" "" 200
+submit_artifact sonnet-throughput "$RESULT_DIR/throughput.json" "$RUN_ID"
 
 # ── 4. 聚合 ──────────────────────────────────────────────────────────────
 echo ""

--- a/submissions/single-gpu-backfill-prefix-repetition-online-73187bc8b-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-prefix-repetition-online-73187bc8b-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 4096,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "prefix_repetition"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-prefix-repetition-online-a46abb7ae-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-prefix-repetition-online-a46abb7ae-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 4096,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "prefix_repetition"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-random-online-2206f1f7b-20260717/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-random-online-2206f1f7b-20260717/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "random"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-random-online-702214146-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-random-online-702214146-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "random"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-random-online-8d28fcf98-20260717/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-random-online-8d28fcf98-20260717/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "random"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-random-online-a46abb7ae-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-random-online-a46abb7ae-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "random"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-6f612fbed-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-6f612fbed-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-702214146-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-702214146-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-73187bc8b-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-73187bc8b-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-8d28fcf98-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-8d28fcf98-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-a46abb7ae-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-a46abb7ae-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-online-ae16d0943-20260720/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-online-ae16d0943-20260720/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-throughput-702214146-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-throughput-702214146-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-throughput-73187bc8b-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-throughput-73187bc8b-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sharegpt-throughput-a46abb7ae-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sharegpt-throughput-a46abb7ae-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sharegpt"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sonnet-throughput-702214146-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sonnet-throughput-702214146-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sonnet"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sonnet-throughput-73187bc8b-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sonnet-throughput-73187bc8b-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sonnet"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sonnet-throughput-a46abb7ae-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sonnet-throughput-a46abb7ae-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sonnet"
   },
   "metrics": {

--- a/submissions/single-gpu-backfill-sonnet-throughput-ae16d0943-20260722/run_leaderboard.json
+++ b/submissions/single-gpu-backfill-sonnet-throughput-ae16d0943-20260722/run_leaderboard.json
@@ -26,7 +26,7 @@
     "input_length": 1024,
     "output_length": 256,
     "batch_size": null,
-    "concurrent_requests": 200,
+    "concurrent_requests": null,
     "dataset": "sonnet"
   },
   "metrics": {

--- a/tests/test_historical_pr_backfill.py
+++ b/tests/test_historical_pr_backfill.py
@@ -195,3 +195,18 @@ def test_dev_hub_secret_env_does_not_override_process_env(
     env = module.dev_hub_secret_env(dev_hub)
 
     assert env == {"VLLM_HUST_API_KEY": "local-secret"}
+
+
+def test_single_gpu_backfill_does_not_treat_prompt_count_as_concurrency() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    backfill_script = (
+        repo_root / "scripts" / "backfill_single_gpu.py"
+    ).read_text(encoding="utf-8")
+    latest_script = (
+        repo_root / "scripts" / "run_latest_benchmark.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'cmd += ["--concurrent-requests", str(params["num_prompts"])]' not in (
+        backfill_script
+    )
+    assert '--concurrent-requests "$num_prompts"' not in latest_script


### PR DESCRIPTION
## Summary
- stop mapping benchmark `num_prompts` to submission `concurrent_requests`
- repair 29 affected historical snapshot records and 19 canonical backfill submissions
- add a regression test for both single-GPU producer scripts

## Validation
- `PYTHONPATH=src:. pytest -q` (252 passed)
- `git diff --check`