### PR TITLE
fix(publish): validate leaderboard before HF commit

### DIFF
--- a/.github/workflows/push-to-hf.yml
+++ b/.github/workflows/push-to-hf.yml
@@ -315,13 +315,6 @@ jobs:
             --execute \
             "${extra_args[@]}"
 
-      - name: Validate trend admission on aggregated snapshots (post-sync gate)
-        id: validate-trend-snapshots
-        if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}
-        run: |
-          PYTHONPATH=src python -m vllm_hust_benchmark.cli validate-trend \
-            --input leaderboard-data/snapshots/
-
       - name: Verify HF snapshots match GitHub canonical snapshots
         if: ${{ steps.sync-hf.conclusion == 'success' && github.event.inputs.dry_run != 'true' }}
         env:

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1212,6 +1212,40 @@ def validate_aggregated_leaderboard_outputs(
         )
 
 
+def validate_public_snapshot_trend_admission(data_dir: Path) -> None:
+    """Validate the entry snapshots before any publication commit is made.
+
+    The compare and timestamp files are aggregate metadata, not trend-entry
+    documents.  Only the single- and multi-chip entry snapshots belong in this
+    gate; passing the whole directory to ``validate-trend`` would incorrectly
+    reject those metadata files after the upload had already happened.
+    """
+    from vllm_hust_benchmark.trend_validator import (
+        load_json_entries,
+        validate_entries,
+    )
+
+    entries: list[dict[str, Any]] = []
+    for file_name in ("leaderboard_single.json", "leaderboard_multi.json"):
+        path = data_dir / file_name
+        try:
+            entries.extend(load_json_entries(path))
+        except (FileNotFoundError, OSError, ValueError) as exc:
+            raise ValueError(f"invalid public snapshot {path}: {exc}") from exc
+
+    report = validate_entries(entries)
+    for decision in report.decisions:
+        print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
+    for issue in report.issues:
+        print(
+            f"  {issue.severity.upper():5} {issue.code}: "
+            f"{issue.entry_id}: {issue.message}",
+            file=sys.stderr,
+        )
+    if not report.passed:
+        raise ValueError("public leaderboard trend admission failed")
+
+
 def upload_to_huggingface(
     *,
     data_dir: Path,
@@ -1288,6 +1322,12 @@ def _upload_existing_snapshots(
     ]
 
     if not _validate_snapshot_workload_contracts(aggregate_output_dir):
+        return 2
+
+    try:
+        validate_public_snapshot_trend_admission(aggregate_output_dir)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
         return 2
 
     operations: list[CommitOperationAdd] = []
@@ -2184,6 +2224,11 @@ def sync_submission_to_huggingface(
             print(str(exc), file=sys.stderr)
             return 2
         if not _validate_snapshot_workload_contracts(rebuilt_output_dir):
+            return 2
+        try:
+            validate_public_snapshot_trend_admission(rebuilt_output_dir)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
             return 2
 
         operations: list[CommitOperationAdd] = []

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1233,6 +1233,9 @@ def validate_public_snapshot_trend_admission(data_dir: Path) -> None:
         except (FileNotFoundError, OSError, ValueError) as exc:
             raise ValueError(f"invalid public snapshot {path}: {exc}") from exc
 
+    if not entries:
+        raise ValueError("public leaderboard snapshots contain no entries")
+
     report = validate_entries(entries)
     for decision in report.decisions:
         print(f"  {decision.status:12} {decision.entry_id}: {decision.reason}")
@@ -1264,6 +1267,7 @@ def upload_to_huggingface(
 
     try:
         validate_aggregated_leaderboard_outputs(data_dir)
+        validate_public_snapshot_trend_admission(data_dir)
         upload_leaderboard_to_hf(
             data_dir=data_dir,
             repo_id=repo_id,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -127,6 +127,23 @@ def test_snapshot_upload_guard_rejects_future_official_artifact_without_contract
     assert "metadata.workload_config_contract" in capsys.readouterr().err
 
 
+def test_public_snapshot_trend_gate_ignores_aggregate_metadata(tmp_path: Path) -> None:
+    (tmp_path / "leaderboard_single.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "leaderboard_compare.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "last_updated.json").write_text("{}", encoding="utf-8")
+
+    integration.validate_public_snapshot_trend_admission(tmp_path)
+
+
+def test_public_snapshot_trend_gate_rejects_invalid_entry(tmp_path: Path) -> None:
+    (tmp_path / "leaderboard_single.json").write_text("[{}]", encoding="utf-8")
+    (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="trend admission failed"):
+        integration.validate_public_snapshot_trend_admission(tmp_path)
+
+
 def test_resolve_repo_layout_defaults_to_repo_sibling_workspace(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_HUST_WORKSPACE_ROOT", raising=False)
     monkeypatch.delenv("VLLM_HUST_REPO", raising=False)
@@ -1083,7 +1100,10 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
             "leaderboard_compare.json",
             "last_updated.json",
         ):
-            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+            payload = (
+                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
+            )
+            (output_dir / file_name).write_text(payload, encoding="utf-8")
         return 0
 
     class FakeCommitOperationAdd:
@@ -1286,7 +1306,10 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
             "leaderboard_compare.json",
             "last_updated.json",
         ):
-            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+            payload = (
+                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
+            )
+            (output_dir / file_name).write_text(payload, encoding="utf-8")
         return 0
 
     class FakeCommitOperationAdd:
@@ -1420,7 +1443,10 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
             "leaderboard_compare.json",
             "last_updated.json",
         ):
-            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+            payload = (
+                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
+            )
+            (output_dir / file_name).write_text(payload, encoding="utf-8")
         return 0
 
     class FakeCommitOperationAdd:
@@ -1734,7 +1760,10 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
             "leaderboard_compare.json",
             "last_updated.json",
         ):
-            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+            payload = (
+                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
+            )
+            (output_dir / file_name).write_text(payload, encoding="utf-8")
         return 0
 
     class FakeCommitOperationAdd:
@@ -1862,7 +1891,10 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
             "leaderboard_compare.json",
             "last_updated.json",
         ):
