### PR TITLE
feat: add CI/CD and manual entry trend validation gates (T12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,36 @@ jobs:
           XDG_CONFIG_HOME: ${{ github.workspace }}/.ci-home/.config
         run: python -m pytest -q tests --junitxml=pytest-results.xml
 
-      - name: Validate trend admission fixtures
+      - name: Validate trend admission fixtures (valid entries must pass)
         run: python scripts/validate_trend_entries.py --input tests/fixtures/trend_coverage/valid
+
+      - name: Validate trend rejection fixtures (invalid entries must be rejected)
+        run: |
+          set +e
+          output=$(python scripts/validate_trend_entries.py --input tests/fixtures/trend_coverage/invalid 2>&1)
+          rc=$?
+          echo "$output"
+          if [ $rc -eq 0 ]; then
+            echo "FAIL: Invalid fixtures were not rejected by the validator"
+            exit 1
+          fi
+          echo "OK: Invalid fixtures correctly rejected (exit code $rc)"
+
+      - name: Validate trend CLI command works (manual patching entry point)
+        run: |
+          python -m vllm_hust_benchmark.cli validate-trend \
+            --input tests/fixtures/trend_coverage/valid/full-matrix.json
+          echo "--- CLI valid test passed ---"
+          set +e
+          output=$(python -m vllm_hust_benchmark.cli validate-trend \
+            --input tests/fixtures/trend_coverage/invalid/bad-version.json 2>&1)
+          rc=$?
+          echo "$output"
+          if [ $rc -eq 0 ]; then
+            echo "FAIL: CLI validate-trend did not reject invalid entry"
+            exit 1
+          fi
+          echo "OK: CLI validate-trend correctly rejected invalid entry (exit code $rc)"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -319,55 +319,8 @@ jobs:
         id: validate-trend-snapshots
         if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}
         run: |
-          python - << 'PYEOF'
-          import json, sys
-          from pathlib import Path
-          from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
-
-          snapshot_dir = Path("leaderboard-data/snapshots")
-          snapshot_files = [
-              "leaderboard_single.json",
-              "leaderboard_multi.json",
-              "leaderboard_compare.json",
-          ]
-
-          all_entries = []
-          for file_name in snapshot_files:
-              path = snapshot_dir / file_name
-              if not path.is_file():
-                  print(f"WARNING: {file_name} not found")
-                  continue
-              try:
-                  entries = load_json_entries(path)
-                  all_entries.extend(entries)
-                  print(f"Loaded {len(entries)} entries from {file_name}")
-              except (ValueError, OSError) as exc:
-                  print(f"WARNING: {path}: {exc}")
-                  continue
-
-          if not all_entries:
-              print("No snapshot entries to validate")
-              sys.exit(0)
-
-          report = validate_entries(all_entries)
-          summary = {}
-          for decision in report.decisions:
-              status = decision.status
-              summary[status] = summary.get(status, 0) + 1
-              print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
-          for issue in report.issues:
-              print(f"  {issue.severity.upper():5} {issue.code}: {issue.entry_id}: {issue.message}")
-
-          print(f"\nSnapshot summary: {json.dumps(summary)}")
-          print(f"Entries: {len(report.decisions)}, Issues: {len(report.issues)}")
-
-          if not report.passed:
-              print("\nFAIL: Aggregated snapshot contains entries that fail trend admission.",
-                    file=sys.stderr)
-              sys.exit(1)
-
-          print("\nOK: Aggregated snapshots passed trend admission validation")
-          PYEOF
+          PYTHONPATH=src python -m vllm_hust_benchmark.cli validate-trend \
+            --input leaderboard-data/snapshots/
 
       - name: Verify HF snapshots match GitHub canonical snapshots
         if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}

--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -102,6 +102,59 @@ jobs:
           sys.exit(1 if errors_found else 0)
           PYEOF
 
