### PR TITLE
fix: align VisionArena with the official fixed target

### DIFF
--- a/docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json
@@ -21,7 +21,7 @@
   "server_parameters": {
     "tensor_parallel_size": 1,
     "gpu_memory_utilization": 0.6,
-    "max_model_len": 30720,
+    "max_model_len": 32768,
     "enforce_eager": "",
     "trust_remote_code": "",
     "disable_log_stats": "",

--- a/scripts/backfill_single_gpu.md
+++ b/scripts/backfill_single_gpu.md
@@ -173,7 +173,7 @@ python3 scripts/backfill_single_gpu.py restore
 | ---------------------------------- | -------------------------------------------- | ---------------------------------------- |
 | `BACKFILL_PYTHON`                  | `~/miniconda3/envs/vllm-hust-dev/bin/python` | Python 解释器路径                        |
 | `SAME_SPEC_GPU_MEMORY_UTILIZATION` | `0.6`                                        | same-spec hash 的 gpu_memory_utilization |
-| `SAME_SPEC_MAX_MODEL_LEN`          | `30720`                                      | same-spec hash 的 max_model_len          |
+| `SAME_SPEC_MAX_MODEL_LEN`          | `32768`                                      | same-spec hash 的 max_model_len          |
 | `HF_ENDPOINT`                      | `https://hf-mirror.com`                      | HuggingFace 镜像                         |
 | `VLLM_USE_V1`                      | `1`                                          | 启用 V1 引擎                             |
 

--- a/src/vllm_hust_benchmark/workload_config_contract.py
+++ b/src/vllm_hust_benchmark/workload_config_contract.py
@@ -72,6 +72,9 @@ OFFICIAL_SINGLE_CHIP_TEXT_DEFAULTS: dict[str, dict[str, Any]] = {
     "sonnet-throughput": {
         "server": {"gpu_memory_utilization": 0.6, "max_model_len": 32768},
     },
+    "visionarena-online": {
+        "server": {"gpu_memory_utilization": 0.6, "max_model_len": 32768},
+    },
 }
 
 

--- a/tests/test_workload_config_contract.py
+++ b/tests/test_workload_config_contract.py
@@ -166,6 +166,20 @@ def test_official_single_chip_specs_define_required_effective_defaults() -> None
             assert key in spec["client_parameters"], f"{scenario}: missing client {key}"
 
 
+def test_visionarena_official_target_uses_public_defaults() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    spec_path = (
+        repo_root
+        / "docs"
+        / "official-baselines"
+        / "official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json"
+    )
+    payload = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    assert payload["server_parameters"]["gpu_memory_utilization"] == 0.6
+    assert payload["server_parameters"]["max_model_len"] == 32768
+
+
 def test_snapshot_entries_never_conflate_num_prompts_with_concurrency() -> None:
     """PR#70 regression: snapshot entries must keep prompt count and concurrency apart.
 


### PR DESCRIPTION
## Summary

- Change the official single-chip VisionArena target from the retired `max_model_len=30720` value to `32768`.
- Align the manual backfill documentation with the fixed public target.
- Make the workload contract enforce `gpu_memory_utilization=0.6` and `max_model_len=32768` for VisionArena.
- Add a regression test over the checked-in official spec.

## Why

The official VisionArena spec still requested `30720`, while the public snapshot validator already rejects `30720` and directs contributors to rerun with `32768`. A run launched from the checked-in official spec could therefore fail its own publication gate.

This change updates the contract only. It does not rewrite, relabel, or fabricate historical measurements; affected records still require quarantine or a real rerun under #105.

## Validation

- `PYTHONPATH=.:src pytest -q tests/test_workload_config_contract.py tests/test_validate_public_leaderboard_snapshots.py` — 14 passed
- `ruff check src/vllm_hust_benchmark/workload_config_contract.py tests/test_workload_config_contract.py`
- `ruff format --check src/vllm_hust_benchmark/workload_config_contract.py tests/test_workload_config_contract.py`
- `git diff --check`

The standalone public snapshot validator continues to report the already-tracked historical `0.9`/`30720` records covered by #105; this PR deliberately does not mutate those measurement artifacts.
