### PR TITLE
feat: add trend coverage JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Within that boundary, the important design point is:
 - `src/vllm_hust_benchmark/data/official_scenarios.json`: initial official scenario mirror
 - `docs/UPSTREAM_ANALYSIS.md`: analysis of upstream benchmark architecture and why this repo is structured this way
 - `docs/LEADERBOARD_ALIGNMENT.md`: scenario taxonomy and exact mapping to website leaderboard schema
+- `docs/TREND_COVERAGE_SCHEMA.md`: definitions and maintenance rules for the trend coverage schema extension
 - `docs/LEADERBOARD_HANDOFF.md`: handoff guide for the leaderboard publication chain and official baseline operations
 - `docs/perfgate-scenario-rollout.md`: requirement and rollout plan for multi-scenario performance gates
 - `tests/`: focused tests for registry loading and command generation

--- a/docs/TREND_COVERAGE_SCHEMA.md
+++ b/docs/TREND_COVERAGE_SCHEMA.md
@@ -1,0 +1,94 @@
+# Trend coverage schema
+
+This document is the maintenance reference for
+[`schemas/leaderboard_trend_v1.schema.json`](../schemas/leaderboard_trend_v1.schema.json).
+The machine-readable schema is authoritative for shape, types, enums, and
+single-entry conditional requirements. The semantic rules below explain how
+those fields are intended to be used by producers, validators, publishers,
+and consumers.
+
+The contract version is `trend-coverage/v1`, carried in the entry field
+`trend_schema_version`. A producer must not infer these values from an
+artifact directory name, filename, or frontend state.
+
+## Fields
+
+| Field | Type / values | Meaning and usage |
+| --- | --- | --- |
+| `trend_schema_version` | string, `trend-coverage/v1` | Identifies this extension. It is required for trend-aware entries. |
+| `coverage_class` | `full-matrix`, `targeted-pair`, `experimental` | Declares the coverage model. `full-matrix` is a fixed-stack matrix; `targeted-pair` is one side of a baseline/head comparison; `experimental` is outside the formal matrix or comparison. |
+| `campaign_id` | non-empty string | Groups a coordinated run campaign with a fixed stack and provenance. Required for `full-matrix` and `targeted-pair`; optional for `experimental`. Use `<campaign-name>/<campaign-version>`. |
+| `comparison_id` | non-empty string | Stable identity of a targeted baseline/head scope. Required for `targeted-pair`, forbidden for `experimental`. It does not prove that both sides exist; T09 must check that. |
+| `point_role` | `baseline`, `head`, `checkpoint`, or `null` | Role within the declared coverage. `full-matrix` requires `checkpoint`; `targeted-pair` requires `baseline` or `head`; `experimental` must omit it or use `null`. |
+| `repeat_group` | non-empty string | Stable identity of one repeated series. Use the campaign and series dimensions, for example `<campaign>::<model>::<hardware>::<precision>::<workload>::<topology>::<engine>`. |
+| `repeat_index` | integer ≥ 0 | Zero-based run index within `repeat_group`. Required whenever `repeat_group` is present. Uniqueness and continuity are cross-entry checks. |
+| `canonical_aggregate` | object | Published aggregate for a repeated series. Required when `repeat_group` is present and the coverage is not experimental. It must declare a method, count, metric values, and outlier handling. |
+| `trend_status` | `default`, `experimental`, `blocked`, `invalid`, `excluded` | Final publication status. Producers may propose it, but the validator is allowed to downgrade or replace it. |
+| `trend_reason` | non-empty string | Human-readable, actionable explanation for `blocked`, `invalid`, or `excluded`; also required for non-default experimental examples. Keep the original artifact for auditability. |
+
+## Coverage and status rules
+
+### Full matrix
+
+Use `coverage_class: "full-matrix"`, `point_role: "checkpoint"`, and a
+`campaign_id`. A repeated formal series also carries `repeat_group`,
+`repeat_index`, and `canonical_aggregate`. The schema validates each entry;
+T09 must decide whether the campaign has complete model/workload/topology
+coverage and whether the repeated series meets the minimum sample policy.
+
+### Targeted pair
+
+Use `coverage_class: "targeted-pair"`, a `campaign_id`, a `comparison_id`,
+and `point_role: "baseline"` or `"head"`. A half-pair remains in the raw
+provenance with `trend_status: "blocked"` and a reason. T09 must require one
+comparable baseline and one comparable head for `default`; JSON Schema cannot
+compare two separate entries.
+
+### Experimental
+
+Use `coverage_class: "experimental"` for exploratory or not-yet-admitted
+data. It cannot participate in a targeted pair, so `comparison_id` is absent
+and `point_role` is absent or `null`. Its status is normally `experimental`;
+`invalid` and `excluded` are allowed for retained audit records such as an
+invalid metric or retired data.
+
+### Invalid metrics and exclusion
+
+Schema validation checks numeric shape and ranges, but it does not decide
+whether a measurement is physically credible. T09 must apply the metric
+policy: preserve the raw artifact, set the published metric to `null` when
+appropriate, and use `invalid` or `blocked` with an actionable reason.
+
+`excluded` is for retained provenance that must not enter either the default
+or experimental view, such as retired records. It is not a synonym for
+`experimental`.
+
+## Canonical aggregate semantics
+
+`canonical_aggregate.method` is one of `mean`, `median`, `trimmed_mean`,
+`min`, or `max`. `trimmed_mean` requires `trim_percent`; mean-like methods
+require at least two samples in this schema. `count` records the source
+sample count, including samples removed or capped by outlier handling.
+
+Each aggregate metric has a required `value` and may carry `min`, `max`, and
+`std`. The producer or aggregate validator must keep the top-level metric
+value synchronized with the aggregate metric value. Raw repetitions must not
+be overwritten.
+
+## Legacy compatibility and ownership
+
+An entry without `trend_schema_version`, `coverage_class`, and
+`trend_status` is accepted by the legacy branch so historical artifacts can
+be read. It is not trend-admitted: T09 must classify missing coverage as
+`unknown`/`excluded` (or another explicitly documented migration result) and
+must write a new trend-aware entry rather than silently upgrading the old
+artifact.
+
+The schema owns local structure and conditional field requirements. T09 owns
+cross-entry pair/matrix completeness, comparability, repeat-index uniqueness,
+aggregation consistency, and final admission. T10/website consumers must use
+`trend_status` for filtering and must not reconstruct admission heuristics.
+
+When adding a field, update this document, the JSON Schema, at least one valid
+and one invalid fixture where applicable, and the focused schema test in the
+same change.