+      - name: Validate trend admission on submission artifacts before aggregation
+        id: validate-trend-submissions
+        run: |
+          python - << 'PYEOF'
+          import json, sys
+          from pathlib import Path
+          from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
+
+          submissions_root = Path("submissions")
+          manifests = sorted(submissions_root.rglob("leaderboard_manifest.json"))
+          if not manifests:
+              print("No submission manifests found — skipping trend validation")
+              sys.exit(0)
+
+          all_entries = []
+          for manifest_path in manifests:
+              try:
+                  payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+              except (ValueError, OSError) as exc:
+                  print(f"WARNING: cannot load {manifest_path}: {exc}")
+                  continue
+              for record in payload.get("entries", []):
+                  artifact_rel = record.get("leaderboard_artifact")
+                  if not artifact_rel:
+                      continue
+                  artifact_path = manifest_path.parent / artifact_rel
+                  if not artifact_path.is_file():
+                      print(f"WARNING: {artifact_path} not found")
+                      continue
+                  try:
+                      all_entries.extend(load_json_entries(artifact_path))
+                  except (ValueError, OSError) as exc:
+                      print(f"WARNING: {artifact_path}: {exc}")
+                      continue
+
+          if not all_entries:
+              print("No submission entries to validate")
+              sys.exit(0)
+
+          report = validate_entries(all_entries)
+          for decision in report.decisions:
+              print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
+          for issue in report.issues:
+              print(f"  {issue.severity.upper():5} {issue.code}: {issue.entry_id}: {issue.message}")
+
+          if not report.passed:
+              print("\nFAIL: Trend admission validation blocked — submission contains invalid entries",
+                    file=sys.stderr)
+              sys.exit(1)
+
+          print(f"\nOK: {len(report.decisions)} submission entry(s) passed trend validation")
+          PYEOF
+
       - name: Resolve submission directories to sync
         id: resolve-submissions
         run: |
@@ -261,6 +314,60 @@ jobs:
             --commit-message "chore: sync benchmark submission and leaderboard data from ${GITHUB_REF} @ ${GITHUB_SHA::8}" \
             --execute \
             "${extra_args[@]}"
+
+      - name: Validate trend admission on aggregated snapshots (post-sync gate)
+        id: validate-trend-snapshots
+        if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}
+        run: |
+          python - << 'PYEOF'
+          import json, sys
+          from pathlib import Path
+          from vllm_hust_benchmark.trend_validator import load_json_entries, validate_entries
+
+          snapshot_dir = Path("leaderboard-data/snapshots")
+          snapshot_files = [
+              "leaderboard_single.json",
+              "leaderboard_multi.json",
+              "leaderboard_compare.json",
+          ]
+
+          all_entries = []
+          for file_name in snapshot_files:
+              path = snapshot_dir / file_name
+              if not path.is_file():
+                  print(f"WARNING: {file_name} not found")
+                  continue
+              try:
+                  entries = load_json_entries(path)
+                  all_entries.extend(entries)
+                  print(f"Loaded {len(entries)} entries from {file_name}")
+              except (ValueError, OSError) as exc:
+                  print(f"WARNING: {path}: {exc}")
+                  continue
+
+          if not all_entries:
+              print("No snapshot entries to validate")
+              sys.exit(0)
+
+          report = validate_entries(all_entries)
+          summary = {}
+          for decision in report.decisions:
+              status = decision.status
+              summary[status] = summary.get(status, 0) + 1
+              print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
+          for issue in report.issues:
+              print(f"  {issue.severity.upper():5} {issue.code}: {issue.entry_id}: {issue.message}")
+
+          print(f"\nSnapshot summary: {json.dumps(summary)}")
+          print(f"Entries: {len(report.decisions)}, Issues: {len(report.issues)}")
+
+          if not report.passed:
+              print("\nFAIL: Aggregated snapshot contains entries that fail trend admission.",
+                    file=sys.stderr)
+              sys.exit(1)
+
+          print("\nOK: Aggregated snapshots passed trend admission validation")
+          PYEOF
 
       - name: Verify HF snapshots match GitHub canonical snapshots
         if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -651,6 +651,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Root submissions directory (default: <benchmark_repo>/submissions).",
     )
 
+    validate_parser = subparsers.add_parser(
+        "validate-trend",
+        help="Validate entries against the trend coverage contract (T08 schema + T09 admission). "
+        "Accepts individual entry JSON files or directories of JSON files. "
+        "Returns non-zero on validation failure.",
+    )
+    validate_parser.add_argument(
+        "--input", type=Path, required=True,
+        help="Entry JSON file or directory of JSON files.",
+    )
+    validate_parser.add_argument(
+        "--schema", type=Path, default=None,
+        help="Path to trend schema JSON (default: schemas/leaderboard_trend_v1.schema.json).",
+    )
+
     return parser
 
 
@@ -1188,6 +1203,43 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  git commit -m \"feat: add benchmark result {args.run_id}\"")
         print(f"  git push")
         print(f"  → GitHub Actions will aggregate and upload to HuggingFace automatically.")
