### PR TITLE
feat: website fixtures, contract tests, and consumption docs (T13)

### DIFF
--- a/docs/WEBSITE_FIXTURE_CONTRACT.md
+++ b/docs/WEBSITE_FIXTURE_CONTRACT.md
@@ -1,0 +1,166 @@
+# Website fixture contract
+
+> **For**: Website consumers that render leaderboard trend data  
+> **Contract version**: `trend-coverage/v1`  
+> **Related**: `docs/TREND_COVERAGE_SCHEMA.md`, `tests/test_website_contract.py`
+
+This document defines the consumer-facing contract between the benchmark data
+pipeline and the website. It describes how the website should interpret each
+trend status, which entries to show as formal trends, and how to use the
+provided fixtures for testing.
+
+---
+
+## 1. Six fixture categories
+
+The following six fixtures in `tests/fixtures/trend_coverage/valid/` cover
+every data scenario the website must handle. Each fixture file is loadable as
+a single JSON object or array and passes JSON Schema validation under
+`trend-coverage/v1`.
+
+| # | Category | Fixture file | Produced `trend_status` | Website rendering |
+|---|----------|-------------|------------------------|-------------------|
+| 1 | **full-matrix** | `full-matrix.json` | `blocked` (without raw repeats) | Hide from trend lines; show diagnostic |
+| 2 | **complete targeted pair** | `complete-pair.json` | `default` (all entries) | Plot as paired trend lines |
+| 3 | **blocked half-pair** | `blocked-half-pair.json` | `blocked` (all entries) | Hide from trend lines; show diagnostic |
+| 4 | **experimental** | `experimental.json` | `experimental` | Show in experimental section only; never in default trend |
+| 5 | **invalid metric** | `invalid.json` | `blocked` | Hide from trend lines; show diagnostic |
+| 6 | **repeat aggregate** | `repeat-aggregate.json` | `default` (all entries) | Plot as formal trend line with aggregate markers |
+
+### 1.1 Status → rendering matrix
+
+| `trend_status` | Show as default trend? | Show in experimental section? | Show in blocked diagnostics? | Show in excluded list? |
+|---------------|----------------------|------------------------------|----------------------------|----------------------|
+| `default`     | ✅ Yes               | ❌ No                        | ❌ No                       | ❌ No                |
+| `experimental`| ❌ No                | ✅ Yes (separate)             | ❌ No                       | ❌ No                |
+| `blocked`     | ❌ No                | ❌ No                        | ✅ Yes (with reason)         | ❌ No                |
+| `invalid`     | ❌ No                | ❌ No                        | ✅ Yes (with reason)         | ❌ No                |
+| `excluded`    | ❌ No                | ❌ No                        | ❌ No                       | ✅ Yes (provenance) |
+
+---
+
+## 2. Filtering contract
+
+The website MUST NOT show `experimental`, `blocked`, `invalid`, or `excluded`
+entries as default formal trend lines. The ONLY allowed filter for the primary
+trend chart is:
+
+```python
+entries_by_status(entries, "default")
+```
+
+Or, expressed declaratively:
+
+```python
+trend_entries = [e for e in all_entries if e.get("trend_status") == "default"]
+```
+
+### 2.1 Experimental section
+
+Experimental entries (`trend_status == "experimental"`) should be displayed in a
+separate section below the main trend chart, clearly labeled as "Experimental"
+or "Preview". They must not be mixed into the same axes as formal `default`
+trends.
+
+### 2.2 Blocked diagnostics
+
+Blocked entries (`trend_status == "blocked"`) carry a `trend_reason` field with
+actionable diagnostic information. The website should expose this in a
+diagnostics panel or tooltip. Example reasons:
+
+```
+"No comparable baseline entry for comparison_id=..."
+"canonical_aggregate.count=3 but repeat_group=... contains 1 raw entries"
+"random-latency may omit throughput_tps; keep the sanitized metric null"
+```
+
+### 2.3 Invalid entries
+
+Invalid entries (`trend_status == "invalid"`) have critical metric failures
+and should be hidden from all trend views. They may be shown in a data-quality
+dashboard with their `trend_reason`.
+
+### 2.4 Excluded entries
+
+Excluded entries (`trend_status == "excluded"`) are legacy records retained
+for provenance only. They must not appear in any published view.
+
+---
+
+## 3. Using fixtures in website tests
+
+### 3.1 Loading fixtures
+
+The fixtures are JSON files that can be loaded in any language:
+
+```python
+import json
+entries = json.loads(path.read_text())
+# entries is either a dict (single entry) or list[dict]
+if not isinstance(entries, list):
+    entries = [entries]
+```
+
+### 3.2 Testing rendering logic
+
+```python
+def test_default_entries_are_plotted():
+    entries = load_fixture("complete-pair.json")
+    default = [e for e in entries if e["trend_status"] == "default"]
+    render_trend_chart(default)
+    assert chart.has_series("baseline")
+    assert chart.has_series("head")
+
+def test_experimental_is_not_on_main_chart():
+    entries = load_fixture("experimental.json")
+    default = [e for e in entries if e["trend_status"] == "default"]
+    assert len(default) == 0  # never shows on main chart
+
+def test_blocked_half_pair_not_on_trend():
+    entries = load_fixture("blocked-half-pair.json")
+    default = [e for e in entries if e["trend_status"] == "default"]
+    assert len(default) == 0
+
+def test_repeat_aggregate_displays_stats():
+    entries = load_fixture("repeat-aggregate.json")
+    assert all(e["trend_status"] == "default" for e in entries)
+    for e in entries:
+        agg = e["canonical_aggregate"]
+        assert "method" in agg
+        assert "count" in agg
+        assert agg["count"] == 3
+```
+
+### 3.3 Viewing full coverage
+
+Run the contract tests to see all six categories:
+
+```bash
+cd /tmp/vllm-hust-benchmark-issue-79/T13
+PYTHONPATH=src python3 -m pytest tests/test_website_contract.py -v
+```
+
+This outputs the status for each category and verifies the filtering contract.
+
+---
+
+## 4. data contract invariants
+
+| Invariant | Enforcement | Category |
+|-----------|-----------|----------|
+| Only `default` entries are formal trends | Website filter | All |
+| `experimental` includes a reason | Validator | Experimental |
+| `blocked` entries have actionable `trend_reason` | Validator schema | Blocked |
+| `invalid` entries are hidden | Website filter | Invalid |
+| `excluded` entries are provenance-only | Website filter | Legacy |
+| Each entry carries `trend_status` | Schema required | All |
+| Aggregate entries declare `canonical_aggregate.count` | Schema conditional check | Repeat aggregate |
+
+---
+
+## 5. Workflow: Adding a new fixture category
+
+1. Create the fixture JSON in `tests/fixtures/trend_coverage/valid/`
+2. Add a `CATEGORIES` entry in `tests/test_website_contract.py`
+3. Add individual status assertion and website filtering tests
+4. Run `pytest tests/test_website_contract.py` to verify

