### PR TITLE
feat(perfgate): harden baseline quality lifecycle

### DIFF
--- a/docs/central-perfgate-baselines.md
+++ b/docs/central-perfgate-baselines.md
@@ -23,6 +23,11 @@ baselines/
               run_leaderboard.json
 ```
 
+`baseline-metadata.json` embeds a `measurement` record. Publication requires at least one discarded
+warmup run and three measured runs aggregated with the per-metric median. The record contains
+ordered SHA-256 checksums for every warmup and measured raw result. The trusted writer must
+recompute those checksums from the producer artifact before publication.
+
 The latest-main pointer is namespaced by target, scenario, and spec:
 
 ```text
@@ -40,6 +45,8 @@ latest-main pointer.
 - matching target repository and commit metadata in the artifact;
 - matching scenario, spec ID, and resolved spec hash;
 - finite throughput, TTFT, and TBT metrics;
+- at least one warmup and three measured runs with ordered raw-result checksums;
+- per-metric medians that exactly match the published artifact;
 - exact core, plugin, and benchmark runner revisions;
 - hardware, CANN, PyTorch, and torch-npu provenance.
 
@@ -58,3 +65,20 @@ This protocol does not grant or consume cross-repository credentials. A trusted 
 writer supplies the checked-out target main history and the central baseline worktree. Pull-request
 workflows remain read-only consumers. Credential management, serialized cross-repository pushes, and
 hardware backfill orchestration are separate rollout steps.