+        return 0
+
+    if args.command == "validate-trend":
+        from vllm_hust_benchmark.trend_validator import (
+            load_json_entries,
+            validate_entries,
+        )
+
+        if not args.input.exists():
+            print(f"ERROR: input path does not exist: {args.input}", file=sys.stderr)
+            return 2
+
+        paths = [args.input] if args.input.is_file() else sorted(args.input.glob("*.json"))
+        entries = []
+        for path in paths:
+            try:
+                entries.extend(load_json_entries(path))
+            except (ValueError, OSError) as error:
+                print(f"ERROR loading {path}: {error}", file=sys.stderr)
+                return 2
+
+        if not entries:
+            print("No entries found to validate.", file=sys.stderr)
+            return 0
+
+        report = validate_entries(entries, schema_path=args.schema)
+        for decision in report.decisions:
+            print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
+        for issue in report.issues:
+            print(f"  {issue.severity.upper():5} {issue.code}: {issue.entry_id}: {issue.message}")
+
+        if not report.passed:
+            print(f"\nFAIL: {len(report.issues)} issue(s) found — release gate blocked", file=sys.stderr)
+            return 1
+
+        passed = sum(1 for d in report.decisions if d.status in ("default", "pending"))
+        print(f"\nOK: {len(report.decisions)} entry(s) validated, {passed} admitted")
         return 0
 
     if args.command == "bench":

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -1238,7 +1238,14 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\nFAIL: {len(report.issues)} issue(s) found — release gate blocked", file=sys.stderr)
             return 1
 
-        passed = sum(1 for d in report.decisions if d.status in ("default", "pending"))
+        passed = sum(1 for d in report.decisions if d.status == "default")
+        pending = sum(1 for d in report.decisions if d.status == "pending")
+        if pending:
+            print(
+                f"WARNING: {pending} entry(s) have unknown coverage_class — "
+                f"skipped cross-entry checks",
+                file=sys.stderr,
+            )
         print(f"\nOK: {len(report.decisions)} entry(s) validated, {passed} admitted")
         return 0
 

--- a/tests/test_ci_cd_validation_gate.py
+++ b/tests/test_ci_cd_validation_gate.py
@@ -129,6 +129,28 @@ class TestCliValidateTrend:
         result = _run_cli(["--input", str(INVALID_DIR)])
         assert "release gate blocked" in result.stderr or "release gate blocked" in result.stdout
 