--- a/tests/fixtures/trend_coverage/valid/blocked-half-pair.json
+++ b/tests/fixtures/trend_coverage/valid/blocked-half-pair.json
@@ -1,0 +1,86 @@
+[
+  {
+    "entry_id": "e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e001",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 38.0, "throughput_tps": 350.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "blocked-pair-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::blocked-head",
+    "repeat_index": 0,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "blocked",
+    "trend_reason": "No comparable baseline entry for comparison_id"
+  },
+  {
+    "entry_id": "e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e002",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 36.0, "throughput_tps": 345.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "blocked-pair-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::blocked-head",
+    "repeat_index": 1,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "blocked",
+    "trend_reason": "No comparable baseline entry for comparison_id"
+  },
+  {
+    "entry_id": "e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e003",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 40.0, "throughput_tps": 358.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "blocked-pair-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::blocked-head",
+    "repeat_index": 2,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "blocked",
+    "trend_reason": "No comparable baseline entry for comparison_id"
+  }
+]

--- a/tests/fixtures/trend_coverage/valid/complete-pair.json
+++ b/tests/fixtures/trend_coverage/valid/complete-pair.json
@@ -1,0 +1,164 @@
+[
+  {
+    "entry_id": "c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c001",
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 40.0, "throughput_tps": 345.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "baseline",
+    "repeat_group": "pair/v1::baseline",
+    "repeat_index": 0,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c002",
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 38.0, "throughput_tps": 340.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "baseline",
+    "repeat_group": "pair/v1::baseline",
+    "repeat_index": 1,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c003",
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 42.0, "throughput_tps": 352.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "baseline",
+    "repeat_group": "pair/v1::baseline",
+    "repeat_index": 2,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "d0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d001",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 36.0, "throughput_tps": 345.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::head",
+    "repeat_index": 0,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "d0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d002",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 38.0, "throughput_tps": 350.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::head",
+    "repeat_index": 1,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "d0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d003",
+    "engine": "vllm-hust",
+    "engine_version": "dev",
+    "config_type": "multi_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 40.0, "throughput_tps": 358.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "targeted-pair",
+    "campaign_id": "engine-comparison-jul-2026/v1",
+    "comparison_id": "hf:Qwen/Qwen2.5-14B-Instruct::910B2::BF16::random-online::2chip::multi_gpu::vllm__vs__vllm-hust",
+    "point_role": "head",
+    "repeat_group": "pair/v1::head",
+    "repeat_index": 2,
+    "canonical_aggregate": {
+      "method": "mean", "count": 3,
+      "metrics": {
+        "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+      },
+      "outlier_handling": "none"
+    },
+    "trend_status": "default"
+  }
+]

--- a/tests/fixtures/trend_coverage/valid/complete-pair.json
+++ b/tests/fixtures/trend_coverage/valid/complete-pair.json
@@ -20,7 +20,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
-        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 350.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },
@@ -47,7 +47,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
-        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 350.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },
@@ -61,7 +61,7 @@
     "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
     "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
     "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
