### PR TITLE
fix: revert official eager fallback and fail closed

### DIFF
--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -1114,7 +1114,7 @@ from vllm_hust_benchmark.official_runtime_inputs import normalize_server_paramet
 payload = json.loads(Path(os.environ["SAME_SPEC_FILE"]).read_text(encoding="utf-8"))
 normalized = normalize_server_parameters(payload["resolved_server_parameters"])
 if os.environ.get("OFFICIAL_FORCE_EAGER_SERVER") == "1":
-    normalized["enforce_eager"] = True
+    normalized["enforce_eager"] = ""
 print(
     json.dumps(
     normalized,

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -817,7 +817,7 @@ run_client_command() {
     throughput|latency)
       prepare_offline_benchmark_runtime || return $?
 
-      run_offline_client_command_with_aclgraph_fallback
+      run_offline_client_command "$CLIENT_ARGS"
       ;;
     *)
       echo "Unsupported benchmark type for official baseline runner: $BENCHMARK_TYPE" >&2
@@ -833,53 +833,6 @@ run_offline_client_command() {
     python "$VLLM_CLI_COMPAT" bench "$BENCHMARK_TYPE" \
     --output-json "$RAW_RESULT_FILE" \
     $effective_client_args
-}
-
-append_enforce_eager_flag() {
-  local client_args=${1:-}
-
-  if [[ "$client_args" == *"--enforce-eager"* ]]; then
-    printf '%s\n' "$client_args"
-    return 0
-  fi
-
-  if [[ -n "$client_args" ]]; then
-    printf '%s --enforce-eager\n' "$client_args"
-  else
-    printf '%s\n' "--enforce-eager"
-  fi
-}
-
-run_offline_client_command_with_aclgraph_fallback() {
-  local failure_log=""
-  local runner_status=0
-  local eager_client_args=""
-
-  failure_log=$(mktemp "${TMPDIR:-/tmp}/official-baseline-offline-client-XXXXXX.log")
-  : > "$failure_log"
-
-  if run_offline_client_command "$CLIENT_ARGS" \
-    > >(tee -a "$failure_log") \
-    2> >(tee -a "$failure_log" >&2); then
-    rm -f "$failure_log"
-    return 0
-  fi
-  runner_status=$?
-
-  if ! grep -Fq "weak_ref_tensor" "$failure_log"; then
-    rm -f "$failure_log"
-    return "$runner_status"
-  fi
-
-  eager_client_args=$(append_enforce_eager_flag "$CLIENT_ARGS")
-  if [[ "$eager_client_args" == "$CLIENT_ARGS" ]]; then
-    rm -f "$failure_log"
-    return "$runner_status"
-  fi
-
-  echo "[goal-baseline] observed weak_ref_tensor failure during ${BENCHMARK_TYPE} benchmark; retrying with --enforce-eager" >&2
-  rm -f "$failure_log"
-  run_offline_client_command "$eager_client_args"
 }
 
 prepare_offline_benchmark_runtime() {
@@ -1095,15 +1048,8 @@ ensure_runtime_dataset_available() {
 }
 
 normalized_server_parameters_json() {
-  local force_eager_server=0
-
-  if should_force_eager_for_server_benchmark; then
-    force_eager_server=1
-  fi
-
   PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
     SAME_SPEC_FILE="$SAME_SPEC_FILE" \
-    OFFICIAL_FORCE_EAGER_SERVER="$force_eager_server" \
     "$HOST_PYTHON_BIN" - <<'PY'
 import json
 import os
@@ -1113,8 +1059,6 @@ from vllm_hust_benchmark.official_runtime_inputs import normalize_server_paramet
 
 payload = json.loads(Path(os.environ["SAME_SPEC_FILE"]).read_text(encoding="utf-8"))
 normalized = normalize_server_parameters(payload["resolved_server_parameters"])
-if os.environ.get("OFFICIAL_FORCE_EAGER_SERVER") == "1":
-    normalized["enforce_eager"] = ""
 print(
     json.dumps(
     normalized,
@@ -1126,12 +1070,6 @@ PY
 }
 
 normalized_client_parameters_json() {
-  local force_eager_offline=0
-
-  if should_force_eager_for_offline_benchmark; then
-    force_eager_offline=1
-  fi
-
   PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" \
     SAME_SPEC_FILE="$SAME_SPEC_FILE" \
     BENCHMARK_TYPE="$BENCHMARK_TYPE" \
@@ -1139,7 +1077,6 @@ normalized_client_parameters_json() {
     OFFICIAL_VLLM_WORKTREE="$OFFICIAL_VLLM_WORKTREE" \
     BENCHMARK_REPO="$REPO_ROOT" \
     OFFICIAL_BENCHMARK_DATASET_ROOT="$OFFICIAL_BENCHMARK_DATASET_ROOT" \
-    OFFICIAL_FORCE_EAGER_OFFLINE="$force_eager_offline" \
     "$HOST_PYTHON_BIN" - <<'PY'
 import json
 import os
@@ -1158,7 +1095,6 @@ print(
             vllm_worktree=os.environ.get("OFFICIAL_VLLM_WORKTREE"),
             benchmark_repo=os.environ.get("BENCHMARK_REPO"),
             dataset_cache_root=os.environ.get("OFFICIAL_BENCHMARK_DATASET_ROOT"),
-            force_eager=os.environ.get("OFFICIAL_FORCE_EAGER_OFFLINE") == "1",
         ),
         separators=(",", ":"),
         ensure_ascii=True,
@@ -1426,85 +1362,6 @@ PY
   fi
 
   printf '%s' "unknown"
-}
-
-official_runtime_supports_aclgraph_weak_ref_tensor() {
-  local probe_status=0
-
-  set +e
-  run_in_official_runtime_python "$OFFICIAL_RUNTIME_PYTHONPATH" <<'PY' >/dev/null 2>&1
-import torch
-
-has_namespace = hasattr(torch.ops, "_C_ascend")
-has_weak_ref = has_namespace and hasattr(torch.ops._C_ascend, "weak_ref_tensor")
-
-raise SystemExit(0 if has_weak_ref else 3)
-PY
-  probe_status=$?
-  set -e
-
-  if [[ "$probe_status" -eq 0 ]]; then
-    return 0
-  fi
-
-  if [[ "$probe_status" -eq 3 ]]; then
-    return 1
-  fi
-
-  echo "[goal-baseline] failed to probe official ACL graph weak_ref_tensor support (status=${probe_status}); leaving graph mode unchanged" >&2
-  return 2
-}
-
-should_force_eager_for_offline_benchmark() {
-  local probe_status=0
-
-  case "${BENCHMARK_TYPE:-}" in
-    throughput|latency)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  official_runtime_supports_aclgraph_weak_ref_tensor
-  probe_status=$?
-
-  if [[ "$probe_status" -eq 0 ]]; then
-    return 1
-  fi
-
-  if [[ "$probe_status" -eq 1 ]]; then
-    echo "[goal-baseline] official runtime lacks torch.ops._C_ascend.weak_ref_tensor; forcing --enforce-eager for ${BENCHMARK_TYPE} benchmark" >&2
-    return 0
-  fi
-
-  return 1
-}
-
-should_force_eager_for_server_benchmark() {
-  local probe_status=0
-
-  case "${BENCHMARK_TYPE:-}" in
-    serve)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  official_runtime_supports_aclgraph_weak_ref_tensor
-  probe_status=$?
-
-  if [[ "$probe_status" -eq 0 ]]; then
-    return 1
-  fi
-
-  if [[ "$probe_status" -eq 1 ]]; then
-    echo "[goal-baseline] official runtime lacks torch.ops._C_ascend.weak_ref_tensor; forcing --enforce-eager for serve benchmark server" >&2
-    return 0
-  fi
-
-  return 1
 }
 
 server_log_indicates_resource_busy() {

--- a/tests/test_prepare_official_env_script.py
+++ b/tests/test_prepare_official_env_script.py
@@ -1083,7 +1083,7 @@ def test_normalized_server_parameters_json_forces_eager_for_serve_when_requested
 
             server_json=$(normalized_server_parameters_json)
             printf '%s\n' "$server_json"
-            grep -Fq '"enforce_eager":true' <<< "$server_json"
+            grep -Fq '"enforce_eager":""' <<< "$server_json"
             """
         )
     )

--- a/tests/test_prepare_official_env_script.py
+++ b/tests/test_prepare_official_env_script.py
@@ -510,13 +510,10 @@ def test_run_client_command_prepares_single_card_runtime_for_offline_benchmarks(
     ]
 
 
-def test_run_client_command_retries_with_enforce_eager_on_weak_ref_failure(
+def test_run_client_command_fails_closed_on_weak_ref_failure(
     tmp_path: Path,
 ) -> None:
     first_args = tmp_path / "offline-first-args.txt"
-    retry_args = tmp_path / "offline-retry-args.txt"
-    first_attempt = tmp_path / "offline-first-attempt.txt"
-
     result = _run_bash(
         _source_run_client_functions(
             f"""
@@ -542,27 +539,22 @@ def test_run_client_command_retries_with_enforce_eager_on_weak_ref_failure(
             run_in_official_runtime() {{
                 local pythonpath_prefix=$1
                 shift
-                if [[ ! -f {shlex.quote(str(first_attempt))} ]]; then
-                    printf '%s\n' "$@" > {shlex.quote(str(first_args))}
-                    printf '1\n' > {shlex.quote(str(first_attempt))}
-                    cat <<'EOF' >&2
+                printf '%s\n' "$@" > {shlex.quote(str(first_args))}
+                cat <<'EOF' >&2
 AttributeError: '_OpNamespace' '_C_ascend' object has no attribute 'weak_ref_tensor'
 EOF
-                    return 1
-                fi
-
-                printf '%s\n' "$@" > {shlex.quote(str(retry_args))}
+                return 1
             }}
 
             run_client_command
             """
-        )
+        ),
+        check=False,
     )
 
-    assert result.returncode == 0
+    assert result.returncode != 0
     assert "--enforce-eager" not in first_args.read_text(encoding="utf-8").splitlines()
-    assert "--enforce-eager" in retry_args.read_text(encoding="utf-8").splitlines()
-    assert "retrying with --enforce-eager" in result.stderr
+    assert "weak_ref_tensor" in result.stderr
 
 
 def test_configure_single_card_ascend_device_derives_from_generic_visible_devices() -> (
@@ -984,88 +976,13 @@ EOF
     assert result.returncode == 0
 
 
-def test_should_force_eager_for_offline_benchmark_when_aclgraph_weak_ref_is_missing() -> (
-    None
-):
-    result = _run_bash(
-        _source_run_official_version_functions(
-            """
-            BENCHMARK_TYPE=throughput
-
-            official_runtime_supports_aclgraph_weak_ref_tensor() {
-                return 1
-            }
-
-            should_force_eager_for_offline_benchmark
-            status=$?
-            printf 'status=%s\n' "$status"
-            [[ "$status" == '0' ]]
-            """
-        ),
-        check=False,
-    )
-
-    assert result.returncode == 0
-    combined_output = result.stdout + result.stderr
-    assert "forcing --enforce-eager" in combined_output
-
-
-def test_official_runtime_supports_aclgraph_weak_ref_tensor_preserves_probe_status() -> (
-    None
-):
-    result = _run_bash(
-        _source_run_official_version_functions(
-            """
-            run_in_official_runtime_python() {
-                return 3
-            }
-
-            if official_runtime_supports_aclgraph_weak_ref_tensor; then
-                echo 'status=unexpected-success'
-            else
-                echo "status=$?"
-            fi
-            """
-        ),
-        check=False,
-    )
-
-    assert result.returncode == 0
-    assert result.stdout.splitlines() == ["status=1"]
-
-
-def test_should_force_eager_for_server_benchmark_when_aclgraph_weak_ref_is_missing() -> (
-    None
-):
-    result = _run_bash(
-        _source_run_official_version_functions(
-            """
-            BENCHMARK_TYPE=serve
-
-            official_runtime_supports_aclgraph_weak_ref_tensor() {
-                return 1
-            }
-
-            should_force_eager_for_server_benchmark
-            status=$?
-            printf 'status=%s\n' "$status"
-            [[ "$status" == '0' ]]
-            """
-        ),
-        check=False,
-    )
-
-    assert result.returncode == 0
-    combined_output = result.stdout + result.stderr
-    assert "forcing --enforce-eager" in combined_output
-
-
-def test_normalized_server_parameters_json_forces_eager_for_serve_when_requested(
+def test_normalized_server_parameters_json_preserves_graph_mode(
     tmp_path: Path,
 ) -> None:
     same_spec_file = tmp_path / "resolved_same_spec.json"
     same_spec_file.write_text(
-        '{"resolved_server_parameters":{"model":"foo/bar","port":8000}}',
+        '{"resolved_server_parameters":{"model":"foo/bar","port":8000,'
+        '"enforce_eager":""}}',
         encoding="utf-8",
     )
 
@@ -1076,10 +993,6 @@ def test_normalized_server_parameters_json_forces_eager_for_serve_when_requested
             HOST_PYTHON_BIN={shlex.quote(sys.executable)}
             BENCHMARK_TYPE=serve
             SAME_SPEC_FILE={shlex.quote(str(same_spec_file))}
-
-            official_runtime_supports_aclgraph_weak_ref_tensor() {{
-                return 1
-            }}
 
             server_json=$(normalized_server_parameters_json)
             printf '%s\n' "$server_json"


### PR DESCRIPTION
## Summary

- Revert #113 so the official Ascend runner no longer turns the server-side eager override into an effective `--enforce-eager`.
- Remove the older automatic eager fallbacks for serve, throughput, and latency runs.
- Fail the official run when ACL graph execution is unavailable instead of silently producing an incomparable eager-mode result.

## Why this is urgent

The public fixed-target contract requires graph mode. Eager-mode measurements must not enter official baseline, backfill, or leaderboard artifacts. #113 made a previously ineffective fallback effective, while an older retry path could already rerun offline workloads with `--enforce-eager`.

## Validation

- `PYTHONPATH=. pytest -q tests/test_prepare_official_env_script.py` — 26 passed
- `ruff check tests/test_prepare_official_env_script.py`
- `ruff format --check tests/test_prepare_official_env_script.py`
- `bash -n scripts/run-official-ascend-goal-baseline.sh`
- `git diff --check`

This PR addresses the eager-fallback safety violation only. The remaining #103 acceptance criteria are tracked separately.