-            (output_dir / file_name).write_text("{}\n", encoding="utf-8")
+            payload = (
+                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
+            )
+            (output_dir / file_name).write_text(payload, encoding="utf-8")
         return 0
 
     class FakeCommitOperationAdd:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,36 @@ def _future_official_artifact() -> dict:
     }
 
 
+def _valid_public_trend_entry() -> dict:
+    return json.loads(
+        (
+            Path(__file__).parent
+            / "fixtures"
+            / "trend_coverage"
+            / "valid"
+            / "experimental.json"
+        ).read_text(encoding="utf-8")
+    )
+
+
+def _write_valid_aggregate_outputs(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    current_entry = _valid_public_trend_entry()
+    baseline_entry = _valid_public_trend_entry()
+    baseline_entry["entry_id"] = "44444444-4444-4444-8444-444444444444"
+    baseline_entry["engine"] = "vllm"
+    payloads = {
+        "leaderboard_single.json": [current_entry, baseline_entry],
+        "leaderboard_multi.json": [],
+        "leaderboard_compare.json": {},
+        "last_updated.json": {},
+    }
+    for file_name, payload in payloads.items():
+        (output_dir / file_name).write_text(
+            json.dumps(payload) + "\n", encoding="utf-8"
+        )
+
+
 def test_formal_submission_rejects_future_official_artifact_without_contract(
     tmp_path: Path,
     capsys,
@@ -128,12 +158,22 @@ def test_snapshot_upload_guard_rejects_future_official_artifact_without_contract
 
 
 def test_public_snapshot_trend_gate_ignores_aggregate_metadata(tmp_path: Path) -> None:
-    (tmp_path / "leaderboard_single.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "leaderboard_single.json").write_text(
+        json.dumps([_valid_public_trend_entry()]), encoding="utf-8"
+    )
     (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
     (tmp_path / "leaderboard_compare.json").write_text("{}", encoding="utf-8")
     (tmp_path / "last_updated.json").write_text("{}", encoding="utf-8")
 
     integration.validate_public_snapshot_trend_admission(tmp_path)
+
+
+def test_public_snapshot_trend_gate_rejects_empty_snapshots(tmp_path: Path) -> None:
+    (tmp_path / "leaderboard_single.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contain no entries"):
+        integration.validate_public_snapshot_trend_admission(tmp_path)
 
 
 def test_public_snapshot_trend_gate_rejects_invalid_entry(tmp_path: Path) -> None:
@@ -1093,17 +1133,7 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
         merged_markers["current"] = source_dir.joinpath(
             "submission-a", "run_leaderboard.json"
         ).exists()
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for file_name in (
-            "leaderboard_single.json",
-            "leaderboard_multi.json",
-            "leaderboard_compare.json",
-            "last_updated.json",
-        ):
-            payload = (
-                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
-            )
-            (output_dir / file_name).write_text(payload, encoding="utf-8")
+        _write_valid_aggregate_outputs(output_dir)
         return 0
 
     class FakeCommitOperationAdd:
@@ -1299,17 +1329,7 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
             (output_dir / "leaderboard_single.json").read_text(encoding="utf-8")
         )
         source_markers["seed_filtered"] = seeded_rows == [{"entry_id": "retained"}]
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for file_name in (
-            "leaderboard_single.json",
-            "leaderboard_multi.json",
-            "leaderboard_compare.json",
-            "last_updated.json",
-        ):
-            payload = (
-                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
-            )
-            (output_dir / file_name).write_text(payload, encoding="utf-8")
+        _write_valid_aggregate_outputs(output_dir)
         return 0
 
     class FakeCommitOperationAdd:
@@ -1436,17 +1456,7 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
         merged_markers["submission_b"] = source_dir.joinpath(
             "submission-b", "run_leaderboard.json"
         ).exists()
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for file_name in (
-            "leaderboard_single.json",
-            "leaderboard_multi.json",
-            "leaderboard_compare.json",
-            "last_updated.json",
-        ):
-            payload = (
-                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
-            )
-            (output_dir / file_name).write_text(payload, encoding="utf-8")
+        _write_valid_aggregate_outputs(output_dir)
         return 0
 
     class FakeCommitOperationAdd:
@@ -1753,17 +1763,7 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
             "declared_baseline_engine": current_accountable["declared_baseline_engine"],
             "baseline_status": current_accountable["baseline_status"],
         }
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for file_name in (
-            "leaderboard_single.json",
-            "leaderboard_multi.json",
-            "leaderboard_compare.json",
-            "last_updated.json",
-        ):
-            payload = (
-                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
-            )
-            (output_dir / file_name).write_text(payload, encoding="utf-8")
+        _write_valid_aggregate_outputs(output_dir)
         return 0
 
     class FakeCommitOperationAdd:
@@ -1884,17 +1884,7 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
             )
         )
         seen_model.update(historical["model"])
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for file_name in (
-            "leaderboard_single.json",
-            "leaderboard_multi.json",
-            "leaderboard_compare.json",
-            "last_updated.json",
-        ):
-            payload = (
-                "[]\n" if file_name.endswith(("single.json", "multi.json")) else "{}\n"
-            )
-            (output_dir / file_name).write_text(payload, encoding="utf-8")
+        _write_valid_aggregate_outputs(output_dir)
         return 0
 
     class FakeCommitOperationAdd:
@@ -2058,6 +2048,34 @@ def test_upload_to_huggingface_rejects_invalid_aggregated_snapshots(
         ),
         encoding="utf-8",
     )
+
+    called = {"upload": False}
+
+    def fake_upload_leaderboard_to_hf(**kwargs):
+        called["upload"] = True
+
+    monkeypatch.setattr(
+        "vllm_hust_benchmark.hf_publisher.upload_leaderboard_to_hf",
+        fake_upload_leaderboard_to_hf,
+    )
+
+    exit_code = upload_to_huggingface(
+        data_dir=data_dir,
+        repo_id="owner/repo",
+    )
+
+    assert exit_code == 2
+    assert called["upload"] is False
+
+
+def test_upload_to_huggingface_rejects_invalid_trend_entry_before_upload(
+    monkeypatch, tmp_path: Path
+) -> None:
+    data_dir = tmp_path / "aggregated"
+    data_dir.mkdir()
+    (data_dir / "leaderboard_single.json").write_text("[{}]", encoding="utf-8")
+    (data_dir / "leaderboard_multi.json").write_text("[]", encoding="utf-8")
+    (data_dir / "leaderboard_compare.json").write_text("{}", encoding="utf-8")
 
     called = {"upload": False}
 

--- a/tests/test_push_to_hf_workflow.py
+++ b/tests/test_push_to_hf_workflow.py
@@ -32,3 +32,15 @@ def test_submission_push_keeps_the_aggregation_path() -> None:
     assert "steps.resolve-submissions.outputs.count != '0'" in workflow_text
     assert 'if [[ "$SKIP_AGGREGATION" != "true" ]]; then' in workflow_text
     assert 'submission_args+=(--submission-dir "$submission_dir")' in workflow_text
+
+
+def test_workflow_does_not_use_post_upload_trend_gate() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "validate_public_snapshot_trend_admission" in (
+        REPO_ROOT / "src/vllm_hust_benchmark/integration.py"
+    ).read_text(encoding="utf-8")
+    assert "post-sync gate" not in workflow_text
+    assert workflow_text.index(
+        "Sync submissions into HF leaderboard snapshots"
+    ) < workflow_text.index("Verify HF snapshots match GitHub canonical snapshots")


### PR DESCRIPTION
## Summary

  Move public leaderboard trend validation before the Hugging Face commit.

  Previously, the workflow uploaded snapshots first and ran the trend gate afterward. If validation failed, the workflow could report
  failure while invalid data had already been published.

  This change:

  - validates `leaderboard_single.json` and `leaderboard_multi.json` before any HF commit;
  - keeps `leaderboard_compare.json`, `last_updated.json`, and audit reports out of trend-entry validation;
  - removes the redundant post-upload trend gate;
  - fails closed when snapshot validation fails.

  This is independent of benchmark PR #114 and the official graph-mode fix in #115.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - `PYTHONPATH=src python3 -m pytest -q tests/test_push_to_hf_workflow.py tests/test_integration.py tests/
  test_ci_cd_validation_gate.py`
    - 63 passed
  - `ruff check src/vllm_hust_benchmark/integration.py tests/test_integration.py tests/test_push_to_hf_workflow.py`
  - `ruff format --check src/vllm_hust_benchmark/integration.py tests/test_integration.py tests/test_push_to_hf_workflow.py`
  - `git diff --check`

  No hardware benchmark or live HF write was performed locally.

  ## Risks

  - This changes the publication gate ordering only; it does not change benchmark measurement or runtime execution.
  - Existing legacy entries may still produce admission warnings, but they do not block publication unless validation reports errors.
  - Remote CI should verify the workflow with the repository's normal Hugging Face credentials.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated the execution/audit documentation for this publication-gate change.
  - [x] I noted the tests I ran, or clearly stated what I could not run.