-    "metrics": {"ttft_ms": 42.0, "throughput_tps": 352.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "metrics": {"ttft_ms": 42.0, "throughput_tps": 350.0, "peak_mem_mb": 10240, "error_rate": 0.0},
     "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
     "trend_schema_version": "trend-coverage/v1",
     "coverage_class": "targeted-pair",
@@ -74,7 +74,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 40.0, "min": 38.0, "max": 42.0, "std": 2.0},
-        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 352.0, "std": 6.0}
+        "throughput_tps": {"value": 345.0, "min": 340.0, "max": 350.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },
@@ -101,7 +101,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
-        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 355.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },
@@ -128,7 +128,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
-        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 355.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },
@@ -142,7 +142,7 @@
     "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 2},
     "model": {"canonical_id": "hf:Qwen/Qwen2.5-14B-Instruct", "repo_id": "Qwen/Qwen2.5-14B-Instruct", "short_name": "Qwen2.5-14B-Instruct", "display_name": "Qwen2.5-14B-Instruct", "name": "Qwen/Qwen2.5-14B-Instruct", "parameters": "14B", "precision": "BF16"},
     "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
-    "metrics": {"ttft_ms": 40.0, "throughput_tps": 358.0, "peak_mem_mb": 10240, "error_rate": 0.0},
+    "metrics": {"ttft_ms": 40.0, "throughput_tps": 355.0, "peak_mem_mb": 10240, "error_rate": 0.0},
     "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
     "trend_schema_version": "trend-coverage/v1",
     "coverage_class": "targeted-pair",
@@ -155,7 +155,7 @@
       "method": "mean", "count": 3,
       "metrics": {
         "ttft_ms": {"value": 38.0, "min": 36.0, "max": 40.0, "std": 2.0},
-        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 358.0, "std": 6.5}
+        "throughput_tps": {"value": 350.0, "min": 345.0, "max": 355.0, "std": 5.0}
       },
       "outlier_handling": "none"
     },