+
+## Quarantine And Withdrawal
+
+An invalid published baseline is retained for audit and blocked by an immutable record under the
+same complete identity:
+
+```text
+revoked/<target-owner>/<target-repository>/<target-sha>/<scenario>/<spec-id>/<spec-hash>/
+  quarantined.json
+  withdrawn.json
+```
+
+Use `python -m vllm_hust_benchmark.perfgate_baselines revoke` in a clean `benchmark-baselines`
+checkout, then commit and push the new `revoked/` record with the scoped central writer. Both states
+make exact fetch and validation fail closed. Valid transitions are
+`active -> quarantined -> withdrawn` or `active -> withdrawn`; `withdrawn` is terminal. Baseline
+files are never deleted or overwritten, and consumers must not fall back to pointers or legacy data.

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -6,6 +6,24 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 VLLM_CLI_COMPAT=${VLLM_CLI_COMPAT:-"$REPO_ROOT/scripts/run_vllm_cli_compat.py"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
+# Perfgate measurement strategy (P0-7): warmup runs are executed against the
+# same live server and discarded; measured runs are aggregated per-metric with
+# the median. Defaults preserve the historical single-run behavior.
+PERFGATE_WARMUP_RUNS=${PERFGATE_WARMUP_RUNS:-0}
+PERFGATE_MEASURED_RUNS=${PERFGATE_MEASURED_RUNS:-1}
+PERFGATE_AGGREGATION=${PERFGATE_AGGREGATION:-median}
+if ! [[ "$PERFGATE_WARMUP_RUNS" =~ ^[0-9]+$ ]]; then
+  echo "PERFGATE_WARMUP_RUNS must be a non-negative integer: $PERFGATE_WARMUP_RUNS" >&2
+  exit 2
+fi
+if ! [[ "$PERFGATE_MEASURED_RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PERFGATE_MEASURED_RUNS must be a positive integer: $PERFGATE_MEASURED_RUNS" >&2
+  exit 2
+fi
+if [[ "$PERFGATE_AGGREGATION" != "median" ]]; then
+  echo "PERFGATE_AGGREGATION only supports median: $PERFGATE_AGGREGATION" >&2
+  exit 2
+fi
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
 CURRENT_RUNTIME_CWD=${CURRENT_RUNTIME_CWD:-"/data/shared_datasets/vllm-hust-benchmark/tmp"}
 CURRENT_VLLM_HUST_REPO=${CURRENT_VLLM_HUST_REPO:-"$WORKSPACE_ROOT/vllm-hust"}
@@ -496,7 +514,7 @@ run_client_command() {
       run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
         "$CURRENT_RUNTIME_PYTHON" "$VLLM_CLI_COMPAT" bench serve \
         --save-result \
-        --result-dir "$RESULT_DIR" \
+        --result-dir "$(dirname "$RAW_RESULT_FILE")" \
         --result-filename "$(basename "$RAW_RESULT_FILE")" \
         $CLIENT_ARGS
       ;;
@@ -1153,12 +1171,58 @@ else
   rm -f "$OFFLINE_GRAPH_PROOF_FILE"
 fi
 
-set +e
-run_client_command_with_server_monitor
-client_status=$?
-set -e
-if [[ "$client_status" -ne 0 ]]; then
-  exit "$client_status"
+PERFGATE_RUNS_DIR="$RESULT_DIR/runs"
+WARMUP_RAW_RESULT_FILES=()
+MEASURED_RAW_RESULT_FILES=()
+
+if [[ "$PERFGATE_WARMUP_RUNS" -eq 0 && "$PERFGATE_MEASURED_RUNS" -eq 1 ]]; then
+  # Historical single-run behavior (non-perfgate callers).
+  set +e
+  run_client_command_with_server_monitor
+  client_status=$?
+  set -e
+  if [[ "$client_status" -ne 0 ]]; then
+    exit "$client_status"
+  fi
+  MEASURED_RAW_RESULT_FILES+=("$RAW_RESULT_FILE")
+else
+  # Perfgate measurement strategy (P0-7): all runs share the already-started
+  # server so warmup absorbs cold-start effects; any failed run aborts with its
+  # original exit code (including 86 node-level failures for outer retries).
+  for ((warmup_index = 1; warmup_index <= PERFGATE_WARMUP_RUNS; warmup_index++)); do
+    RAW_RESULT_FILE="$PERFGATE_RUNS_DIR/warmup-$warmup_index/raw_benchmark_result.json"
+    mkdir -p "$(dirname "$RAW_RESULT_FILE")"
+    echo "[same-spec-current] perfgate warmup run $warmup_index/$PERFGATE_WARMUP_RUNS (discarded from aggregation)"
+    set +e
+    run_client_command_with_server_monitor
+    client_status=$?
+    set -e
+    if [[ "$client_status" -ne 0 ]]; then
+      echo "[same-spec-current] perfgate warmup run $warmup_index failed with status $client_status" >&2
+      exit "$client_status"
+    fi
+    WARMUP_RAW_RESULT_FILES+=("$RAW_RESULT_FILE")
+  done
+
+  for ((run_index = 1; run_index <= PERFGATE_MEASURED_RUNS; run_index++)); do
+    RAW_RESULT_FILE="$PERFGATE_RUNS_DIR/$run_index/raw_benchmark_result.json"
+    mkdir -p "$(dirname "$RAW_RESULT_FILE")"
+    echo "[same-spec-current] perfgate measured run $run_index/$PERFGATE_MEASURED_RUNS"
+    set +e
+    run_client_command_with_server_monitor
+    client_status=$?
+    set -e
+    if [[ "$client_status" -ne 0 ]]; then
+      echo "[same-spec-current] perfgate measured run $run_index failed with status $client_status" >&2
+      exit "$client_status"
+    fi
+    MEASURED_RAW_RESULT_FILES+=("$RAW_RESULT_FILE")
+  done
+
+  # Keep the legacy raw-result path pointing at measured run 1 so downstream
+  # existence checks keep working, and use run 1 as the export template.
+  RAW_RESULT_FILE="${MEASURED_RAW_RESULT_FILES[0]}"
+  cp -f "$RAW_RESULT_FILE" "$RESULT_DIR/raw_benchmark_result.json"
 fi
 
 if [[ "$BENCHMARK_TYPE" != "serve" ]]; then
@@ -1217,5 +1281,25 @@ append_export_arg_if_present --concurrent-requests "$CONCURRENT_REQUESTS"
 run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" \
 "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.cli export-leaderboard-artifact \
   "${EXPORT_ARGS[@]}"
+
+if [[ "$PERFGATE_WARMUP_RUNS" -gt 0 || "$PERFGATE_MEASURED_RUNS" -gt 1 ]]; then
+  AGGREGATE_ARGS=(
+    --template "$ARTIFACT_DIR/run_leaderboard.json"
+    --warmup-runs "$PERFGATE_WARMUP_RUNS"
+    --aggregation "$PERFGATE_AGGREGATION"
+    --output "$ARTIFACT_DIR/run_leaderboard.json"
+    --measurement-out "$ARTIFACT_DIR/measurement.json"
+  )
+  for warmup_raw_result in "${WARMUP_RAW_RESULT_FILES[@]}"; do
+    AGGREGATE_ARGS+=(--warmup-raw-result "$warmup_raw_result")
+  done
+  for measured_raw_result in "${MEASURED_RAW_RESULT_FILES[@]}"; do
+    AGGREGATE_ARGS+=(--run-raw-result "$measured_raw_result")
+  done
+  run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" \
+  "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.cli perfgate-aggregate-runs \
+    "${AGGREGATE_ARGS[@]}"
+  echo "[same-spec-current] aggregated $PERFGATE_MEASURED_RUNS measured runs ($PERFGATE_AGGREGATION) into $ARTIFACT_DIR/run_leaderboard.json"
+fi
 
 echo "[same-spec-current] exported leaderboard artifact to $ARTIFACT_DIR"

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -28,6 +28,7 @@ from vllm_hust_benchmark.integration import (
     validate_runtime_repo,
 )
 from vllm_hust_benchmark.leaderboard_export import export_leaderboard_artifacts
+from vllm_hust_benchmark import perfgate_measurement
 from vllm_hust_benchmark.aggregate_results import (
     VALID_AGG_METHODS,
     VALID_OUTLIER_HANDLING,
@@ -541,6 +542,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Outlier detection method (default: iqr).",
     )
 
+    perfgate_aggregate_parser = subparsers.add_parser(
+        "perfgate-aggregate-runs",
+        help="Aggregate repeated perfgate measured runs (per-metric median) into "
+        "one run_leaderboard.json and emit a measurement.json strategy record.",
+    )
+    perfgate_measurement.add_aggregate_runs_arguments(perfgate_aggregate_parser)
+
     publish_parser = subparsers.add_parser(
         "publish-website",
         help="Aggregate exported leaderboard artifacts into vllm-hust-website data outputs.",
@@ -1048,6 +1056,13 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
             return aggregate_exit_code
         return 0
+
+    if args.command == "perfgate-aggregate-runs":
+        try:
+            return perfgate_measurement.run_aggregate_runs_cli(args)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
 
     if args.command == "aggregate":
         try:

--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -14,9 +14,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from vllm_hust_benchmark.same_spec import compute_resolved_spec_hash
+from vllm_hust_benchmark.perfgate_measurement import validate_measurement_block
 
 
 BASELINE_SCHEMA_VERSION = "perfgate-baseline/v1"
+REVOCATION_SCHEMA_VERSION = "perfgate-baseline-revocation/v1"
+REVOCATION_STATUSES = frozenset({"quarantined", "withdrawn"})
 SUPPORTED_SCENARIOS = frozenset({"random-online"})
 SUPPORTED_TARGET_REPOSITORIES = {
     "vllm-hust/vllm-hust": "vLLM-HUST/vllm-hust",
@@ -79,6 +82,13 @@ def _validate_metadata_value(value: str, *, field: str) -> str:
     normalized = str(value or "").strip()
     if not normalized or any(character in normalized for character in "\0\r\n"):
         raise ValueError(f"{field} must be a non-empty single-line value")
+    return normalized
+
+
+def _validate_evidence_url(value: str, *, field: str) -> str:
+    normalized = _validate_metadata_value(value, field=field)
+    if not normalized.startswith("https://"):
+        raise ValueError(f"{field} must be an HTTPS URL")
     return normalized
 
 
@@ -150,6 +160,27 @@ def latest_pointer_relative_path(identity: BaselineIdentity) -> PurePosixPath:
         identity.spec_id,
         "latest-main.json",
     )
+
+
+def revocation_relative_path(
+    identity: BaselineIdentity, status: str | None = None
+) -> PurePosixPath:
+    identity = normalize_identity(identity)
+    owner, repository = identity.target_repository.split("/", maxsplit=1)
+    root = PurePosixPath(
+        "revoked",
+        owner,
+        repository,
+        identity.target_sha,
+        identity.scenario,
+        identity.spec_id,
+        identity.spec_hash,
+    )
+    if status is None:
+        return root
+    if status not in REVOCATION_STATUSES:
+        raise ValueError(f"invalid revocation status: {status!r}")
+    return root / f"{status}.json"
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
@@ -304,8 +335,9 @@ def _manifest_payload(
     provenance: BaselineProvenance,
     *,
     artifact_sha256: str,
+    measurement: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "schema_version": BASELINE_SCHEMA_VERSION,
         "identity": asdict(identity),
         "provenance": asdict(provenance),
@@ -314,6 +346,9 @@ def _manifest_payload(
             "sha256": artifact_sha256,
         },
     }
+    if measurement is not None:
+        payload["measurement"] = measurement
+    return payload
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -322,6 +357,164 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _load_revocation_file(
+    repository_root: Path, identity: BaselineIdentity, status: str
+) -> dict[str, Any] | None:
+    relative_path = revocation_relative_path(identity, status)
+    _reject_symlink_components(repository_root, relative_path)
+    path = repository_root / relative_path
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise ValueError(f"baseline revocation record is not a file: {path}")
+    payload = _load_json_object(path)
+    if payload.get("schema_version") != REVOCATION_SCHEMA_VERSION:
+        raise ValueError(f"unsupported baseline revocation schema in {path}")
+    if payload.get("identity") != asdict(identity):
+        raise ValueError(f"baseline revocation identity mismatch: {path}")
+    actual_status = payload.get("release_visibility_status")
+    if actual_status != status:
+        raise ValueError(
+            f"baseline revocation status mismatch in {path}: {actual_status!r}"
+        )
+    expected_artifact_path = (
+        baseline_relative_dir(identity).as_posix() + "/run_leaderboard.json"
+    )
+    if payload.get("artifact_path") != expected_artifact_path:
+        raise ValueError(f"baseline revocation artifact path mismatch: {path}")
+    for field in ("reason", "detected_at", "actor"):
+        _validate_metadata_value(payload.get(field), field=field)
+    for field in ("detection_run_url", "workflow_url"):
+        _validate_evidence_url(payload.get(field), field=field)
+    for field in ("publication_commit", "artifact_sha256"):
+        value = _validate_metadata_value(payload.get(field), field=field)
+        if field == "publication_commit":
+            _validate_sha(value, field=field)
+        elif field == "artifact_sha256" and not re.fullmatch(r"[0-9a-f]{64}", value):
+            raise ValueError(f"artifact_sha256 is invalid in {path}")
+    return payload
+
+
+def _load_revocation(
+    repository_root: Path, identity: BaselineIdentity
+) -> dict[str, Any] | None:
+    # A later withdrawn event supersedes quarantine while both immutable records
+    # remain in Git history and in the current tree for audit.
+    for status in ("withdrawn", "quarantined"):
+        payload = _load_revocation_file(repository_root, identity, status)
+        if payload is not None:
+            return payload
+    return None
+
+
+def record_revocation(
+    repository_root: Path,
+    identity: BaselineIdentity,
+    *,
+    status: str,
+    reason: str,
+    detected_at: str,
+    detection_run_url: str,
+    actor: str,
+    workflow_url: str,
+    publication_commit: str,
+) -> Path:
+    """Write an immutable revocation record for one exact central baseline."""
+
+    identity = normalize_identity(identity)
+    if status not in REVOCATION_STATUSES:
+        raise ValueError(
+            f"status must be one of {sorted(REVOCATION_STATUSES)}, got {status!r}"
+        )
+    values = {
+        "reason": _validate_metadata_value(reason, field="reason"),
+        "detected_at": _validate_metadata_value(detected_at, field="detected_at"),
+        "detection_run_url": _validate_evidence_url(
+            detection_run_url, field="detection_run_url"
+        ),
+        "actor": _validate_metadata_value(actor, field="actor"),
+        "workflow_url": _validate_evidence_url(workflow_url, field="workflow_url"),
+        "publication_commit": _validate_sha(
+            publication_commit, field="publication_commit"
+        ),
+    }
+    relative_path = revocation_relative_path(identity, status)
+    existing = _load_revocation_file(repository_root, identity, status)
+    withdrawn = _load_revocation_file(repository_root, identity, "withdrawn")
+    if status == "quarantined" and withdrawn is not None:
+        raise ValueError(
+            "cannot quarantine an exact baseline after it has been withdrawn: "
+            f"{repository_root / revocation_relative_path(identity, 'withdrawn')}"
+        )
+    if _load_revocation(repository_root, identity) is None:
+        # Validate the complete active baseline before recording its withdrawal.
+        load_manifest(repository_root, identity, require_measurement=True)
+    baseline_dir = repository_root / baseline_relative_dir(identity)
+    manifest_path = baseline_dir / "baseline-metadata.json"
+    artifact_path = baseline_dir / "run_leaderboard.json"
+    if not manifest_path.is_file() or not artifact_path.is_file():
+        raise ValueError(f"cannot revoke unavailable exact baseline: {baseline_dir}")
+    manifest = _load_json_object(manifest_path)
+    artifact = manifest.get("artifact")
+    if not isinstance(artifact, dict):
+        raise ValueError(f"baseline artifact metadata is missing: {manifest_path}")
+    artifact_sha256 = str(artifact.get("sha256") or "").strip()
+    if not re.fullmatch(r"[0-9a-f]{64}", artifact_sha256):
+        raise ValueError(f"baseline artifact checksum is invalid: {manifest_path}")
+    if _sha256(artifact_path) != artifact_sha256:
+        raise ValueError(f"baseline artifact checksum mismatch: {artifact_path}")
+    if (repository_root / ".git").exists():
+        artifact_relative_path = (
+            baseline_relative_dir(identity).as_posix() + "/run_leaderboard.json"
+        )
+        publication = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repository_root),
+                "rev-list",
+                "-1",
+                "HEAD",
+                "--",
+                artifact_relative_path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        actual_publication_commit = publication.stdout.strip().lower()
+        if (
+            publication.returncode != 0
+            or actual_publication_commit != values["publication_commit"]
+        ):
+            raise ValueError(
+                "publication_commit does not match the commit that introduced "
+                f"{artifact_relative_path}: expected "
+                f"{actual_publication_commit or 'unavailable'}, got "
+                f"{values['publication_commit']}"
+            )
+    payload = {
+        "schema_version": REVOCATION_SCHEMA_VERSION,
+        "release_visibility_status": status,
+        "identity": asdict(identity),
+        "artifact_path": (
+            baseline_relative_dir(identity).as_posix() + "/run_leaderboard.json"
+        ),
+        "artifact_sha256": artifact_sha256,
+        **values,
+    }
+    path = repository_root / relative_path
+    if existing is not None:
+        if existing != payload:
+            raise ValueError(
+                f"revocation record already exists with different content: {path}"
+            )
+        return path
+    _reject_symlink_components(repository_root, relative_path)
+    _write_json(path, payload)
+    return path
 
 
 def _reject_symlink_components(
@@ -345,10 +538,24 @@ def store_baseline(
     provenance: BaselineProvenance,
     *,
     update_latest_pointer: bool = False,
+    measurement: dict[str, Any] | None = None,
 ) -> Path:
     identity = normalize_identity(identity)
     provenance = normalize_provenance(provenance)
-    validate_artifact(source, identity, provenance)
+    revocation = _load_revocation(repository_root, identity)
+    if revocation is not None:
+        raise ValueError(
+            "cannot store a revoked exact baseline: "
+            f"{repository_root / revocation_relative_path(identity)}"
+        )
+    artifact_payload = validate_artifact(source, identity, provenance)
+    if measurement is not None:
+        validate_measurement_block(
+            measurement,
+            artifact_metrics=artifact_payload.get("metrics"),
+            context=f"{source}: measurement",
+            require_publication_policy=True,
+        )
 
     relative_dir = baseline_relative_dir(identity)
     _reject_symlink_components(repository_root, relative_dir)
@@ -359,7 +566,7 @@ def store_baseline(
     _reject_symlink_components(repository_root, relative_dir / "baseline-metadata.json")
     artifact_sha256 = _sha256(source)
     expected_manifest = _manifest_payload(
-        identity, provenance, artifact_sha256=artifact_sha256
+        identity, provenance, artifact_sha256=artifact_sha256, measurement=measurement
     )
 
     if destination_dir.exists():
@@ -398,9 +605,19 @@ def store_baseline(
 
 
 def load_manifest(
-    repository_root: Path, identity: BaselineIdentity
+    repository_root: Path,
+    identity: BaselineIdentity,
+    *,
+    require_measurement: bool = False,
 ) -> tuple[Path, BaselineProvenance]:
     identity = normalize_identity(identity)
+    revocation = _load_revocation(repository_root, identity)
+    if revocation is not None:
+        status = revocation["release_visibility_status"]
+        raise ValueError(
+            f"exact central baseline is {status}: "
+            f"{repository_root / revocation_relative_path(identity, status)}"
+        )
     relative_dir = baseline_relative_dir(identity)
     _reject_symlink_components(repository_root, relative_dir / "run_leaderboard.json")
     _reject_symlink_components(repository_root, relative_dir / "baseline-metadata.json")
@@ -429,7 +646,16 @@ def load_manifest(
     expected_digest = str(artifact_metadata.get("sha256") or "").strip()
     if _sha256(artifact) != expected_digest:
         raise ValueError(f"baseline artifact checksum mismatch: {artifact}")
-    validate_artifact(artifact, identity, provenance)
+    artifact_payload = validate_artifact(artifact, identity, provenance)
+    if "measurement" in manifest:
+        validate_measurement_block(
+            manifest["measurement"],
+            artifact_metrics=artifact_payload.get("metrics"),
+            context=f"{manifest_path}: measurement",
+            require_publication_policy=True,
+        )
+    elif require_measurement:
+        raise ValueError(f"baseline measurement metadata is missing: {manifest_path}")
     return artifact, provenance
 
 
@@ -439,8 +665,11 @@ def fetch_baseline(
     identity: BaselineIdentity,
     *,
     expected_provenance: BaselineProvenance | None = None,
+    require_measurement: bool = False,
 ) -> Path:
-    artifact, provenance = load_manifest(repository_root, identity)
+    artifact, provenance = load_manifest(
+        repository_root, identity, require_measurement=require_measurement
+    )
     if expected_provenance is not None:
         expected = normalize_provenance(expected_provenance)
         if provenance != expected:
@@ -531,6 +760,7 @@ def publish_baseline(
     max_attempts: int = 5,
     writer_name: str = DEFAULT_WRITER_NAME,
     writer_email: str = DEFAULT_WRITER_EMAIL,
+    measurement: dict[str, Any] | None = None,
 ) -> str:
     identity = normalize_identity(identity)
     provenance = normalize_provenance(provenance)
@@ -541,6 +771,8 @@ def publish_baseline(
         raise ValueError("remote must be non-empty")
     if max_attempts < 1:
         raise ValueError("max_attempts must be at least 1")
+    if measurement is None:
+        raise ValueError("measurement metadata is required for central publication")
 
     verify_main_commit(
         target_git_repository,
@@ -585,6 +817,7 @@ def publish_baseline(
                 identity,
                 provenance,
                 update_latest_pointer=update_latest_pointer,
+                measurement=measurement,
             )
             paths_to_add = ["baselines"]
             if (checkout / "pointers").is_dir():
@@ -676,6 +909,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     store_parser.add_argument("--target-git-repository", type=Path, required=True)
     store_parser.add_argument("--main-ref", default="origin/main")
     store_parser.add_argument("--update-latest-pointer", action="store_true")
+    store_parser.add_argument(
+        "--measurement-file",
+        type=Path,
+        required=True,
+        help="measurement.json produced by perfgate-aggregate-runs; embedded into "
+        "the baseline manifest and cross-checked against the artifact metrics.",
+    )
     _add_identity_arguments(store_parser)
     _add_provenance_arguments(store_parser)
 
@@ -690,6 +930,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     _add_identity_arguments(validate_parser)
     _add_provenance_arguments(validate_parser)
 
+    revoke_parser = commands.add_parser("revoke")
+    revoke_parser.add_argument("--repository-root", type=Path, required=True)
+    revoke_parser.add_argument(
+        "--status", choices=sorted(REVOCATION_STATUSES), required=True
+    )
+    revoke_parser.add_argument("--reason", required=True)
+    revoke_parser.add_argument("--detected-at", required=True)
+    revoke_parser.add_argument("--detection-run-url", required=True)
+    revoke_parser.add_argument("--actor", required=True)
+    revoke_parser.add_argument("--workflow-url", required=True)
+    revoke_parser.add_argument("--publication-commit", required=True)
+    _add_identity_arguments(revoke_parser)
+
     publish_parser = commands.add_parser("publish")
     publish_parser.add_argument("--remote", required=True)
     publish_parser.add_argument("--branch", default=DEFAULT_BASELINE_BRANCH)
@@ -700,6 +953,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     publish_parser.add_argument("--max-attempts", type=int, default=5)
     publish_parser.add_argument("--writer-name", default=DEFAULT_WRITER_NAME)
     publish_parser.add_argument("--writer-email", default=DEFAULT_WRITER_EMAIL)
+    publish_parser.add_argument(
+        "--measurement-file",
+        type=Path,
+        required=True,
+        help="measurement.json produced by perfgate-aggregate-runs; embedded into "
+        "the baseline manifest and cross-checked against the artifact metrics.",
+    )
     _add_identity_arguments(publish_parser)
     _add_provenance_arguments(publish_parser)
     return parser.parse_args(argv)
@@ -709,7 +969,25 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
         identity = _identity_from_args(args)
+        if args.command == "revoke":
+            print(
+                record_revocation(
+                    args.repository_root,
+                    identity,
+                    status=args.status,
+                    reason=args.reason,
+                    detected_at=args.detected_at,
+                    detection_run_url=args.detection_run_url,
+                    actor=args.actor,
+                    workflow_url=args.workflow_url,
+                    publication_commit=args.publication_commit,
+                )
+            )
+            return 0
         provenance = _provenance_from_args(args)
+        measurement: dict[str, Any] | None = None
+        if getattr(args, "measurement_file", None) is not None:
+            measurement = _load_json_object(args.measurement_file)
         if args.command == "store":
             verify_main_commit(
                 args.target_git_repository,
@@ -723,6 +1001,7 @@ def main(argv: list[str] | None = None) -> int:
                 identity,
                 provenance,
                 update_latest_pointer=args.update_latest_pointer,
+                measurement=measurement,
             )
             print(destination)
             return 0
@@ -733,11 +1012,14 @@ def main(argv: list[str] | None = None) -> int:
                     args.output,
                     identity,
                     expected_provenance=provenance,
+                    require_measurement=True,
                 )
             )
             return 0
         if args.command == "validate":
-            _artifact, actual_provenance = load_manifest(args.repository_root, identity)
+            _artifact, actual_provenance = load_manifest(
+                args.repository_root, identity, require_measurement=True
+            )
             if actual_provenance != normalize_provenance(provenance):
                 raise ValueError("exact central baseline provenance mismatch")
             print("Central perfgate baseline is valid.")
@@ -756,6 +1038,7 @@ def main(argv: list[str] | None = None) -> int:
                     max_attempts=args.max_attempts,
                     writer_name=args.writer_name,
                     writer_email=args.writer_email,
+                    measurement=measurement,
                 )
             )
             return 0

--- a/src/vllm_hust_benchmark/perfgate_measurement.py
+++ b/src/vllm_hust_benchmark/perfgate_measurement.py
@@ -1,0 +1,381 @@
+"""Perfgate measurement strategy: warmup + repeated runs with median aggregation.
+
+This module implements the P0-7 fix: instead of producing a perfgate baseline
+from a single cold run, the producer executes ``warmup_runs`` discarded warmup
+runs followed by ``measured_runs`` measured runs against the same live server,
+then aggregates the required metrics per-metric with the median.
+
+The aggregated artifact is a patched copy of the template ``run_leaderboard.json``
+(exported from measured run 1): only ``metrics.throughput_tps``, ``metrics.ttft_ms``
+and ``metrics.tbt_ms`` are replaced by medians. ``error_rate`` must be exactly 0
+in every measured run. ``peak_mem_mb`` is a server-lifetime property measured
+across the whole session, so the template value is kept as-is.
+
+The full strategy and every measured run's raw metrics are recorded in a
+``measurement`` block so consumers and auditors can verify the aggregation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import statistics
+from pathlib import Path
+from typing import Any
+
+MEASUREMENT_STRATEGY = "warmup+median"
+SUPPORTED_AGGREGATIONS = frozenset({"median"})
+MEDIAN_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms")
+PER_RUN_METRICS = ("throughput_tps", "ttft_ms", "tbt_ms", "error_rate", "peak_mem_mb")
+MIN_PUBLICATION_WARMUP_RUNS = 1
+MIN_PUBLICATION_MEASURED_RUNS = 3
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read JSON object from {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_finite_non_negative(name: str, value: Any, *, context: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{context}: metric {name} is not a number: {value!r}")
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"{context}: metric {name} is invalid: {number!r}")
+    return number
+
+
+def run_metrics_from_raw_result(path: Path) -> dict[str, Any]:
+    """Derive per-run leaderboard metrics from one raw vllm-bench result file."""
+
+    from vllm_hust_benchmark.leaderboard_export import (
+        _derive_metrics_from_benchmark_result,
+    )
+
+    payload = _load_json_object(path)
+    derived = _derive_metrics_from_benchmark_result(payload, peak_mem_mb=None)
+    context = str(path)
+    metrics: dict[str, Any] = {}
+    for name in MEDIAN_METRICS:
+        metrics[name] = _require_finite_non_negative(
+            name, derived.get(name), context=context
+        )
+    error_rate = _require_finite_non_negative(
+        "error_rate", derived.get("error_rate"), context=context
+    )
+    if error_rate != 0:
+        raise ValueError(
+            f"{context}: measured run has non-zero error_rate: {error_rate}"
+        )
+    metrics["error_rate"] = 0.0
+    peak = derived.get("peak_mem_mb")
+    metrics["peak_mem_mb"] = (
+        _require_finite_non_negative("peak_mem_mb", peak, context=context)
+        if peak is not None
+        else None
+    )
+    return metrics
+
+
+def aggregate_measured_runs(
+    per_run: list[dict[str, Any]],
+    *,
+    warmup_runs: int,
+    warmup: list[dict[str, Any]] | None = None,
+    aggregation: str = "median",
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Aggregate measured-run metrics; return (median metrics, measurement block).
+
+    ``per_run`` entries must contain ``run_index``, ``raw_result_sha256`` and a
+    ``metrics`` dict with the PER_RUN_METRICS keys.
+    """
+
+    if aggregation not in SUPPORTED_AGGREGATIONS:
+        raise ValueError(f"unsupported aggregation: {aggregation!r}")
+    if isinstance(warmup_runs, bool) or not isinstance(warmup_runs, int):
+        raise ValueError(f"warmup_runs must be an integer, got {warmup_runs!r}")
+    if warmup_runs < 0:
+        raise ValueError(f"warmup_runs must be >= 0, got {warmup_runs}")
+    warmup = [] if warmup is None else warmup
+    if not isinstance(warmup, list) or len(warmup) != warmup_runs:
+        raise ValueError(
+            "warmup evidence must be a list of length warmup_runs "
+            f"({warmup_runs}), got {warmup!r}"
+        )
+    for index, entry in enumerate(warmup, start=1):
+        context = f"warmup run {index}"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{context}: entry must be an object")
+        run_index = entry.get("run_index")
+        if isinstance(run_index, bool) or not isinstance(run_index, int):
+            raise ValueError(f"{context}: run_index must be an integer")
+        if run_index != index:
+            raise ValueError(
+                f"{context}: run_index mismatch: {entry.get('run_index')!r}"
+            )
+        digest = str(entry.get("raw_result_sha256") or "").strip()
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(
+                f"{context}: raw_result_sha256 must be a lowercase SHA-256 digest"
+            )
+    if not per_run:
+        raise ValueError("at least one measured run is required")
+
+    for index, entry in enumerate(per_run, start=1):
+        context = f"measured run {index}"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{context}: per_run entry must be an object")
+        run_index = entry.get("run_index")
+        if isinstance(run_index, bool) or not isinstance(run_index, int):
+            raise ValueError(f"{context}: run_index must be an integer")
+        if run_index != index:
+            raise ValueError(
+                f"{context}: run_index mismatch: {entry.get('run_index')!r}"
+            )
+        digest = str(entry.get("raw_result_sha256") or "").strip()
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(
+                f"{context}: raw_result_sha256 must be a lowercase SHA-256 digest"
+            )
+        metrics = entry.get("metrics")
+        if not isinstance(metrics, dict):
+            raise ValueError(f"{context}: missing metrics object")
+        for name in MEDIAN_METRICS:
+            _require_finite_non_negative(name, metrics.get(name), context=context)
+        error_rate = _require_finite_non_negative(
+            "error_rate", metrics.get("error_rate"), context=context
+        )
+        if error_rate != 0:
+            raise ValueError(f"{context}: non-zero error_rate: {error_rate}")
+        peak_mem_mb = metrics.get("peak_mem_mb")
+        if peak_mem_mb is not None:
+            _require_finite_non_negative("peak_mem_mb", peak_mem_mb, context=context)
+
+    aggregated = {
+        name: float(
+            statistics.median(float(entry["metrics"][name]) for entry in per_run)
+        )
+        for name in MEDIAN_METRICS
+    }
+    aggregated["error_rate"] = 0.0
+
+    measurement = {
+        "strategy": MEASUREMENT_STRATEGY,
+        "warmup_runs": int(warmup_runs),
+        "measured_runs": len(per_run),
+        "aggregation": aggregation,
+        "warmup": [
+            {
+                "run_index": int(entry["run_index"]),
+                "raw_result_sha256": str(entry["raw_result_sha256"]),
+            }
+            for entry in warmup
+        ],
+        "per_run": [
+            {
+                "run_index": int(entry["run_index"]),
+                "raw_result_sha256": str(entry["raw_result_sha256"]),
+                "metrics": {
+                    name: (
+                        float(entry["metrics"][name])
+                        if entry["metrics"].get(name) is not None
+                        else None
+                    )
+                    for name in PER_RUN_METRICS
+                },
+            }
+            for entry in per_run
+        ],
+    }
+    return aggregated, measurement
+
+
+def validate_measurement_block(
+    measurement: Any,
+    *,
+    artifact_metrics: dict[str, Any] | None = None,
+    context: str = "measurement",
+    require_publication_policy: bool = False,
+) -> dict[str, Any]:
+    """Validate the shape of a measurement block.
+
+    When ``artifact_metrics`` is provided, additionally cross-check that the
+    per-metric median of the recorded runs equals the artifact metrics
+    (fail-closed audit of the aggregation).
+    """
+
+    if not isinstance(measurement, dict):
+        raise ValueError(f"{context}: must be an object")
+    if measurement.get("strategy") != MEASUREMENT_STRATEGY:
+        raise ValueError(
+            f"{context}: unsupported strategy: {measurement.get('strategy')!r}"
+        )
+    aggregation = measurement.get("aggregation")
+    if aggregation not in SUPPORTED_AGGREGATIONS:
+        raise ValueError(f"{context}: unsupported aggregation: {aggregation!r}")
+    warmup_runs = measurement.get("warmup_runs")
+    if (
+        isinstance(warmup_runs, bool)
+        or not isinstance(warmup_runs, int)
+        or warmup_runs < 0
+    ):
+        raise ValueError(f"{context}: invalid warmup_runs: {warmup_runs!r}")
+    measured_runs = measurement.get("measured_runs")
+    if (
+        isinstance(measured_runs, bool)
+        or not isinstance(measured_runs, int)
+        or measured_runs < 1
+    ):
+        raise ValueError(f"{context}: invalid measured_runs: {measured_runs!r}")
+    if require_publication_policy and (
+        warmup_runs < MIN_PUBLICATION_WARMUP_RUNS
+        or measured_runs < MIN_PUBLICATION_MEASURED_RUNS
+    ):
+        raise ValueError(
+            f"{context}: publication requires at least "
+            f"{MIN_PUBLICATION_WARMUP_RUNS} warmup run(s) and "
+            f"{MIN_PUBLICATION_MEASURED_RUNS} measured run(s); got "
+            f"{warmup_runs} warmup and {measured_runs} measured"
+        )
+    warmup = measurement.get("warmup")
+    per_run = measurement.get("per_run")
+    if not isinstance(per_run, list) or len(per_run) != measured_runs:
+        raise ValueError(
+            f"{context}: per_run must be a list of length measured_runs "
+            f"({measured_runs}), got {per_run!r}"
+        )
+    aggregated, _ = aggregate_measured_runs(
+        per_run,
+        warmup_runs=warmup_runs,
+        warmup=warmup,
+        aggregation=aggregation,
+    )
+    if artifact_metrics is not None:
+        for name in MEDIAN_METRICS:
+            expected = aggregated[name]
+            actual = _require_finite_non_negative(
+                name, artifact_metrics.get(name), context=f"{context}: artifact"
+            )
+            if not math.isclose(expected, actual, rel_tol=1e-9, abs_tol=1e-9):
+                raise ValueError(
+                    f"{context}: artifact metric {name}={actual!r} does not match "
+                    f"median of recorded runs {expected!r}"
+                )
+    return measurement
+
+
+def apply_median_metrics(
+    template_artifact: Path,
+    aggregated_metrics: dict[str, float],
+    output: Path,
+) -> dict[str, Any]:
+    """Patch the template artifact's median metrics and write it to ``output``.
+
+    Only MEDIAN_METRICS values are replaced; same_spec, metadata, provenance and
+    peak_mem_mb are preserved from the template.
+    """
+
+    payload = _load_json_object(template_artifact)
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict):
+        raise ValueError(f"{template_artifact}: missing object key metrics")
+    for name in MEDIAN_METRICS:
+        metrics[name] = float(aggregated_metrics[name])
+    metrics["error_rate"] = 0.0
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def add_aggregate_runs_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="run_leaderboard.json exported from measured run 1.",
+    )
+    parser.add_argument(
+        "--warmup-raw-result",
+        action="append",
+        default=[],
+        dest="warmup_raw_results",
+        help="Raw benchmark result file of one warmup run, in run order.",
+    )
+    parser.add_argument(
+        "--run-raw-result",
+        action="append",
+        required=True,
+        dest="run_raw_results",
+        help="Raw benchmark result file of one measured run, in run order.",
+    )
+    parser.add_argument("--warmup-runs", type=int, required=True)
+    parser.add_argument("--aggregation", default="median")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path of the aggregated run_leaderboard.json.",
+    )
+    parser.add_argument(
+        "--measurement-out",
+        required=True,
+        help="Path of the measurement.json strategy record.",
+    )
+
+
+def run_aggregate_runs_cli(args: argparse.Namespace) -> int:
+    warmup = [
+        {
+            "run_index": index,
+            "raw_result_sha256": _sha256(Path(raw)),
+        }
+        for index, raw in enumerate(args.warmup_raw_results, start=1)
+    ]
+    per_run = []
+    for index, raw in enumerate(args.run_raw_results, start=1):
+        raw_path = Path(raw)
+        per_run.append(
+            {
+                "run_index": index,
+                "raw_result_sha256": _sha256(raw_path),
+                "metrics": run_metrics_from_raw_result(raw_path),
+            }
+        )
+    aggregated, measurement = aggregate_measured_runs(
+        per_run,
+        warmup_runs=args.warmup_runs,
+        warmup=warmup,
+        aggregation=args.aggregation,
+    )
+    payload = apply_median_metrics(Path(args.template), aggregated, Path(args.output))
+    validate_measurement_block(
+        measurement, artifact_metrics=payload.get("metrics"), context=str(args.output)
+    )
+    measurement_out = Path(args.measurement_out)
+    measurement_out.parent.mkdir(parents=True, exist_ok=True)
+    measurement_out.write_text(
+        json.dumps(measurement, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        "aggregated {count} measured run(s) with {aggregation}: {output}".format(
+            count=len(per_run), aggregation=args.aggregation, output=args.output
+        )
+    )
+    return 0

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -243,3 +243,72 @@ def test_current_same_spec_runner_probe_bypasses_proxy_and_checks_ping() -> None
     assert "set -e" in probe_block
     assert "readiness probe failed:" in probe_block
     assert "curl " not in probe_block
+
+
+def test_current_same_spec_runner_declares_perfgate_measurement_knobs() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert "PERFGATE_WARMUP_RUNS=${PERFGATE_WARMUP_RUNS:-0}" in script
+    assert "PERFGATE_MEASURED_RUNS=${PERFGATE_MEASURED_RUNS:-1}" in script
+    assert "PERFGATE_AGGREGATION=${PERFGATE_AGGREGATION:-median}" in script
+    # Fail-closed validation of the knobs.
+    assert 'if ! [[ "$PERFGATE_WARMUP_RUNS" =~ ^[0-9]+$ ]]' in script
+    assert 'if ! [[ "$PERFGATE_MEASURED_RUNS" =~ ^[1-9][0-9]*$ ]]' in script
+    assert 'if [[ "$PERFGATE_AGGREGATION" != "median" ]]' in script
+
+
+def test_current_same_spec_runner_perfgate_loop_reuses_live_server() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    loop_block = script[
+        script.index(
+            'if [[ "$PERFGATE_WARMUP_RUNS" -eq 0 && "$PERFGATE_MEASURED_RUNS" -eq 1 ]]'
+        ) :
+    ]
+    loop_block = loop_block[: loop_block.index("EXPORT_ARGS=(")]
+
+    # Warmup runs are executed, kept for audit, and excluded from aggregation.
+    assert "warmup-$warmup_index/raw_benchmark_result.json" in loop_block
+    assert "discarded from aggregation" in loop_block
+    assert 'WARMUP_RAW_RESULT_FILES+=("$RAW_RESULT_FILE")' in loop_block
+    # Measured runs land in per-run directories and are collected in order.
+    assert '"$PERFGATE_RUNS_DIR/$run_index/raw_benchmark_result.json"' in loop_block
+    assert 'MEASURED_RAW_RESULT_FILES+=("$RAW_RESULT_FILE")' in loop_block
+    # All runs reuse the already-started server: no server start inside the loop.
+    assert "run_server_command" not in loop_block
+    assert "wait_for_server" not in loop_block
+    # Any failed run aborts with its original exit code (86 passthrough).
+    assert 'exit "$client_status"' in loop_block
+    # Legacy raw-result path keeps pointing at measured run 1.
+    assert (
+        'cp -f "$RAW_RESULT_FILE" "$RESULT_DIR/raw_benchmark_result.json"' in loop_block
+    )
+
+
+def test_current_same_spec_runner_aggregates_measured_runs_after_export() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    export_index = script.index("export-leaderboard-artifact \\")
+    aggregate_index = script.index("perfgate-aggregate-runs \\")
+    assert aggregate_index > export_index
+
+    aggregate_block = script[
+        script.index(
+            'if [[ "$PERFGATE_WARMUP_RUNS" -gt 0 || "$PERFGATE_MEASURED_RUNS" -gt 1 ]]'
+        ) :
+    ]
+    aggregate_block = aggregate_block[
+        : aggregate_block.index("exported leaderboard artifact")
+    ]
+
+    assert '--template "$ARTIFACT_DIR/run_leaderboard.json"' in aggregate_block
+    assert '--warmup-runs "$PERFGATE_WARMUP_RUNS"' in aggregate_block
+    assert '--aggregation "$PERFGATE_AGGREGATION"' in aggregate_block
+    assert '--output "$ARTIFACT_DIR/run_leaderboard.json"' in aggregate_block
+    assert '--measurement-out "$ARTIFACT_DIR/measurement.json"' in aggregate_block
+    assert (
+        'AGGREGATE_ARGS+=(--warmup-raw-result "$warmup_raw_result")' in aggregate_block
+    )
+    assert (
+        'AGGREGATE_ARGS+=(--run-raw-result "$measured_raw_result")' in aggregate_block
+    )

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -223,6 +223,364 @@ def test_store_is_idempotent_but_refuses_overwrite(tmp_path: Path) -> None:
         perfgate_baselines.store_baseline(central, artifact, _identity(), _provenance())
 
 
+def _measurement(
+    *,
+    throughputs: tuple[float, float, float] = (90.0, 100.0, 110.0),
+    ttft: float = 50.0,
+    tbt: float = 10.0,
+) -> dict:
+    return {
+        "strategy": "warmup+median",
+        "warmup_runs": 1,
+        "measured_runs": 3,
+        "aggregation": "median",
+        "warmup": [
+            {
+                "run_index": 1,
+                "raw_result_sha256": "b" * 64,
+            }
+        ],
+        "per_run": [
+            {
+                "run_index": index,
+                "raw_result_sha256": "a" * 64,
+                "metrics": {
+                    "throughput_tps": value,
+                    "ttft_ms": ttft,
+                    "tbt_ms": tbt,
+                    "error_rate": 0.0,
+                    "peak_mem_mb": None,
+                },
+            }
+            for index, value in enumerate(throughputs, start=1)
+        ],
+    }
+
+
+def test_store_embeds_measurement_and_round_trips_manifest(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    # Artifact metrics: throughput=100, ttft=50, tbt=10 (matches medians).
+    _write_artifact(artifact)
+
+    destination = perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        measurement=_measurement(),
+    )
+    manifest = json.loads(
+        (destination.parent / "baseline-metadata.json").read_text(encoding="utf-8")
+    )
+    assert manifest["measurement"]["strategy"] == "warmup+median"
+    assert manifest["measurement"]["measured_runs"] == 3
+
+    # load_manifest validates the measurement block against the artifact.
+    loaded, _provenance_out = perfgate_baselines.load_manifest(central, _identity())
+    assert loaded == destination
+
+
+def test_store_rejects_measurement_median_mismatch(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    with pytest.raises(ValueError, match="does not match median"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(),
+            _provenance(),
+            measurement=_measurement(throughputs=(80.0, 90.0, 95.0)),
+        )
+
+
+def test_store_rejects_measurement_below_publication_policy(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    measurement = _measurement()
+    measurement["warmup_runs"] = 0
+    measurement["warmup"] = []
+
+    with pytest.raises(ValueError, match="publication requires at least"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(),
+            _provenance(),
+            measurement=measurement,
+        )
+
+
+def test_store_with_measurement_is_idempotent_but_refuses_changes(
+    tmp_path: Path,
+) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    first = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance(), measurement=_measurement()
+    )
+    second = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance(), measurement=_measurement()
+    )
+    assert first == second
+
+    changed = _measurement()
+    changed["warmup_runs"] = 2
+    changed["warmup"].append(
+        {
+            "run_index": 2,
+            "raw_result_sha256": "c" * 64,
+        }
+    )
+    with pytest.raises(ValueError, match="different content"):
+        perfgate_baselines.store_baseline(
+            central, artifact, _identity(), _provenance(), measurement=changed
+        )
+
+
+def test_manifest_without_measurement_remains_valid(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    destination = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance()
+    )
+    manifest = json.loads(
+        (destination.parent / "baseline-metadata.json").read_text(encoding="utf-8")
+    )
+    assert "measurement" not in manifest
+    loaded, _provenance_out = perfgate_baselines.load_manifest(central, _identity())
+    assert loaded == destination
+    with pytest.raises(ValueError, match="measurement metadata is missing"):
+        perfgate_baselines.load_manifest(central, _identity(), require_measurement=True)
+
+
+def test_load_manifest_rejects_corrupt_measurement_block(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+
+    destination = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), _provenance(), measurement=_measurement()
+    )
+    manifest_path = destination.parent / "baseline-metadata.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["measurement"]["per_run"][0]["metrics"]["throughput_tps"] = 500.0
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="measurement"):
+        perfgate_baselines.load_manifest(central, _identity())
+
+
+@pytest.mark.parametrize("status", ["quarantined", "withdrawn"])
+def test_revoked_baseline_is_retained_but_consumer_rejects_it(
+    tmp_path: Path, status: str
+) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    destination = perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        measurement=_measurement(),
+    )
+
+    revocation = perfgate_baselines.record_revocation(
+        central,
+        _identity(),
+        status=status,
+        reason="post-publication quality failure",
+        detected_at="2026-07-29T12:00:00Z",
+        detection_run_url="https://github.example/runs/detection",
+        actor="baseline-owner",
+        workflow_url="https://github.example/runs/revocation",
+        publication_commit="9" * 40,
+    )
+    payload = json.loads(revocation.read_text(encoding="utf-8"))
+    assert payload["release_visibility_status"] == status
+    assert payload["artifact_sha256"]
+    assert payload["actor"] == "baseline-owner"
+    assert destination.is_file()
+
+    with pytest.raises(ValueError, match=f"exact central baseline is {status}"):
+        perfgate_baselines.load_manifest(central, _identity(), require_measurement=True)
+    with pytest.raises(ValueError, match="cannot store a revoked exact baseline"):
+        perfgate_baselines.store_baseline(
+            central,
+            artifact,
+            _identity(),
+            _provenance(),
+            measurement=_measurement(),
+        )
+
+
+def test_revocation_record_is_immutable_and_idempotent(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        measurement=_measurement(),
+    )
+    arguments = {
+        "status": "quarantined",
+        "reason": "quality failure",
+        "detected_at": "2026-07-29T12:00:00Z",
+        "detection_run_url": "https://github.example/runs/detection",
+        "actor": "baseline-owner",
+        "workflow_url": "https://github.example/runs/revocation",
+        "publication_commit": "9" * 40,
+    }
+
+    first = perfgate_baselines.record_revocation(central, _identity(), **arguments)
+    second = perfgate_baselines.record_revocation(central, _identity(), **arguments)
+    assert first == second
+
+    with pytest.raises(ValueError, match="different content"):
+        perfgate_baselines.record_revocation(
+            central, _identity(), **dict(arguments, actor="different-actor")
+        )
+
+    withdrawn = perfgate_baselines.record_revocation(
+        central,
+        _identity(),
+        **dict(
+            arguments,
+            status="withdrawn",
+            reason="formal withdrawal completed",
+            workflow_url="https://github.example/runs/withdrawal",
+        ),
+    )
+    assert withdrawn != first
+    with pytest.raises(ValueError, match="exact central baseline is withdrawn"):
+        perfgate_baselines.load_manifest(central, _identity())
+    with pytest.raises(ValueError, match="after it has been withdrawn"):
+        perfgate_baselines.record_revocation(
+            central,
+            _identity(),
+            **dict(
+                arguments,
+                status="quarantined",
+                reason="late quarantine must be rejected",
+            ),
+        )
+
+
+def test_revoke_cli_writes_a_consumer_blocking_record(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        measurement=_measurement(),
+    )
+
+    result = perfgate_baselines.main(
+        [
+            "revoke",
+            "--repository-root",
+            str(central),
+            "--status",
+            "quarantined",
+            "--reason",
+            "quality failure",
+            "--detected-at",
+            "2026-07-29T12:00:00Z",
+            "--detection-run-url",
+            "https://github.example/runs/detection",
+            "--actor",
+            "baseline-owner",
+            "--workflow-url",
+            "https://github.example/runs/revocation",
+            "--publication-commit",
+            "9" * 40,
+            "--target-repository",
+            _identity().target_repository,
+            "--target-sha",
+            _identity().target_sha,
+            "--scenario",
+            _identity().scenario,
+            "--spec-id",
+            _identity().spec_id,
+            "--spec-hash",
+            _identity().spec_hash,
+        ]
+    )
+
+    assert result == 0
+    with pytest.raises(ValueError, match="exact central baseline is quarantined"):
+        perfgate_baselines.load_manifest(central, _identity())
+
+
+def test_revocation_verifies_publication_commit_in_git_checkout(
+    tmp_path: Path,
+) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    _git("init", "-b", "benchmark-baselines", cwd=central)
+    _git("config", "user.name", "Test User", cwd=central)
+    _git("config", "user.email", "test@example.com", cwd=central)
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    perfgate_baselines.store_baseline(
+        central,
+        artifact,
+        _identity(),
+        _provenance(),
+        measurement=_measurement(),
+    )
+    _git("add", "baselines", cwd=central)
+    _git("commit", "-m", "publish baseline", cwd=central)
+    publication_commit = _git("rev-parse", "HEAD", cwd=central)
+    arguments = {
+        "status": "quarantined",
+        "reason": "quality failure",
+        "detected_at": "2026-07-29T12:00:00Z",
+        "detection_run_url": "https://github.example/runs/detection",
+        "actor": "baseline-owner",
+        "workflow_url": "https://github.example/runs/revocation",
+    }
+
+    with pytest.raises(ValueError, match="publication_commit does not match"):
+        perfgate_baselines.record_revocation(
+            central,
+            _identity(),
+            publication_commit="8" * 40,
+            **arguments,
+        )
+    perfgate_baselines.record_revocation(
+        central,
+        _identity(),
+        publication_commit=publication_commit,
+        **arguments,
+    )
+
+
 def test_store_rejects_spec_and_companion_mismatch(tmp_path: Path) -> None:
     central = tmp_path / "central"
     central.mkdir()
@@ -353,6 +711,11 @@ def test_store_cli_requires_target_sha_on_main(tmp_path: Path) -> None:
     _write_artifact(artifact, identity=identity)
     central = tmp_path / "central"
     central.mkdir()
+    measurement = tmp_path / "measurement.json"
+    measurement.write_text(
+        json.dumps(_measurement(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
     common = [
         "store",
@@ -360,6 +723,8 @@ def test_store_cli_requires_target_sha_on_main(tmp_path: Path) -> None:
         str(central),
         "--source",
         str(artifact),
+        "--measurement-file",
+        str(measurement),
         "--target-git-repository",
         str(target),
         "--main-ref",
@@ -519,6 +884,7 @@ def test_publish_bootstraps_updates_and_is_idempotent(tmp_path: Path) -> None:
         identity,
         provenance,
         update_latest_pointer=True,
+        measurement=_measurement(),
     )
     second = perfgate_baselines.publish_baseline(
         str(remote),
@@ -529,6 +895,7 @@ def test_publish_bootstraps_updates_and_is_idempotent(tmp_path: Path) -> None:
         identity,
         provenance,
         update_latest_pointer=True,
+        measurement=_measurement(),
     )
 
     assert first.startswith("published:")
@@ -536,6 +903,26 @@ def test_publish_bootstraps_updates_and_is_idempotent(tmp_path: Path) -> None:
     assert _git(
         "ls-remote", "--heads", str(remote), "benchmark-baselines", cwd=tmp_path
     )
+
+
+def test_publish_requires_measurement_metadata(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target_sha = _commit_target_main(target)
+    identity = _identity(target_sha=target_sha)
+    provenance = _provenance(vllm_hust_sha=target_sha)
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact, identity=identity)
+
+    with pytest.raises(ValueError, match="measurement metadata is required"):
+        perfgate_baselines.publish_baseline(
+            "unused-remote",
+            "benchmark-baselines",
+            artifact,
+            target,
+            "main",
+            identity,
+            provenance,
+        )
 
 
 def test_publish_retries_non_fast_forward_push(
@@ -587,6 +974,7 @@ def test_publish_retries_non_fast_forward_push(
         identity,
         provenance,
         max_attempts=2,
+        measurement=_measurement(),
     )
 
     assert failed_once is True

--- a/tests/test_perfgate_measurement.py
+++ b/tests/test_perfgate_measurement.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_hust_benchmark import perfgate_measurement
+
+
+def _per_run_entry(
+    run_index: int,
+    *,
+    throughput: float = 100.0,
+    ttft: float = 50.0,
+    tbt: float = 10.0,
+    error_rate: float = 0.0,
+    peak_mem: float | None = None,
+) -> dict:
+    return {
+        "run_index": run_index,
+        "raw_result_sha256": hashlib.sha256(str(run_index).encode()).hexdigest(),
+        "metrics": {
+            "throughput_tps": throughput,
+            "ttft_ms": ttft,
+            "tbt_ms": tbt,
+            "error_rate": error_rate,
+            "peak_mem_mb": peak_mem,
+        },
+    }
+
+
+def _three_runs() -> list[dict]:
+    return [
+        _per_run_entry(1, throughput=90.0, ttft=55.0, tbt=12.0),
+        _per_run_entry(2, throughput=110.0, ttft=45.0, tbt=9.0),
+        _per_run_entry(3, throughput=100.0, ttft=50.0, tbt=10.0),
+    ]
+
+
+def _warmup_runs(count: int = 1) -> list[dict]:
+    return [
+        {
+            "run_index": index,
+            "raw_result_sha256": hashlib.sha256(f"warmup-{index}".encode()).hexdigest(),
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+def test_median_is_computed_per_metric_independently() -> None:
+    aggregated, measurement = perfgate_measurement.aggregate_measured_runs(
+        _three_runs(), warmup_runs=1, warmup=_warmup_runs()
+    )
+    assert aggregated == {
+        "throughput_tps": 100.0,
+        "ttft_ms": 50.0,
+        "tbt_ms": 10.0,
+        "error_rate": 0.0,
+    }
+    assert measurement["strategy"] == "warmup+median"
+    assert measurement["warmup_runs"] == 1
+    assert measurement["measured_runs"] == 3
+    assert measurement["aggregation"] == "median"
+    assert [entry["run_index"] for entry in measurement["warmup"]] == [1]
+    assert [entry["run_index"] for entry in measurement["per_run"]] == [1, 2, 3]
+
+
+def test_single_measured_run_median_is_identity() -> None:
+    aggregated, measurement = perfgate_measurement.aggregate_measured_runs(
+        [_per_run_entry(1)], warmup_runs=0
+    )
+    assert aggregated["throughput_tps"] == 100.0
+    assert measurement["measured_runs"] == 1
+
+
+def test_rejects_non_zero_error_rate() -> None:
+    runs = _three_runs()
+    runs[1]["metrics"]["error_rate"] = 0.25
+    with pytest.raises(ValueError, match="non-zero error_rate"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+def test_rejects_non_finite_metric() -> None:
+    runs = _three_runs()
+    runs[0]["metrics"]["ttft_ms"] = float("nan")
+    with pytest.raises(ValueError, match="ttft_ms"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+def test_peak_memory_is_nullable_but_validated_when_present() -> None:
+    runs = _three_runs()
+    runs[0]["metrics"]["peak_mem_mb"] = None
+    runs[1]["metrics"]["peak_mem_mb"] = 2048
+    perfgate_measurement.aggregate_measured_runs(
+        runs, warmup_runs=1, warmup=_warmup_runs()
+    )
+
+    runs[1]["metrics"]["peak_mem_mb"] = float("nan")
+    with pytest.raises(ValueError, match="peak_mem_mb"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+def test_rejects_run_index_mismatch() -> None:
+    runs = _three_runs()
+    runs[2]["run_index"] = 5
+    with pytest.raises(ValueError, match="run_index mismatch"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+def test_rejects_missing_raw_result_sha256() -> None:
+    runs = _three_runs()
+    runs[0]["raw_result_sha256"] = ""
+    with pytest.raises(ValueError, match="raw_result_sha256"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+def test_rejects_malformed_raw_result_sha256() -> None:
+    runs = _three_runs()
+    runs[0]["raw_result_sha256"] = "not-a-digest"
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        perfgate_measurement.aggregate_measured_runs(
+            runs, warmup_runs=1, warmup=_warmup_runs()
+        )
+
+
+@pytest.mark.parametrize("warmup_runs", [True, "1", 1.5])
+def test_rejects_non_integer_warmup_runs(warmup_runs: object) -> None:
+    with pytest.raises(ValueError, match="warmup_runs must be an integer"):
+        perfgate_measurement.aggregate_measured_runs(
+            _three_runs(),
+            warmup_runs=warmup_runs,  # type: ignore[arg-type]
+        )
+
+
+def test_rejects_empty_run_list_and_bad_aggregation() -> None:
+    with pytest.raises(ValueError, match="at least one measured run"):
+        perfgate_measurement.aggregate_measured_runs(
+            [], warmup_runs=1, warmup=_warmup_runs()
+        )
+    with pytest.raises(ValueError, match="unsupported aggregation"):
+        perfgate_measurement.aggregate_measured_runs(
+            _three_runs(), warmup_runs=1, aggregation="mean"
+        )
+    with pytest.raises(ValueError, match="warmup_runs"):
+        perfgate_measurement.aggregate_measured_runs(_three_runs(), warmup_runs=-1)
+
+
+def test_rejects_missing_or_malformed_warmup_evidence() -> None:
+    with pytest.raises(ValueError, match="warmup evidence"):
+        perfgate_measurement.aggregate_measured_runs(_three_runs(), warmup_runs=1)
+
+    warmup = _warmup_runs()
+    warmup[0]["raw_result_sha256"] = "invalid"
+    with pytest.raises(ValueError, match="warmup run 1.*raw_result_sha256"):
+        perfgate_measurement.aggregate_measured_runs(
+            _three_runs(), warmup_runs=1, warmup=warmup
+        )
+
+
+def test_validate_measurement_block_shape_and_cross_check() -> None:
+    _, measurement = perfgate_measurement.aggregate_measured_runs(
+        _three_runs(), warmup_runs=1, warmup=_warmup_runs()
+    )
+    perfgate_measurement.validate_measurement_block(
+        measurement,
+        artifact_metrics={
+            "throughput_tps": 100.0,
+            "ttft_ms": 50.0,
+            "tbt_ms": 10.0,
+            "error_rate": 0.0,
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not match median"):
+        perfgate_measurement.validate_measurement_block(
+            measurement,
+            artifact_metrics={
+                "throughput_tps": 101.0,
+                "ttft_ms": 50.0,
+                "tbt_ms": 10.0,
+                "error_rate": 0.0,
+            },
+        )
+
+    broken = dict(measurement, measured_runs=2)
+    with pytest.raises(ValueError, match="per_run"):
+        perfgate_measurement.validate_measurement_block(broken)
+
+    with pytest.raises(ValueError, match="strategy"):
+        perfgate_measurement.validate_measurement_block(
+            dict(measurement, strategy="single")
+        )
+
+    with pytest.raises(ValueError, match="must be an object"):
+        perfgate_measurement.validate_measurement_block("not-a-dict")
+
+
+def test_publication_policy_rejects_single_cold_measurement() -> None:
+    _, measurement = perfgate_measurement.aggregate_measured_runs(
+        [_per_run_entry(1)], warmup_runs=0
+    )
+    with pytest.raises(ValueError, match="publication requires at least"):
+        perfgate_measurement.validate_measurement_block(
+            measurement,
+            artifact_metrics=measurement["per_run"][0]["metrics"],
+            require_publication_policy=True,
+        )
+
+
+def test_apply_median_metrics_preserves_template_except_median_metrics(
+    tmp_path: Path,
+) -> None:
+    template = tmp_path / "run_leaderboard.json"
+    template.write_text(
+        json.dumps(
+            {
+                "metrics": {
+                    "throughput_tps": 90.0,
+                    "ttft_ms": 55.0,
+                    "tbt_ms": 12.0,
+                    "error_rate": 0.0,
+                    "peak_mem_mb": 2048,
+                },
+                "same_spec": {"spec_id": "spec", "resolved_spec_hash": "abc"},
+                "metadata": {"git_commit": "1" * 40},
+            }
+        ),
+        encoding="utf-8",
+    )
+    aggregated, _ = perfgate_measurement.aggregate_measured_runs(
+        _three_runs(), warmup_runs=1, warmup=_warmup_runs()
+    )
+    output = tmp_path / "aggregated.json"
+    payload = perfgate_measurement.apply_median_metrics(template, aggregated, output)
+
+    written = json.loads(output.read_text(encoding="utf-8"))
+    assert written == payload
+    assert written["metrics"]["throughput_tps"] == 100.0
+    assert written["metrics"]["ttft_ms"] == 50.0
+    assert written["metrics"]["tbt_ms"] == 10.0
+    assert written["metrics"]["error_rate"] == 0.0
+    # Server-lifetime and identity fields keep the template values.
+    assert written["metrics"]["peak_mem_mb"] == 2048
+    assert written["same_spec"] == {"spec_id": "spec", "resolved_spec_hash": "abc"}
+    assert written["metadata"] == {"git_commit": "1" * 40}
+
+
+def test_run_metrics_from_raw_result_derives_and_validates(tmp_path: Path) -> None:
+    raw = tmp_path / "raw_benchmark_result.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "completed": 8,
+                "failed": 0,
+                "mean_ttft_ms": 51.5,
+                "mean_tpot_ms": 10.5,
+                "output_throughput": 99.5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics = perfgate_measurement.run_metrics_from_raw_result(raw)
+    assert metrics["throughput_tps"] == 99.5
+    assert metrics["ttft_ms"] == 51.5
+    assert metrics["tbt_ms"] == 10.5
+    assert metrics["error_rate"] == 0.0
+
+    failing = tmp_path / "failing.json"
+    failing.write_text(
+        json.dumps(
+            {
+                "completed": 7,
+                "failed": 1,
+                "mean_ttft_ms": 51.5,
+                "mean_tpot_ms": 10.5,
+                "output_throughput": 99.5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-zero error_rate"):
+        perfgate_measurement.run_metrics_from_raw_result(failing)
+
+
+def test_aggregate_cli_records_warmup_checksum_for_one_measured_run(
+    tmp_path: Path,
+) -> None:
+    raw_payload = {
+        "completed": 8,
+        "failed": 0,
+        "mean_ttft_ms": 50.0,
+        "mean_tpot_ms": 10.0,
+        "output_throughput": 100.0,
+    }
+    warmup = tmp_path / "warmup.json"
+    measured = tmp_path / "measured.json"
+    for path in (warmup, measured):
+        path.write_text(json.dumps(raw_payload), encoding="utf-8")
+    template = tmp_path / "template.json"
+    template.write_text(
+        json.dumps(
+            {
+                "metrics": {
+                    "throughput_tps": 100.0,
+                    "ttft_ms": 50.0,
+                    "tbt_ms": 10.0,
+                    "error_rate": 0.0,
+                    "peak_mem_mb": None,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "run_leaderboard.json"
+    measurement_out = tmp_path / "measurement.json"
+
+    result = perfgate_measurement.run_aggregate_runs_cli(
+        argparse.Namespace(
+            warmup_raw_results=[str(warmup)],
+            run_raw_results=[str(measured)],
+            warmup_runs=1,
+            aggregation="median",
+            template=str(template),
+            output=str(output),
+            measurement_out=str(measurement_out),
+        )
+    )
+
+    assert result == 0
+    measurement = json.loads(measurement_out.read_text(encoding="utf-8"))
+    assert measurement["warmup_runs"] == 1
+    assert measurement["measured_runs"] == 1
+    assert (
+        measurement["warmup"][0]["raw_result_sha256"]
+        == hashlib.sha256(warmup.read_bytes()).hexdigest()
+    )


### PR DESCRIPTION
## Summary

  Harden the central Perfgate baseline quality lifecycle before the first trusted bootstrap.

  This PR:

  - adds repeated Perfgate measurement using one warmup run and per-metric median aggregation across measured runs;
  - records ordered warmup/measured raw-result SHA-256 checksums in `measurement.json`;
  - requires central publication measurements to contain at least 1 warmup and 3 measured runs;
  - verifies that published throughput, TTFT, and TBT match the recorded per-run medians;
  - preserves the historical single-run behavior for non-Perfgate callers;
  - adds immutable `quarantined` and `withdrawn` revocation records;
  - makes exact baseline fetch/validation fail closed for revoked baselines;
  - prevents republishing a revoked exact baseline key;
  - treats `withdrawn` as a terminal state;
  - documents the measurement and revocation protocols.

  The change prevents cold-start noise from being written into an immutable baseline and provides an auditable recovery path if a
  quality failure is detected after publication.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  Focused Perfgate tests:

  ```bash
  PYTHONPATH=src python3 -m pytest -q \
    tests/test_perfgate_measurement.py \
    tests/test_perfgate_baselines.py \
    tests/test_current_same_spec_script.py \
    tests/test_perfgate.py \
    tests/test_perfgate_specs.py

  Result: 98 passed.

  Full repository test run:

  PYTHONPATH=src python3 -m pytest -q

  Result: 450 passed, 30 failed.

  The 30 failures are confined to the existing official-baseline shell test groups on macOS. They depend on Linux facilities or Bash
  4 features such as mapfile; none cover files changed by this PR.

  Additional checks:

  python3 -m ruff check \
    src/vllm_hust_benchmark/perfgate_measurement.py \
    src/vllm_hust_benchmark/perfgate_baselines.py \
    src/vllm_hust_benchmark/cli.py \
    tests/test_perfgate_measurement.py \
    tests/test_perfgate_baselines.py \
    tests/test_current_same_spec_script.py

  bash -n scripts/run-current-ascend-same-spec.sh
  git diff --check

  All additional checks passed.

  ## Risks

  - No Ascend hardware producer run has been performed yet. The warmup/median flow still requires validation on the trusted self-
    hosted runner.

  - No real central benchmark-baselines publication or revocation has been executed yet.
  - Central store, publish, fetch, and validate now require publication-quality measurement metadata. Baselines without this metadata
    will fail closed. The central branch has not yet been bootstrapped, so no existing central baseline migration is expected.

  - The Core producer must pin the merge commit of this PR through VLLM_HUST_PERFGATE_BENCHMARK_RUNNER_SHA before Core PR #160 is
    merged.

  - Non-Perfgate callers retain the existing 0 warmup + 1 measured default unless they explicitly enable the repeated-run strategy.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.