### PR TITLE
fix: enforce explicit workload configuration metadata

### DIFF
--- a/docs/HISTORICAL_PR_BACKFILL.md
+++ b/docs/HISTORICAL_PR_BACKFILL.md
@@ -198,6 +198,7 @@ Operational rule for shared-data safety:
 - After each successful workload, immediately upload that one submission plus
   regenerated snapshots to HF, then update the GitHub issue ledger before
   starting any next workload.
+
 - Failed startups or failed client runs must be recorded in the ledger but must
   not be uploaded as public leaderboard submissions.
 - Before publication, apply `docs/leaderboard-exclusions.json`. A submission
@@ -207,6 +208,42 @@ Operational rule for shared-data safety:
 - The human audit trail is `docs/HISTORICAL_PR_BENCHMARK_BLACKLIST.md`. Operators
   must read it before selecting a historical gap. Blacklisted commits are not
   missing coverage: they are intentionally forbidden from backfill and retest.
+
+## Required effective-configuration metadata
+
+Every CI/CD run and every manually repaired/backfilled point must publish the
+effective values used by the process, not merely the flags that happened to be
+typed. The exporter stamps compliant official artifacts with
+`metadata.workload_config_contract = "explicit-effective/v1"`, and public
+snapshot validation rejects new official records that omit or contradict the
+contract.
+
+Before committing a submission, verify:
+
+- `workload.input_length`, `workload.output_length`, `workload.batch_size`,
+  `workload.concurrent_requests`, and `workload.dataset` all exist. Use JSON
+  `null` only when the setting is genuinely not applicable.
+- `metadata.submitted_at` is present and is the actual artifact-generation
+  timestamp; do not remove or backdate it to obtain legacy treatment.
+- `same_spec.resolved_server_parameters` records effective server defaults such
+  as `gpu_memory_utilization` and workload-specific `max_model_len`.
+- `same_spec.resolved_client_parameters` records effective client defaults,
+  including `no_stream`, offline GPU memory settings, batch size, and the
+  dataset-specific length fields.
+- `num_prompts` is the total sample count. It must never be copied into
+  `workload.concurrent_requests`; only an actual `max_concurrency` /
+  `concurrent_requests` client setting may populate that field.
+- Workload lengths and batch/concurrency metadata agree with the resolved
+  client parameters.
+
+Do not hand-edit the contract marker to bypass validation. Regenerate the
+artifact through `vllm_hust_benchmark.cli submit` or
+`export-leaderboard-artifact`, then run:
+
+```bash
+PYTHONPATH=src:. python scripts/validate_public_leaderboard_snapshots.py \
+  --snapshot-dir leaderboard-data/snapshots
+```
 
 Container recorded by the originating server at handoff:
 

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json
@@ -20,6 +20,7 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json
@@ -20,6 +20,7 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",
@@ -31,6 +32,7 @@
     "backend": "vllm",
     "endpoint": "/v1/completions",
     "dataset_name": "prefix_repetition",