--- a/tests/fixtures/trend_coverage/valid/repeat-aggregate.json
+++ b/tests/fixtures/trend_coverage/valid/repeat-aggregate.json
@@ -1,0 +1,98 @@
+[
+  {
+    "entry_id": "f0f0f0f0-f0f0-4f0f-8f0f-f0f0f0f0f001",
+    "engine": "vllm-hust",
+    "engine_version": "v0.20.1rc0-535-gceec19abb0",
+    "config_type": "single_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct", "repo_id": "Qwen/Qwen2.5-7B-Instruct", "short_name": "Qwen2.5-7B-Instruct", "display_name": "Qwen2.5-7B-Instruct", "name": "Qwen/Qwen2.5-7B-Instruct", "parameters": "7B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 280.0, "throughput_tps": 182.0, "peak_mem_mb": 20480, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "full-matrix",
+    "campaign_id": "release-verify-jul-2026/v1",
+    "point_role": "checkpoint",
+    "repeat_group": "release-verify-jul-2026/v1::qwen25-7b::910B2::BF16::random-online::1chip::single_gpu::vllm-hust",
+    "repeat_index": 0,
+    "canonical_aggregate": {
+      "method": "mean",
+      "count": 3,
+      "trim_percent": 0.0,
+      "metrics": {
+        "ttft_ms": {"value": 293.33, "min": 280.0, "max": 310.0, "std": 15.28},
+        "throughput_tps": {"value": 187.0, "min": 182.0, "max": 194.0, "std": 6.0},
+        "peak_mem_mb": {"value": 20480, "min": 20480, "max": 20480, "std": 0.0},
+        "error_rate": {"value": 0.0, "min": 0.0, "max": 0.0, "std": 0.0}
+      },
+      "outlier_handling": "none",
+      "outlier_details": null,
+      "note": "Aggregated from 3 independent run(s) using mean."
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "f0f0f0f0-f0f0-4f0f-8f0f-f0f0f0f0f002",
+    "engine": "vllm-hust",
+    "engine_version": "v0.20.1rc0-535-gceec19abb0",
+    "config_type": "single_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct", "repo_id": "Qwen/Qwen2.5-7B-Instruct", "short_name": "Qwen2.5-7B-Instruct", "display_name": "Qwen2.5-7B-Instruct", "name": "Qwen/Qwen2.5-7B-Instruct", "parameters": "7B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 290.0, "throughput_tps": 185.0, "peak_mem_mb": 20480, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "full-matrix",
+    "campaign_id": "release-verify-jul-2026/v1",
+    "point_role": "checkpoint",
+    "repeat_group": "release-verify-jul-2026/v1::qwen25-7b::910B2::BF16::random-online::1chip::single_gpu::vllm-hust",
+    "repeat_index": 1,
+    "canonical_aggregate": {
+      "method": "mean",
+      "count": 3,
+      "trim_percent": 0.0,
+      "metrics": {
+        "ttft_ms": {"value": 293.33, "min": 280.0, "max": 310.0, "std": 15.28},
+        "throughput_tps": {"value": 187.0, "min": 182.0, "max": 194.0, "std": 6.0},
+        "peak_mem_mb": {"value": 20480, "min": 20480, "max": 20480, "std": 0.0},
+        "error_rate": {"value": 0.0, "min": 0.0, "max": 0.0, "std": 0.0}
+      },
+      "outlier_handling": "none",
+      "outlier_details": null,
+      "note": "Aggregated from 3 independent run(s) using mean."
+    },
+    "trend_status": "default"
+  },
+  {
+    "entry_id": "f0f0f0f0-f0f0-4f0f-8f0f-f0f0f0f0f003",
+    "engine": "vllm-hust",
+    "engine_version": "v0.20.1rc0-535-gceec19abb0",
+    "config_type": "single_gpu",
+    "hardware": {"vendor": "Huawei", "chip_model": "910B2", "chip_count": 1},
+    "model": {"canonical_id": "hf:Qwen/Qwen2.5-7B-Instruct", "repo_id": "Qwen/Qwen2.5-7B-Instruct", "short_name": "Qwen2.5-7B-Instruct", "display_name": "Qwen2.5-7B-Instruct", "name": "Qwen/Qwen2.5-7B-Instruct", "parameters": "7B", "precision": "BF16"},
+    "workload": {"name": "random-online", "input_length": 1024, "output_length": 256},
+    "metrics": {"ttft_ms": 310.0, "throughput_tps": 194.0, "peak_mem_mb": 20480, "error_rate": 0.0},
+    "constraints": {}, "versions": {}, "environment": {}, "metadata": {},
+    "trend_schema_version": "trend-coverage/v1",
+    "coverage_class": "full-matrix",
+    "campaign_id": "release-verify-jul-2026/v1",
+    "point_role": "checkpoint",
+    "repeat_group": "release-verify-jul-2026/v1::qwen25-7b::910B2::BF16::random-online::1chip::single_gpu::vllm-hust",
+    "repeat_index": 2,
+    "canonical_aggregate": {
+      "method": "mean",
+      "count": 3,
+      "trim_percent": 0.0,
+      "metrics": {
+        "ttft_ms": {"value": 293.33, "min": 280.0, "max": 310.0, "std": 15.28},
+        "throughput_tps": {"value": 187.0, "min": 182.0, "max": 194.0, "std": 6.0},
+        "peak_mem_mb": {"value": 20480, "min": 20480, "max": 20480, "std": 0.0},
+        "error_rate": {"value": 0.0, "min": 0.0, "max": 0.0, "std": 0.0}
+      },
+      "outlier_handling": "none",
+      "outlier_details": null,
+      "note": "Aggregated from 3 independent run(s) using mean."
+    },
+    "trend_status": "default"
+  }
+]

--- a/tests/test_website_contract.py
+++ b/tests/test_website_contract.py
@@ -1,0 +1,228 @@
+"""Contract tests for website fixture consumption.
+
+These tests verify that:
+1. Each fixture category produces the expected trend_status classification
+2. The website can stably distinguish all six fixture categories
+3. Invalid/experimental entries are never shown as default formal trends
+4. The filtering contract is correctly enforced
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
+
+FIXTURES = Path(__file__).parent / "fixtures" / "trend_coverage"
+
+# ── Category definitions ──────────────────────────────────────────────
+# Each category lists the fixture file(s) and the expected trend_status
+# that the validator must assign for the website to consume.
+
+CATEGORIES: dict[str, dict[str, Any]] = {
+    "full-matrix": {
+        "files": ["valid/full-matrix.json"],
+        "expected_status": "blocked",
+        "desc": "Single full-matrix checkpoint without raw repeats → blocked (needs aggregate entries)",
+    },
+    "complete-targeted-pair": {
+        "files": ["valid/complete-pair.json"],
+        "expected_status": "default",
+        "desc": "Complete targeted pair with both baseline/head and raw repeats → default",
+    },
+    "blocked-half-pair": {
+        "files": ["valid/blocked-half-pair.json"],
+        "expected_status": "blocked",
+        "desc": "Targeted pair with only one side present → blocked (PAIR_HALF_MISSING)",
+    },
+    "experimental": {
+        "files": ["valid/experimental.json"],
+        "expected_status": "experimental",
+        "desc": "W8A8/INT8 entry outside formal support → experimental",
+    },
+    "invalid-metric": {
+        "files": ["valid/invalid.json"],
+        "expected_status": "blocked",
+        "desc": "Entry with invalid metrics → blocked (latency throughput not applicable)",
+    },
+    "repeat-aggregate": {
+        "files": ["valid/repeat-aggregate.json"],
+        "expected_status": "default",
+        "desc": "Full-matrix entry with canonical aggregate from 3 repeat runs → default",
+    },
+}
+
+# Statuses that the website should NOT show as default formal trends
+NON_DEFAULT_STATUSES = {"experimental", "blocked", "invalid", "excluded"}
+
+# Has the validator already been run for the session?
+_CACHED_REPORTS: dict[str, Any] = {}
+
+
+def _load_and_validate(name: str) -> Any:
+    """Load fixture entries and validate them, caching per category."""
+    if name in _CACHED_REPORTS:
+        return _CACHED_REPORTS[name]
+    cat = CATEGORIES[name]
+    entries: list[dict[str, Any]] = []
+    for path in cat["files"]:
+        entries.extend(load_json_entries(FIXTURES / path))
+    report = validate_entries(entries)
+    _CACHED_REPORTS[name] = report
+    return report
+
+
+# ── Contract: Each category produces the expected status ──────────────
+
+
+def test_all_six_categories_are_distinguishable() -> None:
+    """The website must be able to distinguish all six fixture categories."""
+    statuses = {}
+    for name in CATEGORIES:
+        report = _load_and_validate(name)
+        unique = {d.status for d in report.decisions}
+        statuses[name] = unique
+    # Verify each category has a distinct status (or status set)
+    # The six categories produce three distinct statuses (default, blocked, experimental)
+    # but each category is distinguishable by its fixture name → status mapping
+    assert statuses["full-matrix"] == {"blocked"}
+    assert statuses["complete-targeted-pair"] == {"default"}
+    assert statuses["blocked-half-pair"] == {"blocked"}
+    assert statuses["experimental"] == {"experimental"}
+    assert statuses["invalid-metric"] == {"blocked"}
+    assert statuses["repeat-aggregate"] == {"default"}
+
+
+def test_full_matrix_fixture_status() -> None:
+    """A full-matrix checkpoint without raw repeats is blocked until raw data is provided."""
+    report = _load_and_validate("full-matrix")
+    assert report.decisions[0].status == "blocked"
+    assert "MATRIX_REPEAT_INCOMPLETE" in {i.code for i in report.issues}
+
+
+def test_complete_targeted_pair_status() -> None:
+    """A complete targeted pair (baseline + head with raw repeats) is admitted as default."""
+    report = _load_and_validate("complete-targeted-pair")
+    assert all(d.status == "default" for d in report.decisions)
+    assert report.passed
+
+
+def test_blocked_half_pair_status() -> None:
+    """A targeted pair missing its counterpart is blocked with PAIR_HALF_MISSING."""
+    report = _load_and_validate("blocked-half-pair")
+    assert all(d.status == "blocked" for d in report.decisions)
+    assert "PAIR_HALF_MISSING" in {i.code for i in report.issues}
+
+
+def test_experimental_fixture_status() -> None:
+    """An experimental (W8A8/INT8) entry is classified as experimental, not default."""
+    report = _load_and_validate("experimental")
+    assert report.decisions[0].status == "experimental"
+    assert report.passed  # experimental is not a hard error
+
+
+def test_invalid_metric_fixture_status() -> None:
+    """An entry with invalid metrics is blocked, never default."""
+    report = _load_and_validate("invalid-metric")
+    assert report.decisions[0].status == "blocked"
+    assert "LATENCY_THROUGHPUT_NOT_APPLICABLE" in {i.code for i in report.issues}
+
+
+def test_repeat_aggregate_fixture_status() -> None:
+    """A full-matrix entry with complete repeat aggregate is admitted as default."""
+    report = _load_and_validate("repeat-aggregate")
+    assert all(d.status == "default" for d in report.decisions)
+    assert report.passed
+
+
+# ── Contract: Website filtering rules ──────────────────────────────────
+
+
+def test_only_default_status_shows_as_formal_trend() -> None:
+    """The website MUST NOT show experimental/blocked/invalid/excluded as default formal trends."""
+    for name in CATEGORIES:
+        report = _load_and_validate(name)
+        for d in report.decisions:
+            if d.status == "default":
+                continue  # default entries may be shown
+            # Entries with non-default status must NOT be shown as formal trends
+            assert d.status in NON_DEFAULT_STATUSES, (
+                f"{name}/{d.entry_id[:8]}: unexpected status {d.status}"
+            )
+
+
+def test_valid_statuses_are_well_defined() -> None:
+    """All validator-produced statuses must be from the allowed set."""
+    VALID_STATUSES = {"default", "experimental", "blocked", "invalid", "excluded"}
+    for name in CATEGORIES:
+        report = _load_and_validate(name)
+        for d in report.decisions:
+            assert d.status in VALID_STATUSES, f"Unexpected status {d.status} in {name}"
+
+
+def test_experimental_entries_have_diagnostic_reason() -> None:
+    """Experimental entries must include a reason explaining why they are experimental."""
+    report = _load_and_validate("experimental")
+    for d in report.decisions:
+        if d.status == "experimental":
+            assert d.reason, f"Experimental entry {d.entry_id[:8]} has no reason"
+            assert "W8A8" in d.reason or "INT8" in d.reason
+
+
+def test_blocked_entries_have_actionable_trend_reason() -> None:
+    """Blocked entries must include a trend_reason so the website can display diagnostic info."""
+    for name in ("full-matrix", "blocked-half-pair", "invalid-metric"):
+        report = _load_and_validate(name)
+        for d in report.decisions:
+            if d.status == "blocked":
+                assert d.reason, f"Blocked entry {d.entry_id[:8]} in {name} has no reason"
+
+
+# ── Helpers for website consumers ─────────────────────────────────────
+
+
+def _filter_by_status(entries: list[dict], *statuses: str) -> list[dict]:
+    """Utility: filter entries by trend_status (website consumption helper)."""
+    return [e for e in entries if e.get("trend_status") in statuses]
+
+
+def test_website_filter_default_entries() -> None:
+    """Demonstrate how the website filters entries by trend_status.
+
+    Only 'default' entries should be plotted as formal trend lines.
+    This test verifies the fixture supports that filtering contract.
+    """
+    entries = load_json_entries(FIXTURES / "valid" / "complete-pair.json")
+    default_entries = _filter_by_status(entries, "default")
+    assert len(default_entries) == 6  # all 6 entries in the fixture are default
+    non_default = [e for e in entries if e.get("trend_status") != "default"]
+    assert len(non_default) == 0
+
+
+def test_website_excludes_non_default_from_formal_trend() -> None:
+    """Non-default entries (experimental, blocked) are excluded from the default trend filter.
+
+    The website should always filter to trend_status=default before plotting.
+    """
+    entries = load_json_entries(FIXTURES / "valid" / "blocked-half-pair.json")
+    default_entries = _filter_by_status(entries, "default")
+    assert len(default_entries) == 0  # all blocked, none for formal trend
+
+
+def test_website_can_build_filterable_dataframe() -> None:
+    """All fixture entries have the required fields for website filtering.
+
+    This is a structural contract: the website can safely filter by trend_status
+    on any entry without checking for field existence first.
+    """
+    for name in CATEGORIES:
+        cat = CATEGORIES[name]
+        entries: list[dict] = []
+        for path in cat["files"]:
+            entries.extend(load_json_entries(FIXTURES / path))
+        for entry in entries:
+            assert "trend_status" in entry, f"{name}: entry {entry.get('entry_id', '?')[:8]} missing trend_status"
+            assert entry["trend_status"] in ("default", "experimental", "blocked", "invalid", "excluded", "pending"), \
+                f"{name}: unexpected trend_status={entry['trend_status']}"

--- a/tests/test_website_contract.py
+++ b/tests/test_website_contract.py
@@ -5,6 +5,15 @@ These tests verify that:
 2. The website can stably distinguish all six fixture categories
 3. Invalid/experimental entries are never shown as default formal trends
 4. The filtering contract is correctly enforced
+
+Test paths:
+- Status classification tests go through the full validator pipeline
+  (load_json_entries → validate_entries) to verify the adjudicated status.
+- Filtering tests use the raw fixture load path (load_json_entries only)
+  to simulate the website consumer perspective, separate from the
+  validator pipeline. A fixture's trend_status is either set statically
+  (for pre-classified entries) or set by the validator; the website
+  only reads trend_status, not how it was produced.
 """
 
 from __future__ import annotations
@@ -12,6 +21,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
 
@@ -54,39 +65,40 @@ CATEGORIES: dict[str, dict[str, Any]] = {
     },
 }
 