+    def test_schema_flag_accepts_explicit_schema_path(self) -> None:
+        """--schema with a valid path must still pass valid entries."""
+        schema_path = ROOT / "schemas" / "leaderboard_trend_v1.schema.json"
+        assert schema_path.is_file(), f"Schema not found: {schema_path}"
+        result = _run_cli([
+            "--input", str(VALID_DIR / "experimental.json"),
+            "--schema", str(schema_path),
+        ])
+        assert result.returncode == 0, (
+            f"CLI with --schema returned {result.returncode}\n"
+            f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+
+    def test_schema_flag_still_rejects_invalid(self) -> None:
+        """--schema with a valid path must still reject invalid entries."""
+        schema_path = ROOT / "schemas" / "leaderboard_trend_v1.schema.json"
+        result = _run_cli([
+            "--input", str(INVALID_DIR / "bad-version.json"),
+            "--schema", str(schema_path),
+        ])
+        assert result.returncode != 0, "--schema should still reject invalid entries"
+
 
 # ---------------------------------------------------------------------------
 # Script parity tests — scripts/validate_trend_entries.py must behave identically
@@ -159,28 +181,47 @@ class TestScriptParity:
         # Both non-zero
         assert (cli.returncode != 0) == (script.returncode != 0)
 
+    @staticmethod
+    def _parse_decisions(output: str) -> dict[str, str]:
+        """Parse '  status  entry_id: reason' lines into {entry_id: status}."""
+        KNOWN_STATUSES = frozenset({
+            "default", "blocked", "experimental", "excluded", "invalid", "pending",
+        })
+        result: dict[str, str] = {}
+        unknown: list[str] = []
+        for line in output.splitlines():
+            stripped = line.strip()
+            # Match status lines (start with a status word, contain entry_id)
+            # Skip WARNING/ERROR lines from issues
+            status_end = stripped.find(" ")
+            if status_end == -1:
+                continue
+            candidate = stripped[:status_end]
+            if candidate not in KNOWN_STATUSES:
+                if "-" in candidate or candidate.upper() == candidate:
+                    # Skip ERROR / WARNING lines (all-caps with codes)
+                    continue
+                unknown.append(candidate)
+            parts = stripped.split(None, 2)
+            if len(parts) >= 2:
+                entry_id = parts[1]
+                if "-" in entry_id:
+                    result[entry_id] = candidate
+
+        if unknown:
+            raise AssertionError(
+                f"Decision parser found unknown status(es): {sorted(set(unknown))}. "
+                "Update KNOWN_STATUSES or check if a new admission status was added."
+            )
+        return result
+
     def test_script_and_cli_consistent_decisions(self) -> None:
         """Both entry points must produce the same admission decisions per entry."""
         cli = _run_cli(["--input", str(VALID_DIR)])
         script = _run_script(["--input", str(VALID_DIR)])
 
-        def _parse_decisions(output: str) -> dict[str, str]:
-            """Parse '  status  entry_id: reason' lines into {entry_id: status}."""
-            result = {}
-            for line in output.splitlines():
-                stripped = line.strip()
-                # Match status lines (start with a status word, contain entry_id)
-                # Skip WARNING/ERROR lines from issues
-                if stripped.startswith(("default", "blocked", "experimental", "excluded", "invalid", "pending")):
-                    parts = stripped.split(None, 2)
-                    if len(parts) >= 2:
-                        entry_id = parts[1]
-                        if "-" in entry_id:
-                            result[entry_id] = parts[0]
-            return result
-
-        cli_decisions = _parse_decisions(cli.stdout)
-        script_decisions = _parse_decisions(script.stdout)
+        cli_decisions = self._parse_decisions(cli.stdout)
+        script_decisions = self._parse_decisions(script.stdout)
 
         assert cli_decisions == script_decisions, (
             f"CLI and script gave different entry-level decisions\n"

--- a/tests/test_ci_cd_validation_gate.py
+++ b/tests/test_ci_cd_validation_gate.py
@@ -1,0 +1,248 @@
+"""Test that CI/CD release gates enforce the trend coverage contract.
+
+These tests verify that:
+1. The validate-trend CLI command rejects invalid entries with non-zero exit code.
+2. The validate-trend CLI command accepts valid entries with zero exit code.
+3. The scripts/validate_trend_entries.py script behaves identically (parity).
+4. Both entry points produce consistent admission decisions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "validate_trend_entries.py"
+FIXTURE_ROOT = ROOT / "tests" / "fixtures" / "trend_coverage"
+
+VALID_DIR = FIXTURE_ROOT / "valid"
+INVALID_DIR = FIXTURE_ROOT / "invalid"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess:
+    """Run the validate-trend CLI subcommand and return the result."""
+    cmd = [sys.executable, "-m", "vllm_hust_benchmark.cli", "validate-trend"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT)
+
+
+def _run_script(args: list[str]) -> subprocess.CompletedProcess:
+    """Run scripts/validate_trend_entries.py and return the result."""
+    cmd = [sys.executable, str(SCRIPT_PATH)] + args
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT)
+
+
+def _entry_ids_from_output(output: str) -> set[str]:
+    """Extract entry IDs from the output lines like '  default  uuid-...: ...'."""
+    ids = set()
+    for line in output.splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 2 and "-" in parts[1]:
+            ids.add(parts[1])
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — validate-trend command
+# ---------------------------------------------------------------------------
+
+class TestCliValidateTrend:
+    """Tests for the ``validate-trend`` CLI subcommand (manual patching entry point)."""
+
+    def test_valid_fixtures_pass(self) -> None:
+        """All valid trend fixtures must pass validation with exit code 0."""
+        result = _run_cli(["--input", str(VALID_DIR)])
+        assert result.returncode == 0, (
+            f"CLI returned {result.returncode} for valid fixtures\n"
+            f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+        # All 18 entries in valid fixtures should be accounted for
+        ids = _entry_ids_from_output(result.stdout)
+        assert len(ids) == 18, f"Expected 18 entries, got {len(ids)}: {ids}"
+
+    def test_invalid_fixtures_fail(self) -> None:
+        """All invalid trend fixtures must be rejected with non-zero exit code."""
+        result = _run_cli(["--input", str(INVALID_DIR)])
+        assert result.returncode != 0, (
+            f"CLI returned 0 for invalid fixtures — should have failed\n"
+            f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+        # All 4 invalid fixtures should be listed as invalid
+        ids = _entry_ids_from_output(result.stdout)
+        assert len(ids) == 4, f"Expected 4 invalid entries, got {len(ids)}: {ids}"
+
+    def test_valid_single_file_passes(self) -> None:
+        """A single valid entry file must pass."""
+        path = VALID_DIR / "experimental.json"
+        result = _run_cli(["--input", str(path)])
+        assert result.returncode == 0, (
+            f"CLI returned {result.returncode} for {path}\n"
+            f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+
+    def test_invalid_single_file_fails(self) -> None:
+        """A single invalid entry file must be rejected."""
+        path = INVALID_DIR / "bad-version.json"
+        result = _run_cli(["--input", str(path)])
+        assert result.returncode != 0, (
+            f"CLI returned 0 for {path} — expected failure\n"
+            f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+        assert "SCHEMA_INVALID" in result.stdout, "Expected SCHEMA_INVALID error"
+
+    def test_nonexistent_input_fails_gracefully(self) -> None:
+        """A non-existent input path should fail with a clear error."""
+        result = _run_cli(["--input", str(ROOT / "tests" / "nonexistent.json")])
+        assert result.returncode == 2, (
+            f"Expected exit code 2 for missing input, got {result.returncode}"
+        )
+
+    def test_empty_directory_produces_no_errors(self) -> None:
+        """An empty directory with no JSON files should exit 0."""
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmpdir:
+            result = _run_cli(["--input", tmpdir])
+        assert result.returncode == 0
+
+    def test_print_diagnostics_entry_id(self) -> None:
+        """Output must include entry IDs for actionable diagnostics."""
+        result = _run_cli(["--input", str(INVALID_DIR)])
+        # Each invalid entry should have an entry_id in the output
+        assert "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" in result.stdout
+        assert "77777777-7777-4777-8777-777777777777" in result.stdout
+
+    def test_print_diagnostics_error_code(self) -> None:
+        """Output must include error codes like SCHEMA_INVALID."""
+        result = _run_cli(["--input", str(INVALID_DIR)])
+        assert "SCHEMA_INVALID" in result.stdout
+
+    def test_print_diagnostics_release_gate_message(self) -> None:
+        """On failure, output must clearly indicate the release gate is blocked."""
+        result = _run_cli(["--input", str(INVALID_DIR)])
+        assert "release gate blocked" in result.stderr or "release gate blocked" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Script parity tests — scripts/validate_trend_entries.py must behave identically
+# ---------------------------------------------------------------------------
+
+class TestScriptParity:
+    """The legacy script entry point must produce the same results as the CLI."""
+
+    def test_script_valid_fixtures_pass(self) -> None:
+        """The script must pass on all valid fixtures (same as CLI)."""
+        cli = _run_cli(["--input", str(VALID_DIR)])
+        script = _run_script(["--input", str(VALID_DIR)])
+        assert script.returncode == 0, (
+            f"Script returned {script.returncode} for valid fixtures\n"
+            f"stderr: {script.stderr}\nstdout: {script.stdout}"
+        )
+        # Both exit 0
+        assert cli.returncode == script.returncode
+
+    def test_script_invalid_fixtures_fail(self) -> None:
+        """The script must reject invalid fixtures (same as CLI)."""
+        cli = _run_cli(["--input", str(INVALID_DIR)])
+        script = _run_script(["--input", str(INVALID_DIR)])
+        assert script.returncode != 0, (
+            f"Script returned 0 for invalid fixtures — expected failure\n"
+            f"stderr: {script.stderr}\nstdout: {script.stdout}"
+        )
+        # Both non-zero
+        assert (cli.returncode != 0) == (script.returncode != 0)
+
+    def test_script_and_cli_consistent_decisions(self) -> None:
+        """Both entry points must produce the same admission decisions per entry."""
+        cli = _run_cli(["--input", str(VALID_DIR)])
+        script = _run_script(["--input", str(VALID_DIR)])
+
+        def _parse_decisions(output: str) -> dict[str, str]:
+            """Parse '  status  entry_id: reason' lines into {entry_id: status}."""
+            result = {}
+            for line in output.splitlines():
+                stripped = line.strip()
+                # Match status lines (start with a status word, contain entry_id)
+                # Skip WARNING/ERROR lines from issues
+                if stripped.startswith(("default", "blocked", "experimental", "excluded", "invalid", "pending")):
+                    parts = stripped.split(None, 2)
+                    if len(parts) >= 2:
+                        entry_id = parts[1]
+                        if "-" in entry_id:
+                            result[entry_id] = parts[0]
+            return result
+
+        cli_decisions = _parse_decisions(cli.stdout)
+        script_decisions = _parse_decisions(script.stdout)
+
+        assert cli_decisions == script_decisions, (
+            f"CLI and script gave different entry-level decisions\n"
+            f"CLI: {cli_decisions}\nScript: {script_decisions}"
+        )
+        assert len(cli_decisions) == 18, f"Expected 18 entries, got {len(cli_decisions)}"
+
+
+# ---------------------------------------------------------------------------
+# CI/CD gate simulation tests
+# ---------------------------------------------------------------------------
+
+class TestCiCdGate:
+    """Simulate the exact CI/CD gate logic to prove acceptance criteria."""
+
+    def test_ci_would_fail_on_invalid_entry(self) -> None:
+        """Emulate the CI 'Validate trend rejection fixtures' step."""
+        result = _run_script(["--input", str(INVALID_DIR)])
+        assert result.returncode != 0, (
+            "CI gate would pass with invalid entries — WRONG: "
+            "gate must fail when invalid entries are present"
+        )
+
+    def test_ci_would_pass_on_valid_entries(self) -> None:
+        """Emulate the CI 'Validate trend admission fixtures' step."""
+        result = _run_script(["--input", str(VALID_DIR)])
+        assert result.returncode == 0, (
+            f"CI gate would fail with valid entries — WRONG: "
+            f"gate must pass valid entries (exit {result.returncode})"
+        )
+
+    def test_hf_publish_gate_rejects_invalid_snapshot(self) -> None:
+        """Emulate the HF publish gate's post-sync snapshot validation."""
+        # Build a synthetic "snapshot" with one valid + one invalid entry
+        valid_data = json.loads((VALID_DIR / "experimental.json").read_text(encoding="utf-8"))
+        invalid_data = json.loads((INVALID_DIR / "bad-version.json").read_text(encoding="utf-8"))
+        payload = [valid_data, invalid_data]
+
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmpdir:
+            snapshot = Path(tmpdir) / "leaderboard_single.json"
+            snapshot.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            result = _run_cli(["--input", str(snapshot)])
+        assert result.returncode != 0, (
+            "HF publish gate would allow invalid entry through — WRONG"
+        )
+
+    def test_hf_publish_gate_accepts_clean_snapshot(self) -> None:
+        """Emulate the HF publish gate with all-valid snapshot entries."""
+        payload: list[dict] = []
+        for path in sorted(VALID_DIR.glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                payload.extend(data)
+            else:
+                payload.append(data)
+
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmpdir:
+            snapshot = Path(tmpdir) / "leaderboard_single.json"
+            snapshot.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            result = _run_cli(["--input", str(snapshot)])
+        assert result.returncode == 0, (
+            f"HF publish gate rejected clean snapshot (exit {result.returncode})"
+        )


### PR DESCRIPTION
## 概述

在发布闸门处强制执行趋势 coverage 契约（T08 schema + T09 admission），确保 CI/CD 和手工补点使用同一 validator。

## 变更

### 新增 validate-trend CLI 命令
- `src/vllm_hust_benchmark/cli.py`：新增 `validate-trend` 子命令，统一 CI/CD 和手工补点入口
- 用法：`python -m vllm_hust_benchmark.cli validate-trend --input <path>`
- 与 `scripts/validate_trend_entries.py` 行为完全一致（18 entry 校验结果全匹配）

### CI 闸门（ci.yml）
- valid fixture 校验（必须通过，exit 0）
- invalid fixture 校验（必须拒绝，若通过则 CI 失败）
- CLI 双端一致性验证

### HF 发布闸门（push-to-hf.yml）
- **pre-aggregation**：遍历 `submissions/` 下所有 artifact 做趋势校验
- **post-sync**：聚合后验证 `leaderboard_single/multi/compare.json`

### 测试
- `tests/test_ci_cd_validation_gate.py`：16 个验收测试
- 含 CLI 命令测试、script 一致性测试、CI/HF 闸门模拟测试

## 验收

- 构造无效 entry → CI 必须失败 ✅
- 合法 entry → CI 必须通过 ✅
- 两条入口（CLI + script）校验结果一致 ✅（18 entry 全匹配）
- 16/16 测试通过，兼容已有 13 个测试

## 依赖关系

- 前置：T11（trend producer，PR #85）
- 后置：T30（候选正式数据生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)