### PR TITLE
fix(scripts): enforce_eager empty string bug prevents --enforce-eager from reaching vLLM server

### DIFF
--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -1114,7 +1114,7 @@ from vllm_hust_benchmark.official_runtime_inputs import normalize_server_paramet
 payload = json.loads(Path(os.environ["SAME_SPEC_FILE"]).read_text(encoding="utf-8"))
 normalized = normalize_server_parameters(payload["resolved_server_parameters"])
 if os.environ.get("OFFICIAL_FORCE_EAGER_SERVER") == "1":
-    normalized["enforce_eager"] = ""
+    normalized["enforce_eager"] = True
 print(
     json.dumps(
     normalized,

--- a/tests/test_prepare_official_env_script.py
+++ b/tests/test_prepare_official_env_script.py
@@ -1083,7 +1083,7 @@ def test_normalized_server_parameters_json_forces_eager_for_serve_when_requested
 
             server_json=$(normalized_server_parameters_json)
             printf '%s\n' "$server_json"
-            grep -Fq '"enforce_eager":""' <<< "$server_json"
+            grep -Fq '"enforce_eager":true' <<< "$server_json"
             """
         )
     )


### PR DESCRIPTION
normalized_server_parameters_json sets enforce_eager to "" when Ascend lacks weak_ref_tensor. json2args drops empty strings, so --enforce-eager never reaches vLLM server. Fix: use True instead of "".