+VALID_STATUSES = {"default", "experimental", "blocked", "invalid", "excluded"}
+
 # Statuses that the website should NOT show as default formal trends
-NON_DEFAULT_STATUSES = {"experimental", "blocked", "invalid", "excluded"}
-
-# Has the validator already been run for the session?
-_CACHED_REPORTS: dict[str, Any] = {}
+NON_DEFAULT_STATUSES = VALID_STATUSES - {"default"}
 
 
-def _load_and_validate(name: str) -> Any:
-    """Load fixture entries and validate them, caching per category."""
-    if name in _CACHED_REPORTS:
-        return _CACHED_REPORTS[name]
+def _load_category_entries(name: str) -> list[dict[str, Any]]:
+    """Load raw fixture entries for a category (no validator)."""
     cat = CATEGORIES[name]
     entries: list[dict[str, Any]] = []
     for path in cat["files"]:
         entries.extend(load_json_entries(FIXTURES / path))
-    report = validate_entries(entries)
-    _CACHED_REPORTS[name] = report
-    return report
+    return entries
+
+
+@pytest.fixture(scope="module")
+def reports():
+    """Cache validated reports per category, shared across all tests in this module."""
+    cache: dict[str, Any] = {}
+    for name in CATEGORIES:
+        entries = _load_category_entries(name)
+        cache[name] = validate_entries(entries)
+    return cache
 
 
 # ── Contract: Each category produces the expected status ──────────────
 
 