--- a/schemas/leaderboard_trend_v1.schema.json
+++ b/schemas/leaderboard_trend_v1.schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://vllm-hust.sage.org.ai/schemas/leaderboard_trend_v1.schema.json",
+  "title": "vLLM-HUST leaderboard trend coverage schema v1",
+  "description": "Trend coverage extension for leaderboard entries. Legacy entries are accepted for migration and must be classified by the validator.",
+  "oneOf": [
+    { "$ref": "#/$defs/entry" },
+    {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  ],
+  "$defs": {
+    "baseEntry": {
+      "type": "object",
+      "required": [
+        "entry_id", "engine", "engine_version", "config_type", "hardware",
+        "model", "workload", "metrics", "constraints", "versions",
+        "environment", "metadata"
+      ],
+      "properties": {
+        "entry_id": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+        },
+        "engine": { "type": "string", "minLength": 1 },
+        "engine_version": { "type": "string", "minLength": 1 },
+        "config_type": {
+          "type": "string",
+          "enum": ["single_gpu", "multi_gpu", "multi_node"]
+        },
+        "hardware": {
+          "type": "object",
+          "required": ["vendor", "chip_model", "chip_count"],
+          "properties": {
+            "vendor": { "type": "string" },
+            "chip_model": { "type": "string", "minLength": 1 },
+            "chip_count": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": true
+        },
+        "model": {
+          "type": "object",
+          "required": [
+            "canonical_id", "repo_id", "short_name", "display_name", "name",
+            "parameters", "precision"
+          ],
+          "properties": {
+            "canonical_id": { "type": "string", "minLength": 1 },
+            "repo_id": { "type": "string", "minLength": 1 },
+            "short_name": { "type": "string", "minLength": 1 },
+            "display_name": { "type": "string", "minLength": 1 },
+            "name": { "type": "string", "minLength": 1 },
+            "parameters": { "type": "string", "minLength": 1 },
+            "precision": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": true
+        },
+        "workload": {
+          "type": "object",
+          "required": ["name", "input_length", "output_length"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "input_length": { "type": "integer", "minimum": 1 },
+            "output_length": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": true
+        },
+        "metrics": {
+          "type": "object",
+          "required": ["ttft_ms", "throughput_tps", "peak_mem_mb", "error_rate"],
+          "properties": {
+            "ttft_ms": { "type": ["number", "null"], "minimum": 0 },
+            "throughput_tps": { "type": ["number", "null"], "minimum": 0 },
+            "peak_mem_mb": { "type": ["integer", "null"], "minimum": 0 },
+            "error_rate": { "type": ["number", "null"], "minimum": 0, "maximum": 1 }
+          },
+          "additionalProperties": true
+        },
+        "constraints": { "type": "object" },
+        "versions": { "type": "object" },
+        "environment": { "type": "object" },
+        "metadata": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "legacyEntry": {
+      "allOf": [
+        { "$ref": "#/$defs/baseEntry" },
+        {
+          "not": {
+            "anyOf": [
+              { "required": ["trend_schema_version"] },
+              { "required": ["coverage_class"] },
+              { "required": ["trend_status"] }
+            ]
+          }
+        }
+      ]
+    },
+    "aggregateMetric": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": { "type": "number", "minimum": 0 },
+        "min": { "type": "number", "minimum": 0 },
+        "max": { "type": "number", "minimum": 0 },
+        "std": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "canonicalAggregate": {
+      "type": "object",
+      "required": ["method", "count", "metrics", "outlier_handling"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["mean", "median", "trimmed_mean", "min", "max"]
+        },
+        "count": { "type": "integer", "minimum": 1 },
+        "trim_percent": { "type": "number", "minimum": 0, "maximum": 0.5 },
+        "metrics": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/$defs/aggregateMetric" }
+        },
+        "outlier_handling": {
+          "type": "string",
+          "enum": ["none", "removed", "capped"]
+        },
+        "outlier_details": { "type": ["string", "null"] },
+        "note": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "method": { "const": "trimmed_mean" } } },
+          "then": { "required": ["trim_percent"] }
+        },
+        {
+          "if": { "properties": { "method": { "enum": ["mean", "median", "trimmed_mean"] } } },
+          "then": { "properties": { "count": { "minimum": 2 } } }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "trendEntry": {
+      "allOf": [
+        { "$ref": "#/$defs/baseEntry" },
+        {
+          "type": "object",
+          "required": ["trend_schema_version", "coverage_class", "trend_status"],
+          "properties": {
+            "trend_schema_version": {
+              "type": "string",
+              "const": "trend-coverage/v1"
+            },
+            "coverage_class": {
+              "type": "string",
+              "enum": ["full-matrix", "targeted-pair", "experimental"]
+            },
+            "campaign_id": { "type": "string", "minLength": 1 },
+            "comparison_id": { "type": "string", "minLength": 1 },
+            "point_role": {
+              "type": ["string", "null"],
+              "enum": ["baseline", "head", "checkpoint", null]
+            },
+            "repeat_group": { "type": "string", "minLength": 1 },
+            "repeat_index": { "type": "integer", "minimum": 0 },
+            "canonical_aggregate": { "$ref": "#/$defs/canonicalAggregate" },
+            "trend_status": {
+              "type": "string",
+              "enum": ["default", "experimental", "blocked", "invalid", "excluded"]
+            },
+            "trend_reason": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "if": { "properties": { "coverage_class": { "const": "full-matrix" } } },
+          "then": {
+            "required": ["campaign_id", "point_role"],
+            "properties": { "point_role": { "const": "checkpoint" } }
+          }
+        },
+        {
+          "if": { "properties": { "coverage_class": { "const": "targeted-pair" } } },
+          "then": {
+            "required": ["campaign_id", "comparison_id", "point_role"],
+            "properties": { "point_role": { "enum": ["baseline", "head"] } }
+          }
+        },
+        {
+          "if": { "properties": { "coverage_class": { "const": "experimental" } } },
+          "then": {
+            "properties": {
+              "point_role": { "enum": [null] },
+              "trend_status": { "enum": ["experimental", "invalid", "excluded"] }
+            },
+            "not": { "required": ["comparison_id"] }
+          }
+        },
+        {
+          "if": { "required": ["repeat_group"] },
+          "then": {
+            "required": ["repeat_index"],
+            "allOf": [
+              {
+                "if": { "properties": { "coverage_class": { "not": { "const": "experimental" } } } },
+                "then": { "required": ["canonical_aggregate"] }
+              }
+            ]
+          }
+        },
+        {
+          "if": { "properties": { "trend_status": { "enum": ["default", "blocked", "invalid", "excluded"] } } },
+          "then": {
+            "if": { "properties": { "trend_status": { "enum": ["blocked", "invalid", "excluded"] } } },
+            "then": { "required": ["trend_reason"] }
+          }
+        }
+      ]
+    },
+    "entry": {
+      "oneOf": [
+        { "$ref": "#/$defs/trendEntry" },
+        { "$ref": "#/$defs/legacyEntry" }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/trend_coverage/invalid/bad-version.json
+++ b/tests/fixtures/trend_coverage/invalid/bad-version.json
@@ -1,0 +1,9 @@
+{
+  "entry_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "engine": "vllm", "engine_version": "1.0", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "m", "repo_id": "m", "short_name": "m", "display_name": "m", "name": "m", "parameters": "7B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1, "output_length": 1},
+  "metrics": {"ttft_ms": 1, "throughput_tps": 1, "peak_mem_mb": 1, "error_rate": 0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v2", "coverage_class": "experimental", "trend_status": "experimental", "trend_reason": "bad version"
+}

--- a/tests/fixtures/trend_coverage/invalid/experimental-role.json
+++ b/tests/fixtures/trend_coverage/invalid/experimental-role.json
@@ -1,0 +1,9 @@
+{
+  "entry_id": "88888888-8888-4888-8888-888888888888", "engine": "vllm", "engine_version": "1.0", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "m", "repo_id": "m", "short_name": "m", "display_name": "m", "name": "m", "parameters": "7B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1, "output_length": 1},
+  "metrics": {"ttft_ms": 1, "throughput_tps": 1, "peak_mem_mb": 1, "error_rate": 0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "experimental", "point_role": "checkpoint", "trend_status": "experimental", "trend_reason": "wrong role"
+}

--- a/tests/fixtures/trend_coverage/invalid/full-matrix-no-aggregate.json
+++ b/tests/fixtures/trend_coverage/invalid/full-matrix-no-aggregate.json
@@ -1,0 +1,9 @@
+{
+  "entry_id": "99999999-9999-4999-8999-999999999999", "engine": "vllm", "engine_version": "1.0", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "m", "repo_id": "m", "short_name": "m", "display_name": "m", "name": "m", "parameters": "7B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1, "output_length": 1},
+  "metrics": {"ttft_ms": 1, "throughput_tps": 1, "peak_mem_mb": 1, "error_rate": 0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "full-matrix", "campaign_id": "c/v1", "point_role": "checkpoint", "repeat_group": "c/v1::series", "repeat_index": 0, "trend_status": "default"
+}

--- a/tests/fixtures/trend_coverage/invalid/missing-targeted-comparison.json
+++ b/tests/fixtures/trend_coverage/invalid/missing-targeted-comparison.json
@@ -1,0 +1,9 @@
+{
+  "entry_id": "77777777-7777-4777-8777-777777777777", "engine": "vllm", "engine_version": "1.0", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "m", "repo_id": "m", "short_name": "m", "display_name": "m", "name": "m", "parameters": "7B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1, "output_length": 1},
+  "metrics": {"ttft_ms": 1, "throughput_tps": 1, "peak_mem_mb": 1, "error_rate": 0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "targeted-pair", "campaign_id": "c/v1", "point_role": "head", "trend_status": "blocked", "trend_reason": "missing comparison id"
+}

--- a/tests/fixtures/trend_coverage/valid/blocked.json
+++ b/tests/fixtures/trend_coverage/valid/blocked.json
@@ -1,0 +1,14 @@
+{
+  "entry_id": "44444444-4444-4444-8444-444444444444",
+  "engine": "vllm-hust", "engine_version": "dev", "config_type": "multi_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 38.0, "throughput_tps": 350.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "targeted-pair",
+  "campaign_id": "blocked-pair-jul-2026/v1",
+  "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+  "point_role": "head", "trend_status": "blocked",
+  "trend_reason": "Baseline unavailable: runtime blocker prevents matched reference run."
+}

--- a/tests/fixtures/trend_coverage/valid/experimental.json
+++ b/tests/fixtures/trend_coverage/valid/experimental.json
@@ -1,0 +1,11 @@
+{
+  "entry_id": "33333333-3333-4333-8333-333333333333",
+  "engine": "vllm-hust", "engine_version": "dev", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "INT8"},
+  "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 55.0, "throughput_tps": 290.0, "peak_mem_mb": 8192, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "experimental",
+  "trend_status": "experimental", "trend_reason": "single-point-w8a8"
+}

--- a/tests/fixtures/trend_coverage/valid/full-matrix.json
+++ b/tests/fixtures/trend_coverage/valid/full-matrix.json
@@ -1,0 +1,23 @@
+{
+  "entry_id": "11111111-1111-4111-8111-111111111111",
+  "engine": "vllm-hust",
+  "engine_version": "v0.20.1rc0-535-gceec19abb0",
+  "config_type": "multi_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 42.0, "throughput_tps": 321.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1",
+  "coverage_class": "full-matrix",
+  "campaign_id": "full-stack-jul-2026/v1",
+  "point_role": "checkpoint",
+  "repeat_group": "full-stack-jul-2026/v1::qwen25-14b::910B2::BF16::random-online::2chip::multi_gpu::vllm-hust",
+  "repeat_index": 0,
+  "canonical_aggregate": {
+    "method": "mean", "count": 3,
+    "metrics": {"ttft_ms": {"value": 42.0}, "throughput_tps": {"value": 321.0}},
+    "outlier_handling": "none"
+  },
+  "trend_status": "default"
+}

--- a/tests/fixtures/trend_coverage/valid/invalid.json
+++ b/tests/fixtures/trend_coverage/valid/invalid.json
@@ -1,0 +1,11 @@
+{
+  "entry_id": "55555555-5555-4555-8555-555555555555",
+  "engine": "vllm-hust", "engine_version": "dev", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+  "workload": {"name": "random-latency", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 2180.94, "throughput_tps": null, "peak_mem_mb": 0, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "experimental",
+  "trend_status": "invalid", "trend_reason": "throughput_tps=0 was rejected as an invalid measurement."
+}

--- a/tests/fixtures/trend_coverage/valid/legacy.json
+++ b/tests/fixtures/trend_coverage/valid/legacy.json
@@ -1,0 +1,9 @@
+{
+  "entry_id": "66666666-6666-4666-8666-666666666666",
+  "engine": "vllm", "engine_version": "0.18.0", "config_type": "single_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "FP16"},
+  "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 42.0, "throughput_tps": 321.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {}
+}

--- a/tests/fixtures/trend_coverage/valid/targeted-pair.json
+++ b/tests/fixtures/trend_coverage/valid/targeted-pair.json
@@ -1,0 +1,13 @@
+{
+  "entry_id": "22222222-2222-4222-8222-222222222222",
+  "engine": "vllm-hust", "engine_version": "v0.23.1rc0-1276-g1aa7cd10b7", "config_type": "multi_gpu",
+  "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+  "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+  "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+  "metrics": {"ttft_ms": 38.0, "throughput_tps": 350.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+  "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+  "trend_schema_version": "trend-coverage/v1", "coverage_class": "targeted-pair",
+  "campaign_id": "random-latency-fix-jul-2026/v1",
+  "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+  "point_role": "head", "trend_status": "default"
+}

--- a/tests/test_leaderboard_trend_schema.py
+++ b/tests/test_leaderboard_trend_schema.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+
+ROOT = Path(__file__).parent
+SCHEMA_PATH = ROOT.parent / "schemas" / "leaderboard_trend_v1.schema.json"
+FIXTURE_ROOT = ROOT / "fixtures" / "trend_coverage"
+
+
+def _validator() -> Draft7Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def _payload(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_schema_accepts_all_supported_trend_states_and_legacy_payload() -> None:
+    validator = _validator()
+    for path in sorted((FIXTURE_ROOT / "valid").glob("*.json")):
+        errors = list(validator.iter_errors(_payload(path)))
+        assert errors == [], f"{path.name}: {errors}"
+
+
+def test_schema_rejects_missing_or_inconsistent_conditional_fields() -> None:
+    validator = _validator()
+    for path in sorted((FIXTURE_ROOT / "invalid").glob("*.json")):
+        errors = list(validator.iter_errors(_payload(path)))
+        assert errors, f"expected {path.name} to fail schema validation"
+
+
+def test_schema_accepts_a_payload_array() -> None:
+    validator = _validator()
+    payloads = [_payload(FIXTURE_ROOT / "valid" / name) for name in ("full-matrix.json", "experimental.json")]
+    assert list(validator.iter_errors(payloads)) == []
+
+
+def test_schema_requires_aggregate_for_non_experimental_repeated_entry() -> None:
+    validator = _validator()
+    payload = _payload(FIXTURE_ROOT / "valid" / "full-matrix.json")
+    del payload["canonical_aggregate"]
+    assert list(validator.iter_errors(payload))
+


### PR DESCRIPTION
## Summary

- add the versioned `trend-coverage/v1` JSON Schema extension
- encode coverage classes, trend states, conditional fields, and canonical aggregate structure
- add valid and invalid fixtures for full-matrix, targeted-pair, experimental, blocked, invalid, and legacy payloads
- add focused schema validation tests

## Validation

- `PYTHONPATH=src pytest -q tests/test_leaderboard_trend_schema.py`
- Result: 4 passed

Cross-entry pair completeness, matrix completeness, and repeat-group uniqueness remain validator responsibilities for T09.