+    "no_stream": false,
     "num_prompts": 200,
     "input_len": 4096,
     "output_len": 256,

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json
@@ -20,11 +20,13 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": ""
   },
   "client_parameters": {
+    "gpu_memory_utilization": 0.6,
     "input_len": 1024,
     "output_len": 128,
     "batch_size": 8,

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json
@@ -20,6 +20,7 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",
@@ -31,6 +32,7 @@
     "backend": "vllm",
     "endpoint": "/v1/completions",
     "dataset_name": "random",
+    "no_stream": false,
     "num_prompts": 200,
     "input_len": 1024,
     "output_len": 256,

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json
@@ -20,6 +20,7 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",
@@ -31,6 +32,7 @@
     "backend": "vllm",
     "endpoint": "/v1/completions",
     "dataset_name": "sharegpt",
+    "no_stream": false,
     "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
     "num_prompts": 200,
     "request_rate": 1,

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json
@@ -20,11 +20,13 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": ""
   },
   "client_parameters": {
+    "gpu_memory_utilization": 0.6,
     "backend": "vllm",
     "dataset_name": "sharegpt",
     "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json
@@ -20,11 +20,13 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": ""
   },
   "client_parameters": {
+    "gpu_memory_utilization": 0.6,
     "backend": "vllm",
     "dataset_name": "sonnet",
     "dataset_path": "benchmarks/sonnet.txt",

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json
@@ -20,6 +20,8 @@
   "node_count": 1,
   "server_parameters": {
     "tensor_parallel_size": 1,
+    "gpu_memory_utilization": 0.6,
+    "max_model_len": 30720,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",
@@ -34,6 +36,7 @@
     "backend": "openai-chat",
     "endpoint": "/v1/chat/completions",
     "dataset_name": "hf",
+    "no_stream": false,
     "dataset_path": "lmarena-ai/VisionArena-Chat",
     "hf_split": "train",
     "num_prompts": 1000,

--- a/scripts/backfill_single_gpu.md
+++ b/scripts/backfill_single_gpu.md
@@ -83,3 +83,15 @@ for entry in data:
 print(f'Total: {count}')
 "
 ```
+
+## 手工补点的配置字段检查
+
+手工补点与 CI/CD 使用同一份 `explicit-effective/v1` 配置契约。提交前必须检查
+`workload` 的 input/output/batch/concurrency/dataset 字段，以及 `same_spec` 中
+解析后的 server/client 参数均已写全；不适用的字段写 JSON `null`，不能直接省略。
+`metadata.submitted_at` 必须保留真实生成时间，不能删除或倒填来绕过新记录校验。
+
+特别注意：`num_prompts` 是总请求数，不是并发数，禁止将其写入
+`workload.concurrent_requests`。只有真实使用了 `max_concurrency` 或
+`concurrent_requests` 时才能填写并发字段。完整清单和校验命令见
+`docs/HISTORICAL_PR_BACKFILL.md` 的 “Required effective-configuration metadata”。

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -1046,6 +1046,12 @@ NODE_COUNT=$(jq -r '.node_count' "$SPEC_FILE")
 SCENARIO=$(jq -r '.scenario' "$SPEC_FILE")
 INPUT_LEN=$(jq -r '.client_parameters.input_len' "$SPEC_FILE")
 OUTPUT_LEN=$(jq -r '.client_parameters.output_len' "$SPEC_FILE")
+BATCH_SIZE=$(jq -r '.client_parameters.batch_size' "$SPEC_FILE")
+CONCURRENT_REQUESTS=$(jq -r '
+  .client_parameters.max_concurrency
+  // .client_parameters.concurrent_requests
+  // empty
+' "$SPEC_FILE")
 BENCHMARK_TYPE=$(resolve_scenario_benchmark_type)
 
 if [[ -z "$CURRENT_ENGINE_VERSION" ]]; then
@@ -1205,6 +1211,8 @@ EXPORT_ARGS=(
 
 append_export_arg_if_present --input-length "$INPUT_LEN"
 append_export_arg_if_present --output-length "$OUTPUT_LEN"
+append_export_arg_if_present --batch-size "$BATCH_SIZE"
+append_export_arg_if_present --concurrent-requests "$CONCURRENT_REQUESTS"
 
 run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" \
 "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.cli export-leaderboard-artifact \

--- a/scripts/validate_public_leaderboard_snapshots.py
+++ b/scripts/validate_public_leaderboard_snapshots.py
@@ -15,6 +15,11 @@ if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from vllm_hust_benchmark.same_spec import compute_resolved_spec_hash  # noqa: E402
+from vllm_hust_benchmark.workload_config_contract import (  # noqa: E402
+    WORKLOAD_CONFIG_CONTRACT_VERSION,
+    requires_workload_config_contract,
+    validate_explicit_workload_config,
+)
 
 
 PUBLIC_BASELINE_ENGINE = "vllm"
@@ -72,8 +77,11 @@ def validate_entry(entry: dict[str, Any], *, source: Path) -> list[str]:
     workload = str((entry.get("workload") or {}).get("name") or "").strip()
     model = entry.get("model") if isinstance(entry.get("model"), dict) else {}
     hardware = entry.get("hardware") if isinstance(entry.get("hardware"), dict) else {}
-    same_spec = entry.get("same_spec") if isinstance(entry.get("same_spec"), dict) else {}
+    same_spec = (
+        entry.get("same_spec") if isinstance(entry.get("same_spec"), dict) else {}
+    )
     spec_id = str(same_spec.get("spec_id") or "")
+    metadata = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
 
     if engine == PUBLIC_BASELINE_ENGINE and engine_version != PUBLIC_BASELINE_VERSION:
         errors.append(
@@ -88,9 +96,7 @@ def validate_entry(entry: dict[str, Any], *, source: Path) -> list[str]:
         )
 
     if contains_retired_baseline_token(spec_id):
-        errors.append(
-            f"{source.name}:{entry_id}: retired baseline spec_id {spec_id!r}"
-        )
+        errors.append(f"{source.name}:{entry_id}: retired baseline spec_id {spec_id!r}")
 
     entry_model_name = str(model.get("name") or model.get("repo_id") or "")
     entry_precision_value = str(model.get("precision") or "")
@@ -134,11 +140,21 @@ def validate_entry(entry: dict[str, Any], *, source: Path) -> list[str]:
                 f"precision must match same_spec; entry={entry_precision!r} "
                 f"same_spec={spec_precision!r}"
             )
-        if expected_chip and (entry_chip != expected_chip or spec_chip != expected_chip):
+        if expected_chip and (
+            entry_chip != expected_chip or spec_chip != expected_chip
+        ):
             errors.append(
                 f"{source.name}:{entry_id}: official v0.18.0 public spec "
                 f"{spec_id!r} must be {expected_chip}; entry={entry_chip!r} "
                 f"same_spec={spec_chip!r}"
+            )
+
+    contract_version = str(metadata.get("workload_config_contract") or "")
+    if requires_workload_config_contract(entry) or contract_version:
+        for message in validate_explicit_workload_config(entry):
+            errors.append(
+                f"{source.name}:{entry_id}: workload config contract "
+                f"{WORKLOAD_CONFIG_CONTRACT_VERSION}: {message}"
             )
 
     return errors

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -28,6 +28,11 @@ from vllm_hust_benchmark.submission_artifacts import iter_submission_artifact_pa
 from vllm_hust_benchmark.submission_artifacts import (
     normalize_submission_artifacts_in_tree,
 )
+from vllm_hust_benchmark.workload_config_contract import (
+    is_official_workload_contract_entry,
+    requires_workload_config_contract,
+    validate_explicit_workload_config,
+)
 
 FLAG_PATTERN = re.compile(r"^\s+--([a-z0-9][a-z0-9-_]*)\b", re.MULTILINE)
 DEFAULT_RUNTIME_ENGINE = "vllm-hust"
@@ -381,11 +386,7 @@ def build_ascend_benchmark_ci_command(layout: RepoLayout) -> list[str]:
     #   "vllm-hust Ascend benchmark CI script not found: .../worktrees/vllm-hust--<sha>/..."
     repo = _resolve_stable_repo(layout.vllm_hust_repo)
     ci_script = (
-        repo
-        / ".github"
-        / "workflows"
-        / "scripts"
-        / "run_ascend_benchmark_ci.sh"
+        repo / ".github" / "workflows" / "scripts" / "run_ascend_benchmark_ci.sh"
     )
     if not ci_script.is_file():
         raise ValueError(f"vllm-hust Ascend benchmark CI script not found: {ci_script}")
@@ -579,9 +580,7 @@ def _normalize_baseline_engine(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
-def _build_entry_baseline_coverage_key(
-    entry: Mapping[str, Any], *, engine: str
-) -> str:
+def _build_entry_baseline_coverage_key(entry: Mapping[str, Any], *, engine: str) -> str:
     model = entry.get("model") if isinstance(entry.get("model"), Mapping) else {}
     hardware = (
         entry.get("hardware") if isinstance(entry.get("hardware"), Mapping) else {}
@@ -644,7 +643,9 @@ def _derive_accountable_scope_baseline_metadata(
         "baseline_engine": official_engine,
         "declared_baseline_engine": declared_engine,
         "baseline_status": baseline_status,
-        "scope_baseline_engine": declared_engine or official_engine or "unknown-baseline",
+        "scope_baseline_engine": declared_engine
+        or official_engine
+        or "unknown-baseline",
     }
 
 
@@ -659,7 +660,9 @@ def _normalize_accountable_scope_baseline_metadata(
         return None
 
     accountable_scope = constraints.get("accountable_scope")
-    accountable_scope = accountable_scope if isinstance(accountable_scope, dict) else None
+    accountable_scope = (
+        accountable_scope if isinstance(accountable_scope, dict) else None
+    )
     if accountable_scope is None:
         return None
 
@@ -740,7 +743,9 @@ def _load_official_baseline_coverage_keys(layout: RepoLayout) -> set[str]:
 
         export_payload = payload.get("export")
         export_payload = export_payload if isinstance(export_payload, Mapping) else {}
-        baseline_engine = str(export_payload.get("baseline_engine") or "").strip().lower()
+        baseline_engine = (
+            str(export_payload.get("baseline_engine") or "").strip().lower()
+        )
         if not baseline_engine:
             continue
 
@@ -846,7 +851,9 @@ def _build_compare_setting_signature(entry: Mapping[str, Any]) -> str:
     if same_spec_hash:
         return same_spec_hash
 
-    workload = entry.get("workload") if isinstance(entry.get("workload"), Mapping) else {}
+    workload = (
+        entry.get("workload") if isinstance(entry.get("workload"), Mapping) else {}
+    )
     same_spec = _get_same_spec_payload(entry)
     server = same_spec.get("resolved_server_parameters")
     server = server if isinstance(server, Mapping) else {}
@@ -931,8 +938,12 @@ def _build_goal_scope_key_debug(entry: Mapping[str, Any]) -> str:
 
 
 def _is_goal_baseline_entry_debug(entry: Mapping[str, Any]) -> bool:
-    metadata = entry.get("metadata") if isinstance(entry.get("metadata"), Mapping) else {}
-    engine = str(entry.get("engine") or metadata.get("engine") or "unknown").strip().lower()
+    metadata = (
+        entry.get("metadata") if isinstance(entry.get("metadata"), Mapping) else {}
+    )
+    engine = (
+        str(entry.get("engine") or metadata.get("engine") or "unknown").strip().lower()
+    )
     engine_version = str(
         entry.get("engine_version") or metadata.get("engine_version") or ""
     ).strip()
@@ -967,7 +978,9 @@ def _print_aggregated_compare_diagnostics(data_dir: Path) -> None:
             str((item.get("metadata") or {}).get("submitted_at") or ""),
         ),
     ):
-        metadata = entry.get("metadata") if isinstance(entry.get("metadata"), Mapping) else {}
+        metadata = (
+            entry.get("metadata") if isinstance(entry.get("metadata"), Mapping) else {}
+        )
         accountable = {}
         constraints = entry.get("constraints")
         if isinstance(constraints, Mapping) and isinstance(
@@ -997,7 +1010,9 @@ def _print_aggregated_compare_diagnostics(data_dir: Path) -> None:
     compare_grouped: dict[str, list[Mapping[str, Any]]] = {}
     goal_grouped: dict[str, list[Mapping[str, Any]]] = {}
     for entry in entries:
-        compare_grouped.setdefault(_build_compare_scope_key_debug(entry), []).append(entry)
+        compare_grouped.setdefault(_build_compare_scope_key_debug(entry), []).append(
+            entry
+        )
         goal_grouped.setdefault(_build_goal_scope_key_debug(entry), []).append(entry)
 
     print("aggregated compare debug: compare-scope candidates", file=sys.stderr)
@@ -1022,8 +1037,12 @@ def _print_aggregated_compare_diagnostics(data_dir: Path) -> None:
 
     print("aggregated compare debug: goal-scope candidates", file=sys.stderr)
     for scope_key, scope_entries in sorted(goal_grouped.items()):
-        current_entries = [entry for entry in scope_entries if _normalize_engine(entry) == "vllm-hust"]
-        baseline_entries = [entry for entry in scope_entries if _is_goal_baseline_entry_debug(entry)]
+        current_entries = [
+            entry for entry in scope_entries if _normalize_engine(entry) == "vllm-hust"
+        ]
+        baseline_entries = [
+            entry for entry in scope_entries if _is_goal_baseline_entry_debug(entry)
+        ]
         if not current_entries and not baseline_entries:
             continue
         print(
@@ -1044,9 +1063,15 @@ def _print_aggregated_compare_diagnostics(data_dir: Path) -> None:
                 file=sys.stderr,
             )
 
-    hard_constraints = compare.get("hard_constraints") if isinstance(compare, Mapping) else {}
+    hard_constraints = (
+        compare.get("hard_constraints") if isinstance(compare, Mapping) else {}
+    )
     hard_constraints = hard_constraints if isinstance(hard_constraints, Mapping) else {}
-    scopes = hard_constraints.get("scopes") if isinstance(hard_constraints.get("scopes"), list) else []
+    scopes = (
+        hard_constraints.get("scopes")
+        if isinstance(hard_constraints.get("scopes"), list)
+        else []
+    )
     goal_progress = compare.get("goal_progress") if isinstance(compare, Mapping) else {}
     goal_progress = goal_progress if isinstance(goal_progress, Mapping) else {}
     print(
@@ -1195,6 +1220,9 @@ def _upload_existing_snapshots(
         "leaderboard_compare.json",
         "last_updated.json",
     ]
+
+    if not _validate_snapshot_workload_contracts(aggregate_output_dir):
+        return 2
 
     operations: list[CommitOperationAdd] = []
     planned_paths: list[str] = []
@@ -1371,7 +1399,69 @@ def _validate_formal_submission_sources(
                 )
                 return False
 
+            if not _validate_entry_workload_contract(
+                payload,
+                source=str(artifact_path),
+                require_official=True,
+            ):
+                return False
+
     return True
+
+
+def _validate_entry_workload_contract(
+    payload: Mapping[str, Any],
+    *,
+    source: str,
+    require_official: bool = False,
+) -> bool:
+    metadata = payload.get("metadata")
+    has_contract_marker = isinstance(metadata, Mapping) and bool(
+        metadata.get("workload_config_contract")
+    )
+    must_validate = (
+        (require_official and is_official_workload_contract_entry(payload))
+        or requires_workload_config_contract(payload)
+        or has_contract_marker
+    )
+    if not must_validate:
+        return True
+
+    errors = validate_explicit_workload_config(payload)
+    for error in errors:
+        print(
+            f"invalid explicit workload configuration in {source}: {error}",
+            file=sys.stderr,
+        )
+    return not errors
+
+
+def _validate_snapshot_workload_contracts(snapshot_dir: Path) -> bool:
+    valid = True
+    for file_name in ("leaderboard_single.json", "leaderboard_multi.json"):
+        snapshot_path = snapshot_dir / file_name
+        if not snapshot_path.is_file():
+            continue
+        try:
+            payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(
+                f"invalid leaderboard snapshot {snapshot_path}: {exc}", file=sys.stderr
+            )
+            return False
+        if not isinstance(payload, list):
+            # Snapshot structure is validated by the existing aggregation checks.
+            # This guard is intentionally limited to the workload contract.
+            continue
+        for index, entry in enumerate(payload):
+            if not isinstance(entry, Mapping):
+                continue
+            if not _validate_entry_workload_contract(
+                entry,
+                source=f"{snapshot_path}[{index}]",
+            ):
+                valid = False
+    return valid
 
 
 def sync_submission_to_huggingface(
@@ -1395,7 +1485,11 @@ def sync_submission_to_huggingface(
     else:
         normalized_submission_dirs = list(submission_dirs)
 
-    if not normalized_submission_dirs and not allow_existing_only and not skip_aggregation:
+    if (
+        not normalized_submission_dirs
+        and not allow_existing_only
+        and not skip_aggregation
+    ):
         print(
             "at least one submission directory is required unless --existing-only or --skip-aggregation is set",
             file=sys.stderr,
@@ -1568,6 +1662,8 @@ def sync_submission_to_huggingface(
         except ValueError as exc:
             _print_aggregated_compare_diagnostics(rebuilt_output_dir)
             print(str(exc), file=sys.stderr)
+            return 2
+        if not _validate_snapshot_workload_contracts(rebuilt_output_dir):
             return 2
 
         operations: list[CommitOperationAdd] = []

--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -14,6 +14,11 @@ from vllm_hust_benchmark.model_registry import normalize_model_identity_payload
 from vllm_hust_benchmark.model_registry import resolve_model_identity
 from vllm_hust_benchmark.model_registry import validate_model_identity_payload
 from vllm_hust_benchmark.models import ScenarioDefinition
+from vllm_hust_benchmark.workload_config_contract import (
+    WORKLOAD_CONFIG_CONTRACT_VERSION,
+    is_official_workload_contract_entry,
+    validate_explicit_workload_config,
+)
 
 REQUIRED_METRIC_KEYS = (
     "ttft_ms",
@@ -64,9 +69,7 @@ REQUIRED_SAME_SPEC_KEYS = (
 
 BASELINE_STATUS_PENDING = "pending-baseline"
 BASELINE_STATUS_NONE = "no-baseline-declared"
-DIRTY_ENGINE_VERSION_MARKERS = (
-    "path string is null",
-)
+DIRTY_ENGINE_VERSION_MARKERS = ("path string is null",)
 ENGINE_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
 LEADERBOARD_COMPONENT_VERSION_PATTERN = re.compile(r"^\d+\.\d+[\w.+-]*$")
 
@@ -92,7 +95,9 @@ def _short_commit(value: Any) -> str:
 def _sanitize_engine_version(value: Any, *, git_commit: str | None = None) -> str:
     raw = str(value or "")
     saw_multiline = "\n" in raw or "\r" in raw
-    saw_dirty_marker = any(marker in raw.lower() for marker in DIRTY_ENGINE_VERSION_MARKERS)
+    saw_dirty_marker = any(
+        marker in raw.lower() for marker in DIRTY_ENGINE_VERSION_MARKERS
+    )
 
     candidates: list[str] = []
     for line in raw.splitlines() or [raw]:
@@ -105,12 +110,16 @@ def _sanitize_engine_version(value: Any, *, git_commit: str | None = None) -> st
         candidates.append(normalized)
 
     for candidate in candidates:
-        if any(ch.isdigit() for ch in candidate) and ENGINE_VERSION_PATTERN.match(candidate):
+        if any(ch.isdigit() for ch in candidate) and ENGINE_VERSION_PATTERN.match(
+            candidate
+        ):
             return candidate
 
     if candidates:
         primary = candidates[0]
-        if ENGINE_VERSION_PATTERN.match(primary) and not (saw_multiline or saw_dirty_marker):
+        if ENGINE_VERSION_PATTERN.match(primary) and not (
+            saw_multiline or saw_dirty_marker
+        ):
             return primary
 
     short_commit = _short_commit(git_commit)
@@ -138,7 +147,9 @@ def _sanitize_component_version(value: Any) -> str:
     return "N/A"
 
 
-def _validate_constraints_metrics(constraints_metrics: dict[str, Any]) -> dict[str, Any]:
+def _validate_constraints_metrics(
+    constraints_metrics: dict[str, Any],
+) -> dict[str, Any]:
     long_context_length = constraints_metrics.get("long_context_length")
     if long_context_length is None:
         return constraints_metrics
@@ -164,7 +175,9 @@ def _default_constraints_metrics() -> dict[str, Any]:
     return {key: None for key in REQUIRED_CONSTRAINT_METRIC_KEYS}
 
 
-def _normalize_constraints_metrics(constraints_metrics: dict[str, Any]) -> dict[str, Any]:
+def _normalize_constraints_metrics(
+    constraints_metrics: dict[str, Any],
+) -> dict[str, Any]:
     merged = _default_constraints_metrics()
     merged.update(constraints_metrics)
     return _validate_constraints_metrics(merged)
@@ -216,16 +229,24 @@ def _derive_long_context_constraints(
             benchmark_result_payload.get("p99_tpot_ms")
         ),
         "long_context_ttft_p95_stable": (
-            is_stable if benchmark_result_payload.get("p95_ttft_ms") is not None else None
+            is_stable
+            if benchmark_result_payload.get("p95_ttft_ms") is not None
+            else None
         ),
         "long_context_ttft_p99_stable": (
-            is_stable if benchmark_result_payload.get("p99_ttft_ms") is not None else None
+            is_stable
+            if benchmark_result_payload.get("p99_ttft_ms") is not None
+            else None
         ),
         "long_context_tpot_p95_stable": (
-            is_stable if benchmark_result_payload.get("p95_tpot_ms") is not None else None
+            is_stable
+            if benchmark_result_payload.get("p95_tpot_ms") is not None
+            else None
         ),
         "long_context_tpot_p99_stable": (
-            is_stable if benchmark_result_payload.get("p99_tpot_ms") is not None else None
+            is_stable
+            if benchmark_result_payload.get("p99_tpot_ms") is not None
+            else None
         ),
     }
 
@@ -275,7 +296,9 @@ def _load_constraints_metrics(constraints_file: Path) -> dict[str, Any]:
     payload = json.loads(constraints_file.read_text(encoding="utf-8"))
     constraints_metrics = payload.get("constraints_metrics", payload)
     if not isinstance(constraints_metrics, dict):
-        raise ValueError("constraints file must be a JSON object or include constraints_metrics")
+        raise ValueError(
+            "constraints file must be a JSON object or include constraints_metrics"
+        )
     return _normalize_constraints_metrics(dict(constraints_metrics))
 
 
@@ -353,7 +376,10 @@ def _derive_metrics_from_benchmark_result(
         "throughput_tps": float(throughput_tps),
         "peak_mem_mb": int(
             peak_mem_mb or benchmark_result_payload.get("peak_mem_mb") or 0.0
-        ) if (peak_mem_mb or benchmark_result_payload.get("peak_mem_mb") or 0.0) is not None else None,
+        )
+        if (peak_mem_mb or benchmark_result_payload.get("peak_mem_mb") or 0.0)
+        is not None
+        else None,
         "error_rate": float(error_rate),
     }
 
@@ -369,7 +395,9 @@ def _derive_metrics_from_benchmark_result(
 
     missing_metrics = [key for key in REQUIRED_METRIC_KEYS if key not in metrics]
     if missing_metrics:
-        raise ValueError(f"derived metrics missing required keys: {', '.join(missing_metrics)}")
+        raise ValueError(
+            f"derived metrics missing required keys: {', '.join(missing_metrics)}"
+        )
     return metrics
 
 
@@ -573,7 +601,8 @@ def export_leaderboard_artifacts(
     )
     workload_name = str(scenario.leaderboard.get("workload_name") or scenario.name)
     representative_business_scenario = str(
-        scenario.leaderboard.get("representative_business_scenario") or "general-serving"
+        scenario.leaderboard.get("representative_business_scenario")
+        or "general-serving"
     )
     idempotency_key = _build_idempotency_key(
         scenario_name=scenario.name,
@@ -706,6 +735,16 @@ def export_leaderboard_artifacts(
     validate_model_identity_payload(artifact["model"])
     if same_spec_payload is not None:
         artifact["same_spec"] = same_spec_payload
+    if is_official_workload_contract_entry(artifact):
+        artifact["metadata"]["workload_config_contract"] = (
+            WORKLOAD_CONFIG_CONTRACT_VERSION
+        )
+        workload_config_errors = validate_explicit_workload_config(artifact)
+        if workload_config_errors:
+            raise ValueError(
+                "official workload configuration contract failed: "
+                + "; ".join(workload_config_errors)
+            )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     artifact_path = output_dir / artifact_name

--- a/src/vllm_hust_benchmark/workload_config_contract.py
+++ b/src/vllm_hust_benchmark/workload_config_contract.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+WORKLOAD_CONFIG_CONTRACT_VERSION = "explicit-effective/v1"
+WORKLOAD_CONFIG_CONTRACT_REQUIRED_AFTER = "2026-07-24T00:00:00Z"
+OFFICIAL_SPEC_PREFIX = "official-ascend-jan-2026-v0.18.0-"
+
+REQUIRED_EFFECTIVE_PARAMETERS: dict[str, dict[str, tuple[str, ...]]] = {
+    "instructcoder-online": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("no_stream",),
+    },
+    "prefix-repetition-online": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("no_stream",),
+    },
+    "random-latency": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("gpu_memory_utilization",),
+    },
+    "random-online": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("no_stream",),
+    },
+    "sharegpt-online": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("no_stream",),
+    },
+    "sharegpt-throughput": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("gpu_memory_utilization",),
+    },
+    "sonnet-throughput": {
+        "server": ("gpu_memory_utilization",),
+        "client": ("gpu_memory_utilization",),
+    },
+    "visionarena-online": {
+        "server": ("gpu_memory_utilization", "max_model_len"),
+        "client": ("no_stream",),
+    },
+}
+
+
+def is_official_workload_contract_entry(entry: Mapping[str, Any]) -> bool:
+    same_spec = entry.get("same_spec")
+    if not isinstance(same_spec, Mapping):
+        return False
+    return str(same_spec.get("spec_id") or "").startswith(OFFICIAL_SPEC_PREFIX)
+
+
+def requires_workload_config_contract(entry: Mapping[str, Any]) -> bool:
+    if not is_official_workload_contract_entry(entry):
+        return False
+    metadata = entry.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    submitted_at = str(metadata.get("submitted_at") or "").strip()
+    return submitted_at >= WORKLOAD_CONFIG_CONTRACT_REQUIRED_AFTER
+
+
+def _positive_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _expected_workload_lengths(
+    client: Mapping[str, Any],
+) -> tuple[int | None, int | None]:
+    dataset_name = str(client.get("dataset_name") or "")
+    if dataset_name == "random":
+        return (
+            _positive_int(client.get("random_input_len")),
+            _positive_int(client.get("random_output_len")),
+        )
+    if dataset_name == "prefix_repetition":
+        prefix = _positive_int(client.get("prefix_repetition_prefix_len"))
+        suffix = _positive_int(client.get("prefix_repetition_suffix_len"))
+        output = _positive_int(client.get("prefix_repetition_output_len"))
+        return (
+            prefix + suffix if prefix is not None and suffix is not None else None,
+            output,
+        )
+    return (
+        _positive_int(client.get("input_len")),
+        _positive_int(client.get("output_len")),
+    )
+
+
+def validate_explicit_workload_config(entry: Mapping[str, Any]) -> list[str]:
+    if not is_official_workload_contract_entry(entry):
+        return []
+
+    errors: list[str] = []
+    metadata = entry.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    contract_version = str(metadata.get("workload_config_contract") or "")
+    if contract_version != WORKLOAD_CONFIG_CONTRACT_VERSION:
+        errors.append(
+            "metadata.workload_config_contract must be "
+            f"{WORKLOAD_CONFIG_CONTRACT_VERSION!r}"
+        )
+    if not str(metadata.get("submitted_at") or "").strip():
+        errors.append("metadata.submitted_at must be explicitly recorded")
+
+    workload = entry.get("workload")
+    if not isinstance(workload, Mapping):
+        return [*errors, "workload must be an object"]
+    for key in (
+        "name",
+        "input_length",
+        "output_length",
+        "batch_size",
+        "concurrent_requests",
+        "dataset",
+    ):
+        if key not in workload:
+            errors.append(f"workload.{key} must be explicitly recorded")
+
+    input_length = _positive_int(workload.get("input_length"))
+    output_length = _positive_int(workload.get("output_length"))
+    if input_length is None:
+        errors.append("workload.input_length must be a positive integer")
+    if output_length is None:
+        errors.append("workload.output_length must be a positive integer")
+
+    same_spec = entry.get("same_spec")
+    same_spec = same_spec if isinstance(same_spec, Mapping) else {}
+    server = same_spec.get("resolved_server_parameters")
+    client = same_spec.get("resolved_client_parameters")
+    server = server if isinstance(server, Mapping) else {}
+    client = client if isinstance(client, Mapping) else {}
+    scenario = str(same_spec.get("scenario") or workload.get("name") or "")
+
+    required = REQUIRED_EFFECTIVE_PARAMETERS.get(scenario, {})
+    for key in required.get("server", ()):
+        if key not in server:
+            errors.append(
+                f"same_spec.resolved_server_parameters.{key} must be explicitly recorded"
+            )
+    for key in required.get("client", ()):
+        if key not in client:
+            errors.append(
+                f"same_spec.resolved_client_parameters.{key} must be explicitly recorded"
+            )
+
+    expected_input, expected_output = _expected_workload_lengths(client)
+    if expected_input is not None and input_length != expected_input:
+        errors.append(
+            f"workload.input_length {input_length!r} does not match "
+            f"effective client value {expected_input}"
+        )
+    if expected_output is not None and output_length != expected_output:
+        errors.append(
+            f"workload.output_length {output_length!r} does not match "
+            f"effective client value {expected_output}"
+        )
+
+    expected_batch = _positive_int(client.get("batch_size"))
+    actual_batch = _positive_int(workload.get("batch_size"))
+    if expected_batch is not None and actual_batch != expected_batch:
+        errors.append(
+            f"workload.batch_size {actual_batch!r} does not match "
+            f"effective client value {expected_batch}"
+        )
+
+    expected_concurrency = _positive_int(
+        client.get("max_concurrency") or client.get("concurrent_requests")
+    )
+    actual_concurrency = _positive_int(workload.get("concurrent_requests"))
+    if expected_concurrency is None and actual_concurrency is not None:
+        errors.append(
+            "workload.concurrent_requests must be null unless the effective "
+            "client config records max_concurrency"
+        )
+    elif (
+        expected_concurrency is not None and actual_concurrency != expected_concurrency
+    ):
+        errors.append(
+            f"workload.concurrent_requests {actual_concurrency!r} does not match "
+            f"effective client value {expected_concurrency}"
+        )
+
+    return errors

--- a/tests/test_historical_pr_backfill.py
+++ b/tests/test_historical_pr_backfill.py
@@ -6,7 +6,11 @@ import sys
 from pathlib import Path
 
 
-SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "backfill_historical_pr_benchmarks.py"
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "backfill_historical_pr_benchmarks.py"
+)
 
 
 def load_module():
@@ -19,7 +23,9 @@ def load_module():
     return module
 
 
-def write_spec(path: Path, *, scenario: str, chip_model: str = "910B2", chip_count: int = 1) -> None:
+def write_spec(
+    path: Path, *, scenario: str, chip_model: str = "910B2", chip_count: int = 1
+) -> None:
     path.write_text(
         json.dumps(
             {
@@ -38,11 +44,13 @@ def write_spec(path: Path, *, scenario: str, chip_model: str = "910B2", chip_cou
 def test_collect_official_specs_filters_to_910b2_single_chip(tmp_path: Path) -> None:
     module = load_module()
     write_spec(
-        tmp_path / "official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+        tmp_path
+        / "official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
         scenario="sharegpt-online",
     )
     write_spec(
-        tmp_path / "official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json",
+        tmp_path
+        / "official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json",
         scenario="sonnet-throughput",
         chip_count=4,
     )
@@ -142,7 +150,9 @@ def test_managed_same_spec_parameters_match_effective_server_args(monkeypatch) -
     assert parameters["max_num_seqs"] == str(args.managed_max_num_seqs)
 
 
-def test_ensure_plugin_build_info_materializes_source_worktree_file(tmp_path: Path) -> None:
+def test_ensure_plugin_build_info_materializes_source_worktree_file(
+    tmp_path: Path,
+) -> None:
     module = load_module()
     plugin_worktree = tmp_path / "plugin"
     package_dir = plugin_worktree / "vllm_ascend"
@@ -151,8 +161,7 @@ def test_ensure_plugin_build_info_materializes_source_worktree_file(tmp_path: Pa
     module.ensure_plugin_build_info(plugin_worktree, chip_model="910B2")
 
     assert (package_dir / "_build_info.py").read_text(encoding="utf-8") == (
-        "# Auto-generated file for benchmark source worktree\n"
-        "__device_type__ = 'A2'\n"
+        "# Auto-generated file for benchmark source worktree\n__device_type__ = 'A2'\n"
     )
 
 
@@ -199,14 +208,30 @@ def test_dev_hub_secret_env_does_not_override_process_env(
 
 def test_single_gpu_backfill_does_not_treat_prompt_count_as_concurrency() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    backfill_script = (
-        repo_root / "scripts" / "backfill_single_gpu.py"
-    ).read_text(encoding="utf-8")
-    latest_script = (
-        repo_root / "scripts" / "run_latest_benchmark.sh"
-    ).read_text(encoding="utf-8")
+    backfill_script = (repo_root / "scripts" / "backfill_single_gpu.py").read_text(
+        encoding="utf-8"
+    )
+    latest_script = (repo_root / "scripts" / "run_latest_benchmark.sh").read_text(
+        encoding="utf-8"
+    )
 
     assert 'cmd += ["--concurrent-requests", str(params["num_prompts"])]' not in (
         backfill_script
     )
     assert '--concurrent-requests "$num_prompts"' not in latest_script
+
+
+def test_current_same_spec_runner_exports_effective_batch_and_concurrency() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    runner = (repo_root / "scripts" / "run-current-ascend-same-spec.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert ".client_parameters.batch_size" in runner
+    assert "append_export_arg_if_present --batch-size" in runner
+    assert ".client_parameters.max_concurrency" in runner
+    assert "append_export_arg_if_present --concurrent-requests" in runner
+    assert (
+        ".client_parameters.num_prompts"
+        not in runner.split("CONCURRENT_REQUESTS=", 1)[1].split("BENCHMARK_TYPE=", 1)[0]
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,6 +36,97 @@ def _minimal_artifact(model_name: str = "Qwen/Qwen2.5-14B-Instruct") -> str:
     return json.dumps({"model": {"name": model_name}})
 
 
+def _future_official_artifact() -> dict:
+    return {
+        "workload": {
+            "name": "random-online",
+            "input_length": 1024,
+            "output_length": 256,
+            "batch_size": None,
+            "concurrent_requests": None,
+            "dataset": "random",
+        },
+        "metadata": {"submitted_at": "2026-07-25T00:00:00Z"},
+        "same_spec": {
+            "spec_id": (
+                "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
+            ),
+            "scenario": "random-online",
+            "resolved_server_parameters": {"gpu_memory_utilization": 0.6},
+            "resolved_client_parameters": {
+                "dataset_name": "random",
+                "random_input_len": 1024,
+                "random_output_len": 256,
+                "num_prompts": 200,
+                "request_rate": 1,
+                "no_stream": False,
+            },
+        },
+    }
+
+
+def test_formal_submission_rejects_future_official_artifact_without_contract(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    submission_dir = tmp_path / "submission"
+    submission_dir.mkdir()
+    (submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(_future_official_artifact()),
+        encoding="utf-8",
+    )
+
+    assert not integration._validate_formal_submission_sources([submission_dir])
+    assert "metadata.workload_config_contract" in capsys.readouterr().err
+
+
+def test_formal_submission_rejects_official_artifact_without_timestamp_or_contract(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    artifact = _future_official_artifact()
+    artifact["metadata"] = {}
+    submission_dir = tmp_path / "submission"
+    submission_dir.mkdir()
+    (submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(artifact),
+        encoding="utf-8",
+    )
+
+    assert not integration._validate_formal_submission_sources([submission_dir])
+    error_output = capsys.readouterr().err
+    assert "metadata.workload_config_contract" in error_output
+    assert "metadata.submitted_at" in error_output
+
+
+def test_snapshot_guard_grandfathers_prepublished_legacy_official_artifact(
+    tmp_path: Path,
+) -> None:
+    artifact = _future_official_artifact()
+    artifact["metadata"]["submitted_at"] = "2026-07-23T23:59:59Z"
+    (tmp_path / "leaderboard_single.json").write_text(
+        json.dumps([artifact]),
+        encoding="utf-8",
+    )
+    (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+
+    assert integration._validate_snapshot_workload_contracts(tmp_path)
+
+
+def test_snapshot_upload_guard_rejects_future_official_artifact_without_contract(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    (tmp_path / "leaderboard_single.json").write_text(
+        json.dumps([_future_official_artifact()]),
+        encoding="utf-8",
+    )
+    (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+
+    assert not integration._validate_snapshot_workload_contracts(tmp_path)
+    assert "metadata.workload_config_contract" in capsys.readouterr().err
+
+
 def test_resolve_repo_layout_defaults_to_repo_sibling_workspace(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_HUST_WORKSPACE_ROOT", raising=False)
     monkeypatch.delenv("VLLM_HUST_REPO", raising=False)
@@ -761,7 +852,8 @@ def test_load_official_baseline_coverage_keys_requires_published_submission(
         )
 
     official_submission_dir = (
-        submissions_root / "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+        submissions_root
+        / "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
     )
     official_submission_dir.mkdir()
     (official_submission_dir / "run_leaderboard.json").write_text(
@@ -1632,9 +1724,7 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
         }
         seen_baselines["current"] = {
             "baseline_engine": current_accountable["baseline_engine"],
-            "declared_baseline_engine": current_accountable[
-                "declared_baseline_engine"
-            ],
+            "declared_baseline_engine": current_accountable["declared_baseline_engine"],
             "baseline_status": current_accountable["baseline_status"],
         }
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -1907,7 +1997,10 @@ def test_sync_submission_to_huggingface_reports_hf_listing_failure(
 
     captured = capsys.readouterr()
     assert exit_code == 2
-    assert "failed to list dataset files from owner/repo@main: network is unreachable" in captured.err
+    assert (
+        "failed to list dataset files from owner/repo@main: network is unreachable"
+        in captured.err
+    )
 
 
 def test_upload_to_huggingface_rejects_invalid_aggregated_snapshots(

--- a/tests/test_validate_public_leaderboard_snapshots.py
+++ b/tests/test_validate_public_leaderboard_snapshots.py
@@ -16,7 +16,9 @@ SCRIPT_PATH = (
 
 
 def load_module():
-    spec = importlib.util.spec_from_file_location("validate_public_snapshots", SCRIPT_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "validate_public_snapshots", SCRIPT_PATH
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -80,3 +82,32 @@ def test_rejects_one_recorded_hash_for_different_effective_parameters(
 
     assert module.main() == 1
     assert "maps to different effective parameters" in capsys.readouterr().out
+
+
+def test_future_official_entry_requires_effective_config_contract() -> None:
+    module = load_module()
+    payload = same_spec()
+    payload["spec_id"] = (
+        "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
+    )
+    payload["scenario"] = "random-online"
+    candidate = entry("future", payload)
+    candidate["engine"] = "vllm-hust"
+    candidate["workload"] = {
+        "name": "random-online",
+        "input_length": 1024,
+        "output_length": 256,
+        "batch_size": None,
+        "concurrent_requests": None,
+        "dataset": "random",
+    }
+    candidate["model"]["name"] = "Qwen/Qwen2.5-14B-Instruct"
+    candidate["metadata"] = {"submitted_at": "2026-07-25T00:00:00Z"}
+
+    errors = module.validate_entry(
+        candidate,
+        source=Path("leaderboard_single.json"),
+    )
+
+    assert any("workload config contract" in error for error in errors)
+    assert any("workload_config_contract" in error for error in errors)

--- a/tests/test_workload_config_contract.py
+++ b/tests/test_workload_config_contract.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from vllm_hust_benchmark.workload_config_contract import (
+    REQUIRED_EFFECTIVE_PARAMETERS,
+    WORKLOAD_CONFIG_CONTRACT_VERSION,
+    requires_workload_config_contract,
+    validate_explicit_workload_config,
+)
+
+
+def official_random_online_entry() -> dict:
+    return {
+        "engine": "vllm-hust",
+        "workload": {
+            "name": "random-online",
+            "input_length": 1024,
+            "output_length": 256,
+            "batch_size": None,
+            "concurrent_requests": None,
+            "dataset": "random",
+        },
+        "metadata": {
+            "submitted_at": "2026-07-25T00:00:00Z",
+            "workload_config_contract": WORKLOAD_CONFIG_CONTRACT_VERSION,
+        },
+        "same_spec": {
+            "spec_id": (
+                "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
+            ),
+            "scenario": "random-online",
+            "resolved_server_parameters": {
+                "gpu_memory_utilization": 0.6,
+            },
+            "resolved_client_parameters": {
+                "dataset_name": "random",
+                "random_input_len": 1024,
+                "random_output_len": 256,
+                "num_prompts": 200,
+                "request_rate": 1,
+                "no_stream": False,
+            },
+        },
+    }
+
+
+def test_complete_effective_config_passes_contract() -> None:
+    entry = official_random_online_entry()
+
+    assert requires_workload_config_contract(entry)
+    assert validate_explicit_workload_config(entry) == []
+
+
+def test_contract_rejects_missing_defaults_and_workload_fields() -> None:
+    entry = official_random_online_entry()
+    del entry["workload"]["batch_size"]
+    del entry["same_spec"]["resolved_server_parameters"]["gpu_memory_utilization"]
+    del entry["same_spec"]["resolved_client_parameters"]["no_stream"]
+
+    errors = validate_explicit_workload_config(entry)
+
+    assert "workload.batch_size must be explicitly recorded" in errors
+    assert any("gpu_memory_utilization" in error for error in errors)
+    assert any("no_stream" in error for error in errors)
+
+
+def test_contract_rejects_prompt_count_conflated_with_concurrency() -> None:
+    entry = official_random_online_entry()
+    entry["workload"]["concurrent_requests"] = 200
+
+    errors = validate_explicit_workload_config(entry)
+
+    assert any("must be null unless" in error for error in errors)
+
+
+def test_contract_rejects_workload_values_that_disagree_with_client() -> None:
+    entry = official_random_online_entry()
+    entry["workload"]["input_length"] = 6144
+
+    errors = validate_explicit_workload_config(entry)
+
+    assert any(
+        "does not match effective client value 1024" in error for error in errors
+    )
+
+
+def test_contract_accepts_real_explicit_max_concurrency() -> None:
+    entry = deepcopy(official_random_online_entry())
+    entry["same_spec"]["resolved_client_parameters"]["max_concurrency"] = 32
+    entry["workload"]["concurrent_requests"] = 32
+
+    assert validate_explicit_workload_config(entry) == []
+
+
+def test_legacy_official_entry_is_grandfathered_by_activation_time() -> None:
+    entry = official_random_online_entry()
+    entry["metadata"]["submitted_at"] = "2026-07-23T23:59:59Z"
+    del entry["metadata"]["workload_config_contract"]
+
+    assert not requires_workload_config_contract(entry)
+
+
+def test_official_single_chip_specs_define_required_effective_defaults() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    specs = []
+    for path in (repo_root / "docs" / "official-baselines").glob(
+        "official-ascend-jan-2026-v0180-*.json"
+    ):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("chip_count") == 1:
+            specs.append(payload)
+
+    by_scenario = {str(spec.get("scenario") or ""): spec for spec in specs}
+    for scenario, scopes in REQUIRED_EFFECTIVE_PARAMETERS.items():
+        spec = by_scenario[scenario]
+        for key in scopes.get("server", ()):
+            assert key in spec["server_parameters"], f"{scenario}: missing server {key}"
+        for key in scopes.get("client", ()):
+            assert key in spec["client_parameters"], f"{scenario}: missing client {key}"


### PR DESCRIPTION
## Summary
- make effective workload/server/client values explicit in official same-spec artifacts
- reject missing or contradictory workload metadata in formal submissions and direct snapshot uploads
- keep pre-activation published snapshots compatible while requiring all newly submitted official artifacts to comply
- document the CI/CD and manual-backfill checklist, including that num_prompts is not concurrency

## Validation
- PYTHONPATH=src:. pytest -q (265 passed)
- targeted ruff check
- bash -n scripts/run-current-ascend-same-spec.sh
- official baseline JSON parse audit
- current snapshot workload-contract audit
- git diff --check