-def test_all_six_categories_are_distinguishable() -> None:
-    """The website must be able to distinguish all six fixture categories."""
+def test_all_six_categories_produce_expected_status(reports) -> None:
+    """Each fixture category must produce the expected trend_status after validation."""
     statuses = {}
     for name in CATEGORIES:
-        report = _load_and_validate(name)
-        unique = {d.status for d in report.decisions}
+        unique = {d.status for d in reports[name].decisions}
         statuses[name] = unique
-    # Verify each category has a distinct status (or status set)
-    # The six categories produce three distinct statuses (default, blocked, experimental)
-    # but each category is distinguishable by its fixture name → status mapping
     assert statuses["full-matrix"] == {"blocked"}
     assert statuses["complete-targeted-pair"] == {"default"}
     assert statuses["blocked-half-pair"] == {"blocked"}
@@ -95,87 +107,94 @@ def test_all_six_categories_are_distinguishable() -> None:
     assert statuses["repeat-aggregate"] == {"default"}
 
 
-def test_full_matrix_fixture_status() -> None:
+def test_full_matrix_fixture_status(reports) -> None:
     """A full-matrix checkpoint without raw repeats is blocked until raw data is provided."""
-    report = _load_and_validate("full-matrix")
-    assert report.decisions[0].status == "blocked"
-    assert "MATRIX_REPEAT_INCOMPLETE" in {i.code for i in report.issues}
+    assert reports["full-matrix"].decisions[0].status == "blocked"
+    assert "MATRIX_REPEAT_INCOMPLETE" in {i.code for i in reports["full-matrix"].issues}
 
 
-def test_complete_targeted_pair_status() -> None:
+def test_complete_targeted_pair_status(reports) -> None:
     """A complete targeted pair (baseline + head with raw repeats) is admitted as default."""
