### PR TITLE
feat: add trend admission validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           XDG_CONFIG_HOME: ${{ github.workspace }}/.ci-home/.config
         run: python -m pytest -q tests --junitxml=pytest-results.xml
 
+      - name: Validate trend admission fixtures
+        run: python scripts/validate_trend_entries.py --input tests/fixtures/trend_coverage/valid
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/validate_trend_entries.py
+++ b/scripts/validate_trend_entries.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Validate a trend entry JSON file or directory for CI and local use."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="JSON file or directory of JSON files")
+    args = parser.parse_args()
+    paths = [args.input] if args.input.is_file() else sorted(args.input.glob("*.json"))
+    entries = []
+    for path in paths:
+        entries.extend(load_json_entries(path))
+    report = validate_entries(entries)
+    for decision in report.decisions:
+        print(f"{decision.status:12} {decision.entry_id}: {decision.reason}")
+    for issue in report.issues:
+        print(f"{issue.severity.upper():5} {issue.code}: {issue.entry_id}: {issue.message}")
+    return 1 if not report.passed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vllm_hust_benchmark/trend_validator.py
+++ b/src/vllm_hust_benchmark/trend_validator.py
@@ -179,6 +179,29 @@ def _pair_key(entry: Mapping[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _repeat_completeness(
+    entry: Mapping[str, Any], entries: list[dict[str, Any]]
+) -> tuple[bool, str]:
+    """Check that a declared aggregate is backed by the raw repeat entries."""
+    group = entry.get("repeat_group")
+    aggregate = entry.get("canonical_aggregate")
+    if not group or not isinstance(aggregate, Mapping):
+        return False, "repeat_group and canonical_aggregate are required"
+
+    series = [candidate for candidate in entries if candidate.get("repeat_group") == group]
+    expected = aggregate.get("count")
+    if expected != len(series):
+        return False, (
+            f"canonical_aggregate.count={expected!r} but repeat_group={group!r} "
+            f"contains {len(series)} raw entries"
+        )
+
+    indices = [candidate.get("repeat_index") for candidate in series]
+    if len(indices) != len(set(indices)) or sorted(indices) != list(range(len(indices))):
+        return False, "repeat_index values must be unique and contiguous from 0"
+    return True, ""
+
+
 def _cross_entry_decision(entry: dict[str, Any], decision: AdmissionDecision, entries: list[dict[str, Any]], local: dict[str, AdmissionDecision]) -> AdmissionDecision:
     if decision.status != "pending":
         return decision
@@ -191,15 +214,11 @@ def _cross_entry_decision(entry: dict[str, Any], decision: AdmissionDecision, en
         group = entry.get("repeat_group")
         if not group:
             return AdmissionDecision(entry_id, "experimental", "Single full-matrix run has no repeat_group")
-        series = [candidate for candidate in entries if candidate.get("repeat_group") == group]
-        indices = [candidate.get("repeat_index") for candidate in series]
-        if len(indices) != len(set(indices)) or sorted(indices) != list(range(len(indices))):
-            issue = ValidationIssue("MATRIX_REPEAT_INDEX_INVALID", "repeat_index values must be unique and contiguous from 0", entry_id, "warning")
+        complete, reason = _repeat_completeness(entry, entries)
+        if not complete:
+            issue = ValidationIssue("MATRIX_REPEAT_INCOMPLETE", reason, entry_id, "warning")
             return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
         aggregate = entry.get("canonical_aggregate") or {}
-        if len(series) > 1 and aggregate.get("count") != len(series):
-            issue = ValidationIssue("MATRIX_AGGREGATE_MISMATCH", f"canonical_aggregate.count={aggregate.get('count')!r} does not match {len(series)} raw repetitions", entry_id, "warning")
-            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
         if aggregate.get("count", 0) < 3:
             return AdmissionDecision(entry_id, "experimental", f"Insufficient repetitions: got {aggregate.get('count')}, need at least 3")
         return AdmissionDecision(entry_id, "default", "Formal full-matrix series passed admission")
@@ -207,6 +226,10 @@ def _cross_entry_decision(entry: dict[str, Any], decision: AdmissionDecision, en
     if coverage == "targeted-pair":
         if not entry.get("repeat_group") or not entry.get("canonical_aggregate"):
             issue = ValidationIssue("PAIR_AGGREGATE_MISSING", "targeted-pair requires repeat_group and canonical_aggregate before formal admission", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        complete, reason = _repeat_completeness(entry, entries)
+        if not complete:
+            issue = ValidationIssue("PAIR_REPEAT_INCOMPLETE", reason, entry_id, "warning")
             return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
         if (entry.get("canonical_aggregate") or {}).get("count", 0) < 3:
             return AdmissionDecision(entry_id, "experimental", "Insufficient repetitions: targeted-pair needs at least 3 samples per side")
@@ -218,6 +241,23 @@ def _cross_entry_decision(entry: dict[str, Any], decision: AdmissionDecision, en
             return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
         if _pair_key(entry) != _pair_key(counterpart):
             issue = ValidationIssue("PAIR_NOT_COMPARABLE", "Pair dimensions differ; align model, hardware, precision, workload, and topology", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        counterpart_complete, counterpart_reason = _repeat_completeness(counterpart, entries)
+        if not counterpart_complete:
+            issue = ValidationIssue(
+                "PAIR_COUNTERPART_REPEAT_INCOMPLETE",
+                f"Counterpart repeat series is incomplete: {counterpart_reason}",
+                entry_id,
+                "warning",
+            )
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        if (counterpart.get("canonical_aggregate") or {}).get("count", 0) < 3:
+            issue = ValidationIssue(
+                "PAIR_COUNTERPART_REPETITIONS_INSUFFICIENT",
+                "Counterpart has fewer than 3 repetitions; both sides must meet the minimum",
+                entry_id,
+                "warning",
+            )
             return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
         counterpart_decision = local.get(_entry_id(counterpart))
         if counterpart_decision is None or counterpart_decision.status != "pending":

--- a/src/vllm_hust_benchmark/trend_validator.py
+++ b/src/vllm_hust_benchmark/trend_validator.py
@@ -1,0 +1,250 @@
+"""Schema and cross-entry admission checks for trend coverage data.
+
+The JSON schema owns shape and single-entry conditional requirements.  This
+module owns the checks that need the complete candidate set, such as pair
+matching and repeat-series completeness.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from jsonschema import Draft7Validator
+
+from vllm_hust_benchmark.workload_config_contract import (
+    requires_workload_config_contract,
+    validate_explicit_workload_config,
+)
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "leaderboard_trend_v1.schema.json"
+FORMAL_COVERAGE = {"full-matrix", "targeted-pair"}
+RETIRED_MODEL_TOKENS = {"qwen3-8b", "qwen/qwen3-8b"}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    message: str
+    entry_id: str = "<missing-entry-id>"
+    severity: str = "error"
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    entry_id: str
+    status: str
+    reason: str
+    issues: tuple[ValidationIssue, ...] = ()
+
+
+@dataclass
+class ValidationReport:
+    decisions: list[AdmissionDecision] = field(default_factory=list)
+    issues: list[ValidationIssue] = field(default_factory=list)
+    sanitized_entries: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return not any(issue.severity == "error" for issue in self.issues)
+
+
+def _entry_id(entry: Mapping[str, Any]) -> str:
+    return str(entry.get("entry_id") or "<missing-entry-id>")
+
+
+def _nested(entry: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = entry.get(key)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _is_retired(entry: Mapping[str, Any]) -> bool:
+    model = _nested(entry, "model")
+    names = {
+        str(model.get("name") or "").lower(),
+        str(model.get("repo_id") or "").lower(),
+        str(model.get("short_name") or "").lower(),
+    }
+    precision = str(model.get("precision") or "").lower()
+    return bool(names & RETIRED_MODEL_TOKENS) and precision == "bf16"
+
+
+def _is_w8a8(entry: Mapping[str, Any]) -> bool:
+    model = _nested(entry, "model")
+    values = [model.get("name"), model.get("short_name"), model.get("precision")]
+    return any("w8a8" in str(value or "").lower() or str(value or "").lower() == "int8" for value in values)
+
+
+def check_invalid_metrics(entry: Mapping[str, Any]) -> tuple[dict[str, Any], list[str], bool]:
+    """Return a sanitized metric copy, reasons, and whether a critical metric is invalid."""
+    metrics = dict(_nested(entry, "metrics"))
+    workload_name = str(_nested(entry, "workload").get("name") or "").lower()
+    reasons: list[str] = []
+    critical = False
+
+    throughput = metrics.get("throughput_tps")
+    if throughput is None:
+        reasons.append("throughput_tps is null; latency workloads may omit it, other workloads require it")
+        critical = "latency" not in workload_name
+    elif not isinstance(throughput, (int, float)) or throughput <= 0:
+        metrics["throughput_tps"] = None
+        reasons.append("throughput_tps must be > 0; set it to null and retain the raw artifact")
+        critical = "latency" not in workload_name
+
+    ttft = metrics.get("ttft_ms")
+    if ttft is None and "throughput" not in workload_name:
+        reasons.append("ttft_ms is required for latency and online workloads")
+        critical = True
+    elif ttft is not None and (not isinstance(ttft, (int, float)) or ttft <= 0):
+        metrics["ttft_ms"] = None
+        reasons.append("ttft_ms must be > 0 for this workload; set it to null")
+        critical = True
+
+    error_rate = metrics.get("error_rate")
+    if error_rate is not None and (not isinstance(error_rate, (int, float)) or not 0 <= error_rate <= 1):
+        metrics["error_rate"] = None
+        reasons.append("error_rate must be within [0, 1]; set it to null")
+        critical = True
+    elif isinstance(error_rate, (int, float)) and error_rate > 0.5:
+        reasons.append("error_rate is above 0.5; downgrade to experimental until investigated")
+
+    for name in ("peak_mem_mb", "tbt_ms", "tpot_ms"):
+        value = metrics.get(name)
+        if isinstance(value, (int, float)) and value < 0:
+            metrics[name] = None
+            reasons.append(f"{name} must not be negative; set it to null")
+
+    return metrics, reasons, critical
+
+
+def _schema_issues(entry: Mapping[str, Any], validator: Draft7Validator) -> list[ValidationIssue]:
+    return [
+        ValidationIssue("SCHEMA_INVALID", error.message, _entry_id(entry))
+        for error in sorted(validator.iter_errors(entry), key=lambda item: list(item.path))
+    ]
+
+
+def _local_decision(entry: dict[str, Any], validator: Draft7Validator) -> AdmissionDecision:
+    entry_id = _entry_id(entry)
+    schema_issues = _schema_issues(entry, validator)
+    if schema_issues:
+        return AdmissionDecision(entry_id, "invalid", "Schema validation failed; fix the listed fields", tuple(schema_issues))
+
+    if not entry.get("trend_schema_version") or not entry.get("coverage_class"):
+        issue = ValidationIssue("LEGACY_NOT_ADMITTED", "Legacy entry has no trend coverage fields; migrate it before formal admission", entry_id, "warning")
+        return AdmissionDecision(entry_id, "excluded", "Legacy entry retained for provenance only", (issue,))
+
+    contract_errors: list[str] = []
+    metadata = _nested(entry, "metadata")
+    if requires_workload_config_contract(entry) or metadata.get("workload_config_contract"):
+        contract_errors = validate_explicit_workload_config(entry)
+    if contract_errors:
+        issues = tuple(ValidationIssue("EFFECTIVE_CONFIG_INVALID", message, entry_id, "warning") for message in contract_errors)
+        return AdmissionDecision(entry_id, "blocked", "Effective workload config is incomplete or inconsistent", issues)
+
+    metrics, metric_reasons, critical_invalid = check_invalid_metrics(entry)
+    entry["metrics"] = metrics
+    if critical_invalid:
+        issues = tuple(ValidationIssue("INVALID_METRIC", reason, entry_id) for reason in metric_reasons)
+        return AdmissionDecision(entry_id, "invalid", "; ".join(metric_reasons), issues)
+
+    coverage = entry["coverage_class"]
+    if _is_retired(entry):
+        reason = "Retired Qwen3-8B/BF16 record; exclude from all published trend views"
+        return AdmissionDecision(entry_id, "excluded", reason)
+    if metric_reasons and any("throughput_tps" in reason for reason in metric_reasons) and "latency" in str(_nested(entry, "workload").get("name") or "").lower():
+        issue = ValidationIssue("LATENCY_THROUGHPUT_NOT_APPLICABLE", "random-latency may omit throughput_tps; keep the sanitized metric null and admit only as blocked", entry_id, "warning")
+        return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+    if coverage == "experimental":
+        reason = "W8A8/INT8 is outside the formal support matrix" if _is_w8a8(entry) else (entry.get("trend_reason") or "Experimental entry")
+        return AdmissionDecision(entry_id, "experimental", reason)
+    if metric_reasons:
+        return AdmissionDecision(entry_id, "experimental", "; ".join(metric_reasons))
+    return AdmissionDecision(entry_id, "pending", "Awaiting cross-entry coverage checks")
+
+
+def _pair_key(entry: Mapping[str, Any]) -> tuple[Any, ...]:
+    model = _nested(entry, "model")
+    hardware = _nested(entry, "hardware")
+    workload = _nested(entry, "workload")
+    return (
+        model.get("canonical_id") or model.get("repo_id") or model.get("name"),
+        hardware.get("vendor"), hardware.get("chip_model"), hardware.get("chip_count"),
+        model.get("precision"), workload.get("name"), workload.get("input_length"), workload.get("output_length"),
+        entry.get("config_type"),
+    )
+
+
+def _cross_entry_decision(entry: dict[str, Any], decision: AdmissionDecision, entries: list[dict[str, Any]], local: dict[str, AdmissionDecision]) -> AdmissionDecision:
+    if decision.status != "pending":
+        return decision
+    entry_id = _entry_id(entry)
+    coverage = entry.get("coverage_class")
+    if coverage == "full-matrix":
+        if entry.get("point_role") != "checkpoint" or not entry.get("campaign_id"):
+            issue = ValidationIssue("MATRIX_METADATA_MISSING", "full-matrix requires campaign_id and point_role=checkpoint", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        group = entry.get("repeat_group")
+        if not group:
+            return AdmissionDecision(entry_id, "experimental", "Single full-matrix run has no repeat_group")
+        series = [candidate for candidate in entries if candidate.get("repeat_group") == group]
+        indices = [candidate.get("repeat_index") for candidate in series]
+        if len(indices) != len(set(indices)) or sorted(indices) != list(range(len(indices))):
+            issue = ValidationIssue("MATRIX_REPEAT_INDEX_INVALID", "repeat_index values must be unique and contiguous from 0", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        aggregate = entry.get("canonical_aggregate") or {}
+        if len(series) > 1 and aggregate.get("count") != len(series):
+            issue = ValidationIssue("MATRIX_AGGREGATE_MISMATCH", f"canonical_aggregate.count={aggregate.get('count')!r} does not match {len(series)} raw repetitions", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        if aggregate.get("count", 0) < 3:
+            return AdmissionDecision(entry_id, "experimental", f"Insufficient repetitions: got {aggregate.get('count')}, need at least 3")
+        return AdmissionDecision(entry_id, "default", "Formal full-matrix series passed admission")
+
+    if coverage == "targeted-pair":
+        if not entry.get("repeat_group") or not entry.get("canonical_aggregate"):
+            issue = ValidationIssue("PAIR_AGGREGATE_MISSING", "targeted-pair requires repeat_group and canonical_aggregate before formal admission", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        if (entry.get("canonical_aggregate") or {}).get("count", 0) < 3:
+            return AdmissionDecision(entry_id, "experimental", "Insufficient repetitions: targeted-pair needs at least 3 samples per side")
+        comparison_id = entry.get("comparison_id")
+        role = entry.get("point_role")
+        counterpart = next((candidate for candidate in entries if candidate.get("comparison_id") == comparison_id and candidate.get("point_role") != role), None)
+        if counterpart is None:
+            issue = ValidationIssue("PAIR_HALF_MISSING", f"No comparable {('head' if role == 'baseline' else 'baseline')} entry for comparison_id={comparison_id!r}", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        if _pair_key(entry) != _pair_key(counterpart):
+            issue = ValidationIssue("PAIR_NOT_COMPARABLE", "Pair dimensions differ; align model, hardware, precision, workload, and topology", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        counterpart_decision = local.get(_entry_id(counterpart))
+        if counterpart_decision is None or counterpart_decision.status != "pending":
+            status = counterpart_decision.status if counterpart_decision else "unknown"
+            issue = ValidationIssue("PAIR_COUNTERPART_NOT_ADMITTED", f"Counterpart status is {status}; resolve it before publishing the pair", entry_id, "warning")
+            return AdmissionDecision(entry_id, "blocked", issue.message, (issue,))
+        return AdmissionDecision(entry_id, "default", f"Formal targeted-pair {role} passed admission")
+    return decision
+
+
+def validate_entries(entries: Iterable[Mapping[str, Any]], *, schema_path: Path | None = None) -> ValidationReport:
+    """Validate and classify a complete candidate set without mutating input entries."""
+    copied = [copy.deepcopy(dict(entry)) for entry in entries]
+    schema_file = schema_path or SCHEMA_PATH
+    schema = json.loads(schema_file.read_text(encoding="utf-8"))
+    validator = Draft7Validator(schema)
+    report = ValidationReport(sanitized_entries=copied)
+    local = {_entry_id(entry): _local_decision(entry, validator) for entry in copied}
+    report.decisions = [_cross_entry_decision(entry, local[_entry_id(entry)], copied, local) for entry in copied]
+    report.issues = [issue for decision in report.decisions for issue in decision.issues]
+    return report
+
+
+def load_json_entries(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list) and all(isinstance(item, dict) for item in payload):
+        return payload
+    raise ValueError(f"{path}: expected an object or an array of objects")

--- a/tests/test_trend_validator.py
+++ b/tests/test_trend_validator.py
@@ -16,21 +16,26 @@ def fixture(name: str) -> dict:
     return json.loads((FIXTURES / "valid" / name).read_text(encoding="utf-8"))
 
 
-def make_repeated_pair() -> list[dict]:
+def make_repeated_pair(side_count: int = 3) -> list[dict]:
     baseline = fixture("targeted-pair.json")
-    baseline["entry_id"] = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     baseline["point_role"] = "baseline"
     baseline["repeat_group"] = "pair/v1::baseline"
-    baseline["repeat_index"] = 0
     baseline["canonical_aggregate"] = {
         "method": "mean", "count": 3, "metrics": {"ttft_ms": {"value": 40}}, "outlier_handling": "none"
     }
-    head = copy.deepcopy(baseline)
-    head["entry_id"] = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
-    head["point_role"] = "head"
-    head["repeat_group"] = "pair/v1::head"
-    head["repeat_index"] = 0
-    return [baseline, head]
+    entries = []
+    for role, prefix, group in (
+        ("baseline", "a", "pair/v1::baseline"),
+        ("head", "b", "pair/v1::head"),
+    ):
+        for index in range(side_count):
+            candidate = copy.deepcopy(baseline)
+            candidate["entry_id"] = f"{prefix * 8}-{prefix * 4}-4{prefix * 3}-8{prefix * 3}-{prefix * 12}"
+            candidate["point_role"] = role
+            candidate["repeat_group"] = group
+            candidate["repeat_index"] = index
+            entries.append(candidate)
+    return entries
 
 
 @pytest.mark.parametrize("throughput", [None, 0])
@@ -56,26 +61,48 @@ def test_w8a8_is_experimental() -> None:
 
 
 def test_blocked_half_pair_has_actionable_reason() -> None:
-    entry = fixture("blocked.json")
-    entry["repeat_group"] = "blocked/v1::head"
-    entry["canonical_aggregate"] = {
-        "method": "mean", "count": 3, "metrics": {"throughput_tps": {"value": 350}}, "outlier_handling": "none"
-    }
-    entry["repeat_index"] = 0
-    report = validate_entries([entry])
-    assert report.decisions[0].status == "blocked"
+    entries = [entry for entry in make_repeated_pair() if entry["point_role"] == "head"]
+    for entry in entries:
+        entry["comparison_id"] = fixture("blocked.json")["comparison_id"]
+        entry["repeat_group"] = "blocked/v1::head"
+    report = validate_entries(entries)
+    assert all(decision.status == "blocked" for decision in report.decisions)
     assert "PAIR_HALF_MISSING" in {issue.code for issue in report.issues}
     assert "comparison_id" in report.decisions[0].reason
 
 
+def test_full_matrix_requires_raw_entries_for_declared_aggregate() -> None:
+    report = validate_entries([fixture("full-matrix.json")])
+    assert report.decisions[0].status == "blocked"
+    assert "MATRIX_REPEAT_INCOMPLETE" in {issue.code for issue in report.issues}
+
+
+def test_pair_is_blocked_when_counterpart_has_insufficient_raw_repeats() -> None:
+    entries = make_repeated_pair(side_count=3)
+    entries = [entry for entry in entries if entry["point_role"] == "baseline"] + [
+        entry for entry in entries if entry["point_role"] == "head" and entry["repeat_index"] == 0
+    ]
+    report = validate_entries(entries)
+    baseline_decisions = [decision for decision in report.decisions if decision.entry_id.startswith("a")]
+    assert baseline_decisions
+    assert all(decision.status == "blocked" for decision in baseline_decisions)
+    assert "PAIR_COUNTERPART_REPEAT_INCOMPLETE" in {issue.code for issue in report.issues}
+
+
 def test_complete_pair_and_full_matrix_are_admitted() -> None:
     pair = make_repeated_pair()
-    matrix = fixture("full-matrix.json")
-    report = validate_entries([*pair, matrix])
+    matrix_template = fixture("full-matrix.json")
+    matrix = []
+    for index in range(3):
+        candidate = copy.deepcopy(matrix_template)
+        candidate["entry_id"] = f"c{index + 1:07d}-c00{index + 1}-4c0{index + 1}-8c0{index + 1}-{'c' * 12}"
+        candidate["repeat_index"] = index
+        matrix.append(candidate)
+    report = validate_entries([*pair, *matrix])
     statuses = {decision.entry_id: decision.status for decision in report.decisions}
     assert statuses["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"] == "default"
     assert statuses["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"] == "default"
-    assert statuses[matrix["entry_id"]] == "default"
+    assert all(statuses[entry["entry_id"]] == "default" for entry in matrix)
     assert report.passed
 
 

--- a/tests/test_trend_validator.py
+++ b/tests/test_trend_validator.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_hust_benchmark.trend_validator import validate_entries
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "trend_coverage"
+
+
+def fixture(name: str) -> dict:
+    return json.loads((FIXTURES / "valid" / name).read_text(encoding="utf-8"))
+
+
+def make_repeated_pair() -> list[dict]:
+    baseline = fixture("targeted-pair.json")
+    baseline["entry_id"] = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    baseline["point_role"] = "baseline"
+    baseline["repeat_group"] = "pair/v1::baseline"
+    baseline["repeat_index"] = 0
+    baseline["canonical_aggregate"] = {
+        "method": "mean", "count": 3, "metrics": {"ttft_ms": {"value": 40}}, "outlier_handling": "none"
+    }
+    head = copy.deepcopy(baseline)
+    head["entry_id"] = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    head["point_role"] = "head"
+    head["repeat_group"] = "pair/v1::head"
+    head["repeat_index"] = 0
+    return [baseline, head]
+
+
+@pytest.mark.parametrize("throughput", [None, 0])
+def test_random_latency_missing_or_zero_throughput_is_blocked_not_invalid(throughput) -> None:
+    entry = fixture("invalid.json")
+    entry["metrics"]["throughput_tps"] = throughput
+    report = validate_entries([entry])
+    assert report.decisions[0].status == "blocked"
+    assert "LATENCY_THROUGHPUT_NOT_APPLICABLE" in {issue.code for issue in report.issues}
+
+
+def test_retired_qwen3_bf16_is_excluded() -> None:
+    entry = fixture("experimental.json")
+    entry["model"].update({"name": "Qwen/Qwen3-8B", "repo_id": "Qwen/Qwen3-8B", "short_name": "Qwen3-8B", "precision": "BF16"})
+    report = validate_entries([entry])
+    assert report.decisions[0].status == "excluded"
+
+
+def test_w8a8_is_experimental() -> None:
+    report = validate_entries([fixture("experimental.json")])
+    assert report.decisions[0].status == "experimental"
+    assert "W8A8" in report.decisions[0].reason
+
+
+def test_blocked_half_pair_has_actionable_reason() -> None:
+    entry = fixture("blocked.json")
+    entry["repeat_group"] = "blocked/v1::head"
+    entry["canonical_aggregate"] = {
+        "method": "mean", "count": 3, "metrics": {"throughput_tps": {"value": 350}}, "outlier_handling": "none"
+    }
+    entry["repeat_index"] = 0
+    report = validate_entries([entry])
+    assert report.decisions[0].status == "blocked"
+    assert "PAIR_HALF_MISSING" in {issue.code for issue in report.issues}
+    assert "comparison_id" in report.decisions[0].reason
+
+
+def test_complete_pair_and_full_matrix_are_admitted() -> None:
+    pair = make_repeated_pair()
+    matrix = fixture("full-matrix.json")
+    report = validate_entries([*pair, matrix])
+    statuses = {decision.entry_id: decision.status for decision in report.decisions}
+    assert statuses["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"] == "default"
+    assert statuses["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"] == "default"
+    assert statuses[matrix["entry_id"]] == "default"
+    assert report.passed
+
+
+def test_effective_config_contract_failure_is_blocked() -> None:
+    entry = fixture("full-matrix.json")
+    entry["same_spec"] = {
+        "spec_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+        "scenario": "random-online",
+        "resolved_server_parameters": {},
+        "resolved_client_parameters": {},
+    }
+    entry["metadata"] = {"submitted_at": "2026-07-25T00:00:00Z"}
+    report = validate_entries([entry])
+    assert report.decisions[0].status == "blocked"
+    assert "EFFECTIVE_CONFIG_INVALID" in {issue.code for issue in report.issues}


### PR DESCRIPTION
## Summary

- add schema-backed trend admission validation for leaderboard entries
- validate effective workload configuration and invalid metrics
- enforce targeted-pair and full-matrix completeness with actionable reasons
- add focused tests and a CI invocation entrypoint

## Validation

- PYTHONPATH=src:. pytest -q tests/test_trend_validator.py tests/test_leaderboard_trend_schema.py tests/test_validate_public_leaderboard_snapshots.py — 13 passed
- git diff --check — passed
- full repository pytest was started but stopped during a long-running existing integration-test phase without a failure traceback