-    report = _load_and_validate("complete-targeted-pair")
-    assert all(d.status == "default" for d in report.decisions)
-    assert report.passed
+    assert all(d.status == "default" for d in reports["complete-targeted-pair"].decisions)
+    assert reports["complete-targeted-pair"].passed
 
 
-def test_blocked_half_pair_status() -> None:
+def test_blocked_half_pair_status(reports) -> None:
     """A targeted pair missing its counterpart is blocked with PAIR_HALF_MISSING."""
-    report = _load_and_validate("blocked-half-pair")
-    assert all(d.status == "blocked" for d in report.decisions)
-    assert "PAIR_HALF_MISSING" in {i.code for i in report.issues}
+    assert all(d.status == "blocked" for d in reports["blocked-half-pair"].decisions)
+    assert "PAIR_HALF_MISSING" in {i.code for i in reports["blocked-half-pair"].issues}
 
 
-def test_experimental_fixture_status() -> None:
+def test_experimental_fixture_status(reports) -> None:
     """An experimental (W8A8/INT8) entry is classified as experimental, not default."""
-    report = _load_and_validate("experimental")
-    assert report.decisions[0].status == "experimental"
-    assert report.passed  # experimental is not a hard error
+    assert reports["experimental"].decisions[0].status == "experimental"
+    assert reports["experimental"].passed  # experimental is not a hard error
 
 
-def test_invalid_metric_fixture_status() -> None:
+def test_invalid_metric_fixture_status(reports) -> None:
     """An entry with invalid metrics is blocked, never default."""
-    report = _load_and_validate("invalid-metric")
-    assert report.decisions[0].status == "blocked"
-    assert "LATENCY_THROUGHPUT_NOT_APPLICABLE" in {i.code for i in report.issues}
+    assert reports["invalid-metric"].decisions[0].status == "blocked"
+    assert "LATENCY_THROUGHPUT_NOT_APPLICABLE" in {i.code for i in reports["invalid-metric"].issues}
 
 
-def test_repeat_aggregate_fixture_status() -> None:
+def test_repeat_aggregate_fixture_status(reports) -> None:
     """A full-matrix entry with complete repeat aggregate is admitted as default."""
-    report = _load_and_validate("repeat-aggregate")
-    assert all(d.status == "default" for d in report.decisions)
-    assert report.passed
+    assert all(d.status == "default" for d in reports["repeat-aggregate"].decisions)
+    assert reports["repeat-aggregate"].passed
 
 
 # ── Contract: Website filtering rules ──────────────────────────────────
 
 
-def test_only_default_status_shows_as_formal_trend() -> None:
-    """The website MUST NOT show experimental/blocked/invalid/excluded as default formal trends."""
+def test_default_filter_contract_across_all_categories(reports) -> None:
+    """The default-only filter excludes all non-default entries across every category.
+
+    This is the core contract: the one-line filter rule
+    ``entry.get('trend_status') == 'default'`` is the ONLY gate for formal trends.
+    The website must never show experimental/blocked/invalid/excluded as formal trends.
+
+    Uses the validator-adjudicated reports (the same pipeline that produces the
+    production data the website consumes), not raw fixture files.
+    """
     for name in CATEGORIES:
-        report = _load_and_validate(name)
-        for d in report.decisions:
-            if d.status == "default":
-                continue  # default entries may be shown
-            # Entries with non-default status must NOT be shown as formal trends
-            assert d.status in NON_DEFAULT_STATUSES, (
-                f"{name}/{d.entry_id[:8]}: unexpected status {d.status}"
+        report = reports[name]
+        default_count = sum(1 for d in report.decisions if d.status == "default")
+        cat = CATEGORIES[name]
+        if cat["expected_status"] == "default":
+            assert default_count == len(report.decisions), (
+                f"{name}: expected all {len(report.decisions)} entries to be "
+                f"default, got {default_count}"
+            )
+        else:
+            assert default_count == 0, (
+                f"{name}: expected 0 default entries (status={cat['expected_status']}), "
+                f"got {default_count}. Non-default entries must be excluded from the "
+                f"formal trend filter."
             )
 
 
-def test_valid_statuses_are_well_defined() -> None:
-    """All validator-produced statuses must be from the allowed set."""
-    VALID_STATUSES = {"default", "experimental", "blocked", "invalid", "excluded"}
+def test_non_default_statuses_are_valid(reports) -> None:
+    """All non-default statuses belong to the known set of allowed statuses."""
     for name in CATEGORIES:
-        report = _load_and_validate(name)
-        for d in report.decisions:
-            assert d.status in VALID_STATUSES, f"Unexpected status {d.status} in {name}"
+        for d in reports[name].decisions:
+            if d.status != "default":
+                assert d.status in NON_DEFAULT_STATUSES, (
+                    f"{name}/{d.entry_id[:8]}: unexpected non-default status {d.status}"
+                )
 
 
-def test_experimental_entries_have_diagnostic_reason() -> None:
+def test_experimental_entries_have_diagnostic_reason(reports) -> None:
     """Experimental entries must include a reason explaining why they are experimental."""
-    report = _load_and_validate("experimental")
-    for d in report.decisions:
+    for d in reports["experimental"].decisions:
         if d.status == "experimental":
             assert d.reason, f"Experimental entry {d.entry_id[:8]} has no reason"
             assert "W8A8" in d.reason or "INT8" in d.reason
 
 
-def test_blocked_entries_have_actionable_trend_reason() -> None:
+def test_blocked_entries_have_actionable_trend_reason(reports) -> None:
     """Blocked entries must include a trend_reason so the website can display diagnostic info."""
     for name in ("full-matrix", "blocked-half-pair", "invalid-metric"):
-        report = _load_and_validate(name)
-        for d in report.decisions:
+        for d in reports[name].decisions:
             if d.status == "blocked":
                 assert d.reason, f"Blocked entry {d.entry_id[:8]} in {name} has no reason"
 
@@ -184,7 +203,11 @@ def test_blocked_entries_have_actionable_trend_reason() -> None:
 
 
 def _filter_by_status(entries: list[dict], *statuses: str) -> list[dict]:
-    """Utility: filter entries by trend_status (website consumption helper)."""
+    """Utility: filter entries by trend_status (website consumption helper).
+
+    Used in the filtering tests below to demonstrate the exact filter
+    the website should apply when building its trend chart.
+    """
     return [e for e in entries if e.get("trend_status") in statuses]
 
 
@@ -192,7 +215,8 @@ def test_website_filter_default_entries() -> None:
     """Demonstrate how the website filters entries by trend_status.
 
     Only 'default' entries should be plotted as formal trend lines.
-    This test verifies the fixture supports that filtering contract.
+    This test exercises the raw fixture load path (website consumer perspective)
+    rather than the validator pipeline, to verify the fixture's on-disk contract.
     """
     entries = load_json_entries(FIXTURES / "valid" / "complete-pair.json")
     default_entries = _filter_by_status(entries, "default")
@@ -205,6 +229,7 @@ def test_website_excludes_non_default_from_formal_trend() -> None:
     """Non-default entries (experimental, blocked) are excluded from the default trend filter.
 
     The website should always filter to trend_status=default before plotting.
+    This test exercises the raw fixture load path (website consumer perspective).
     """
     entries = load_json_entries(FIXTURES / "valid" / "blocked-half-pair.json")
     default_entries = _filter_by_status(entries, "default")
@@ -218,11 +243,11 @@ def test_website_can_build_filterable_dataframe() -> None:
     on any entry without checking for field existence first.
     """
     for name in CATEGORIES:
-        cat = CATEGORIES[name]
-        entries: list[dict] = []
-        for path in cat["files"]:
-            entries.extend(load_json_entries(FIXTURES / path))
+        entries = _load_category_entries(name)
         for entry in entries:
-            assert "trend_status" in entry, f"{name}: entry {entry.get('entry_id', '?')[:8]} missing trend_status"
-            assert entry["trend_status"] in ("default", "experimental", "blocked", "invalid", "excluded", "pending"), \
+            assert "trend_status" in entry, (
+                f"{name}: entry {entry.get('entry_id', '?')[:8]} missing trend_status"
+            )
+            assert entry["trend_status"] in VALID_STATUSES, (
                 f"{name}: unexpected trend_status={entry['trend_status']}"
+            )


### PR DESCRIPTION
## Summary

T13 delivers six fixture categories that let the website team verify data contracts without depending on production data. Three new fixtures supplement the three existing ones from T08.

## Changes

### New fixtures (3)

| Fixture | Status | Purpose |
|---------|--------|---------|
| `complete-pair.json` | `default` | Full baseline + head targeted pair with 3 raw repeats each |
| `blocked-half-pair.json` | `blocked` | Head-only pair — demonstrates PAIR_HALF_MISSING |
| `repeat-aggregate.json` | `default` | Full-matrix with canonical_aggregate from 3 repeat runs |

### Contract tests (14 tests in `test_website_contract.py`)

- **Category classification**: each fixture produces the expected `trend_status`
- **Website filtering**: only `default` entries are shown as formal trend lines
- **Safety guarantee**: `experimental`/`blocked`/`invalid`/`excluded` are never shown as default trends
- **Diagnostic contract**: blocked entries carry actionable `trend_reason`

### Consumption docs (`docs/WEBSITE_FIXTURE_CONTRACT.md`)

- Status → rendering matrix for all 5 statuses
- One-line filter rule: `entry.get("trend_status") == "default"`
- Python code examples for website test authoring

## Verification

```bash
PYTHONPATH=src python3 -m pytest \
  tests/test_website_contract.py \
  tests/test_leaderboard_trend_schema.py \
  tests/test_trend_validator.py -v
# 27 passed in 0.41s
```

## Related

- Depends on T08/T09 schema and validator (PR #82, merged to main)
- No modifications to existing files — fully parallel with T11/T12
- Final acceptance verified by T35

🤖 Generated with [Claude Code](https://claude.com/claude-code)