### PR TITLE
feat(backfill): PR#80 startup diagnose & failure-path hardening (#97)

### DIFF
--- a/docs/HISTORICAL_PR_BACKFILL.md
+++ b/docs/HISTORICAL_PR_BACKFILL.md
@@ -394,3 +394,70 @@ The canonical plugin commit is **earliest-submitted entry's plugin commit**, not
 or "the one embedded in `engine_version`". The earliest-submitted rule mirrors "what plugin was
 actually installed the first time this vllm-hust commit was benchmarked" — that is the ground truth,
 and later backfills should adapt to it, not the other way around.
+
+## Failure-Path Contract (Issue #97)
+
+When a managed dev-hub run fails to become healthy within
+`--managed-ready-timeout-seconds` (default 600s), the backfill orchestrator
+**must** retain a diagnostics bundle and release all resources before
+exiting. The contract has three parts:
+
+### BLOCKED.txt diagnostics bundle
+
+On failure, `capture_failure_diagnostics` writes a bundle to:
+
+```
+.benchmarks/historical-pr-backfill/blocked/<run_key>/
+├── BLOCKED.txt              # structured blocker report
+├── container.stdout.log     # vllm serve stdout/stderr (if available)
+├── npu-smi.txt              # NPU process state snapshot
+├── docker-ps.txt            # docker ps -a (if docker present)
+├── manage-status.txt        # manage.sh status output
+├── systemd-status.txt       # systemctl --user is-active <unit>
+├── port-probe.txt           # lsof -i :<port> (if port configured)
+├── vllm-processes.txt       # ps -ef | grep VLLMEngine|vllm.entrypoints
+├── state.json               # copy of the current state file
+└── cleanup.log              # defensive cleanup actions taken
+```
+
+The `BLOCKED.txt` file includes: `blocked_at`, `run_key`, `target_label`,
+`spec_path`, `core_ref`, `plugin_ref`, `pr_number`, `container`,
+`systemd_unit`, `npu_devices`, `server_port`, `blocker_reason`, and
+`next_steps` guidance.
+
+**The bundle lives under `.benchmarks/` (gitignored) and is NEVER uploaded
+to `submissions/`**. Failed runs must not produce half-finished or empty
+artifacts that could leak into the public leaderboard.
+
+The `state.json` entry for a failed run now carries a `blocked_dir` field
+pointing to the diagnostics bundle path, so operators can find the
+diagnostics from the state file.
+
+### Defensive cleanup sequence
+
+After `manage.sh stop`, the orchestrator runs `force_cleanup_managed_server`
+which executes a defense-in-depth cleanup (all with `check=False`):
+
+1. Kill processes on managed NPU devices (via `npu-smi info` + `os.kill`)
+2. Kill stale `VLLMEngineCore` / `vllm.entrypoints` processes (via `pgrep`)
+3. `systemctl --user stop <unit>` + `systemctl --user reset-failed <unit>`
+4. Free the managed port (via `lsof -ti :<port>` + `os.kill`)
+5. `docker rm -f <container>` (if docker is installed)
+
+After cleanup, `verify_cleanup_success` checks for residuals and logs
+warnings to stderr for any resources that could not be released.
+
+Use `--skip-defensive-cleanup` to skip this step when debugging (leaves
+residuals for manual inspection).
+
+### Pre-flight NPU idle check
+
+Before calling `manage.sh restart`, `verify_npu_idle` checks that the
+managed NPU devices have no running processes. If NPU0 (or any managed
+device) is occupied, the run fails fast with a `RuntimeError` — this
+prevents the residual-process scenario where a prior failed run left
+processes on the NPU.
+
+Use `--allow-busy-npu` to bypass this check when intentionally starting on
+an occupied NPU (debugging only).
+

--- a/docs/HISTORICAL_PR_BACKFILL.md
+++ b/docs/HISTORICAL_PR_BACKFILL.md
@@ -397,10 +397,9 @@ and later backfills should adapt to it, not the other way around.
 
 ## Failure-Path Contract (Issue #97)
 
-When a managed dev-hub run fails to become healthy within
-`--managed-ready-timeout-seconds` (default 600s), the backfill orchestrator
-**must** retain a diagnostics bundle and release all resources before
-exiting. The contract has three parts:
+When a managed dev-hub run fails to become healthy within `--managed-ready-timeout-seconds` (default
+600s), the backfill orchestrator **must** retain a diagnostics bundle and release all resources
+before exiting. The contract has three parts:
 
 ### BLOCKED.txt diagnostics bundle
 
@@ -420,44 +419,40 @@ On failure, `capture_failure_diagnostics` writes a bundle to:
 └── cleanup.log              # defensive cleanup actions taken
 ```
 
-The `BLOCKED.txt` file includes: `blocked_at`, `run_key`, `target_label`,
-`spec_path`, `core_ref`, `plugin_ref`, `pr_number`, `container`,
-`systemd_unit`, `npu_devices`, `server_port`, `blocker_reason`, and
-`next_steps` guidance.
+The `BLOCKED.txt` file includes: `blocked_at`, `run_key`, `target_label`, `spec_path`, `core_ref`,
+`plugin_ref`, `pr_number`, `container`, `systemd_unit`, `npu_devices`, `server_port`,
+`blocker_reason`, and `next_steps` guidance.
 
-**The bundle lives under `.benchmarks/` (gitignored) and is NEVER uploaded
-to `submissions/`**. Failed runs must not produce half-finished or empty
-artifacts that could leak into the public leaderboard.
+**The bundle lives under `.benchmarks/` (gitignored) and is NEVER uploaded to `submissions/`**.
+Failed runs must not produce half-finished or empty artifacts that could leak into the public
+leaderboard.
 
-The `state.json` entry for a failed run now carries a `blocked_dir` field
-pointing to the diagnostics bundle path, so operators can find the
-diagnostics from the state file.
+The `state.json` entry for a failed run now carries a `blocked_dir` field pointing to the
+diagnostics bundle path, so operators can find the diagnostics from the state file.
 
 ### Defensive cleanup sequence
 
-After `manage.sh stop`, the orchestrator runs `force_cleanup_managed_server`
-which executes a defense-in-depth cleanup (all with `check=False`):
+After `manage.sh stop`, the orchestrator runs `force_cleanup_managed_server` which executes a
+defense-in-depth cleanup (all with `check=False`):
 
 1. Kill processes on managed NPU devices (via `npu-smi info` + `os.kill`)
-2. Kill stale `VLLMEngineCore` / `vllm.entrypoints` processes (via `pgrep`)
-3. `systemctl --user stop <unit>` + `systemctl --user reset-failed <unit>`
-4. Free the managed port (via `lsof -ti :<port>` + `os.kill`)
-5. `docker rm -f <container>` (if docker is installed)
+1. Kill stale `VLLMEngineCore` / `vllm.entrypoints` processes (via `pgrep`)
+1. `systemctl --user stop <unit>` + `systemctl --user reset-failed <unit>`
+1. Free the managed port (via `lsof -ti :<port>` + `os.kill`)
+1. `docker rm -f <container>` (if docker is installed)
 
-After cleanup, `verify_cleanup_success` checks for residuals and logs
-warnings to stderr for any resources that could not be released.
+After cleanup, `verify_cleanup_success` checks for residuals and logs warnings to stderr for any
+resources that could not be released.
 
-Use `--skip-defensive-cleanup` to skip this step when debugging (leaves
-residuals for manual inspection).
+Use `--skip-defensive-cleanup` to skip this step when debugging (leaves residuals for manual
+inspection).
 
 ### Pre-flight NPU idle check
 
-Before calling `manage.sh restart`, `verify_npu_idle` checks that the
-managed NPU devices have no running processes. If NPU0 (or any managed
-device) is occupied, the run fails fast with a `RuntimeError` — this
-prevents the residual-process scenario where a prior failed run left
-processes on the NPU.
+Before calling `manage.sh restart`, `verify_npu_idle` checks that the managed NPU devices have no
+running processes. If NPU0 (or any managed device) is occupied, the run fails fast with a
+`RuntimeError` — this prevents the residual-process scenario where a prior failed run left processes
+on the NPU.
 
-Use `--allow-busy-npu` to bypass this check when intentionally starting on
-an occupied NPU (debugging only).
-
+Use `--allow-busy-npu` to bypass this check when intentionally starting on an occupied NPU
+(debugging only).

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -432,7 +432,14 @@ def to_container_workspace_path(path: Path) -> str:
     return f"{container_workspace}/" + relative.as_posix()
 
 
-def require_container_workspace_path(path: Path, *, purpose: str) -> str:
+def require_container_workspace_path(
+    path: Path, *, purpose: str, in_container: bool = False
+) -> str:
+    if in_container:
+        # manage-container.sh runs vllm serve directly inside the host
+        # container; PYTHONPATH must be the real filesystem path, not a
+        # remapped /workspace mount. Skip the /workspace prefix check.
+        return str(path.resolve())
     container_path = to_container_workspace_path(path)
     if not container_path.startswith("/workspace/"):
         raise RuntimeError(
@@ -1007,13 +1014,16 @@ def start_managed_server(
             )
         model_path = spec.model
 
+    in_container = getattr(args, "manage_script", "manage.sh") != "manage.sh"
     core_container_path = require_container_workspace_path(
         core_worktree,
         purpose="core worktree",
+        in_container=in_container,
     )
     plugin_container_path = require_container_workspace_path(
         plugin_worktree,
         purpose="plugin worktree",
+        in_container=in_container,
     )
     extra_args = ["--generation-config", "vllm"]
     if args.managed_disable_ascend_fusion:

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -818,7 +818,6 @@ def force_cleanup_managed_server(
         "systemd_stopped": False,
         "npu_procs_killed": [],
         "port_freed": False,
-        "vllm_procs_killed": [],
     }
     if not execute:
         return report
@@ -842,26 +841,7 @@ def force_cleanup_managed_server(
             except (OSError, ProcessLookupError) as exc:
                 _log(f"could not kill NPU process {pid}: {exc}")
 
-    # 2. Pattern-based cleanup for stale VLLMEngineCore processes.
-    try:
-        result = subprocess.run(
-            ["bash", "-c", "pgrep -f 'VLLMEngineCore|vllm.entrypoints' || true"],
-            text=True,
-            check=False,
-            capture_output=True,
-        )
-        stale_pids = [int(p) for p in result.stdout.split() if p.strip().isdigit()]
-        for pid in stale_pids:
-            try:
-                os.kill(pid, 9)
-                report["vllm_procs_killed"].append(pid)
-                _log(f"killed stale vLLM process {pid}")
-            except (OSError, ProcessLookupError) as exc:
-                _log(f"could not kill stale vLLM process {pid}: {exc}")
-    except (OSError, subprocess.SubprocessError) as exc:
-        _log(f"pgrep for stale vLLM processes failed: {exc}")
-
-    # 3. Stop/reset-failed the systemd user unit.
+    # 2. Stop/reset-failed the systemd user unit.
     systemd_unit = getattr(args, "managed_systemd_unit", "") or ""
     if systemd_unit and systemd_unit.endswith(".service"):
         try:
@@ -1014,7 +994,8 @@ def start_managed_server(
             )
         model_path = spec.model
 
-    in_container = getattr(args, "manage_script", "manage.sh") != "manage.sh"
+    manage_basename = Path(getattr(args, "manage_script", "manage.sh")).name
+    in_container = manage_basename != "manage.sh"
     core_container_path = require_container_workspace_path(
         core_worktree,
         purpose="core worktree",
@@ -1106,7 +1087,7 @@ def start_managed_server(
 
     # manage-container.sh (in-container mode) needs the python binary and
     # conda env name to activate the runtime before launching vllm serve.
-    if getattr(args, "manage_script", "manage.sh") != "manage.sh":
+    if in_container:
         if args.runtime_python:
             env["VLLM_ENGINE_PYTHON"] = args.runtime_python
         env_prefix = getattr(args, "current_env_prefix", "")

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -1025,6 +1025,11 @@ def start_managed_server(
         purpose="plugin worktree",
         in_container=in_container,
     )
+    pythonpath_value = f"{core_container_path}:{plugin_container_path}"
+    if in_container:
+        existing_pythonpath = os.environ.get("PYTHONPATH", "")
+        if existing_pythonpath:
+            pythonpath_value = f"{pythonpath_value}:{existing_pythonpath}"
     extra_args = ["--generation-config", "vllm"]
     if args.managed_disable_ascend_fusion:
         additional_config = {
@@ -1070,8 +1075,16 @@ def start_managed_server(
         "VLLM_ENGINE_ENFORCE_EAGER": "1" if args.managed_enforce_eager else "0",
         "VLLM_ENGINE_COMPILATION_CONFIG": "{}",
         "VLLM_ENGINE_EXTRA_ARGS_JSON": json.dumps(extra_args),
-        "VLLM_ENGINE_PYTHONPATH": f"{core_container_path}:{plugin_container_path}",
-        "VLLM_ENGINE_BASE_PYTHONPATH": f"{core_container_path}:{plugin_container_path}",
+        "VLLM_ENGINE_PYTHONPATH": pythonpath_value,
+        "VLLM_ENGINE_BASE_PYTHONPATH": pythonpath_value,
+        # In-container mode (manage-container.sh) does not translate
+        # VLLM_ENGINE_PYTHONPATH into PYTHONPATH the way the docker
+        # entrypoint does for manage.sh. Set PYTHONPATH directly so vllm
+        # serve imports the historical PR commit's code, not the installed
+        # site-packages version.
+        "PYTHONPATH": pythonpath_value
+        if in_container
+        else os.environ.get("PYTHONPATH", ""),
         "VLLM_PLUGINS": "ascend",
         # dev-hub intentionally filters environment variable names containing
         # KEY/TOKEN/SECRET, so prefix forwarding is required for HF cache vars.

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -450,6 +450,12 @@ def require_container_workspace_path(
 
 
 def find_local_model_path(model_id: str) -> str | None:
+    override = os.environ.get("VLLM_HUST_LOCAL_MODEL_PATH")
+    if override:
+        override_path = Path(override)
+        if override_path.exists():
+            return str(override_path)
+        return None
     known = {
         "Qwen/Qwen2.5-14B-Instruct": [
             Path("/data/shared_models/Qwen2.5-14B-Instruct"),
@@ -485,11 +491,6 @@ def find_local_model_path(model_id: str) -> str | None:
     for candidate in known.get(model_id, []):
         if candidate.exists():
             return str(candidate)
-    override = os.environ.get("VLLM_HUST_LOCAL_MODEL_PATH")
-    if override:
-        override_path = Path(override)
-        if override_path.exists():
-            return str(override_path)
     return None
 
 

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -18,7 +18,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_HF_REPO = "intellistream/vllm-hust-benchmark-results"
 DEFAULT_OFFICIAL_SPEC_DIR = REPO_ROOT / "docs" / "official-baselines"
@@ -50,6 +49,20 @@ SUSPECT_TARGET_REFS = (
         ),
     },
 )
+BLOCKED_DIR_NAME = "blocked"
+BLOCKED_MARKER_FILE = "BLOCKED.txt"
+
+
+class _HealthTimeoutError(RuntimeError):
+    """Raised when managed dev-hub server fails to become healthy within timeout.
+
+    Carries the path to the captured diagnostics bundle (``blocked_dir``) so the
+    outer exception handler can record it in the state file without re-capturing.
+    """
+
+    def __init__(self, message: str, blocked_dir: Path | None = None) -> None:
+        super().__init__(message)
+        self.blocked_dir = blocked_dir
 
 
 @dataclass(frozen=True)
@@ -395,12 +408,17 @@ def copy_submission_to_repo(submission_dir: Path, submissions_root: Path) -> Pat
 
 def to_container_workspace_path(path: Path) -> str:
     resolved = path.resolve()
-    home = Path("/home/shuhao")
+    host_workspace = Path(
+        os.environ.get("VLLM_HUST_HOST_WORKSPACE_ROOT", "/home/shuhao")
+    ).resolve()
     try:
-        relative = resolved.relative_to(home)
+        relative = resolved.relative_to(host_workspace)
     except ValueError:
         return str(resolved)
-    return "/workspace/" + relative.as_posix()
+    container_workspace = os.environ.get(
+        "VLLM_HUST_CONTAINER_WORKSPACE_ROOT", "/workspace"
+    )
+    return f"{container_workspace}/" + relative.as_posix()
 
 
 def require_container_workspace_path(path: Path, *, purpose: str) -> str:
@@ -533,6 +551,412 @@ def actual_chip_model_for_run(args: argparse.Namespace, spec: OfficialSpec) -> s
     return actual
 
 
+def parse_npu_smi_processes(output: str, devices: str) -> list[tuple[int, int]]:
+    """Parse ``npu-smi info`` process table for ``(device_id, pid)`` pairs.
+
+    The process section starts after a separator line containing
+    ``Process id``. Each process row looks like::
+
+        | 0       0                 | 1504884       |                    | 35358                 | 412309                  |
+    """
+    ids = set(managed_device_ids(devices))
+    if not ids:
+        return []
+    in_process_section = False
+    pairs: list[tuple[int, int]] = []
+    for line in output.splitlines():
+        if "Process id" in line:
+            in_process_section = True
+            continue
+        if not in_process_section:
+            continue
+        if "No running processes" in line:
+            continue
+        match = re.match(r"^\|\s*(\d+)\s+\d+\s+\|\s*(\d+)", line)
+        if not match:
+            continue
+        device_id = int(match.group(1))
+        pid = int(match.group(2))
+        if device_id in ids and pid > 0:
+            pairs.append((device_id, pid))
+    return pairs
+
+
+def detect_npu_processes(devices: str) -> list[tuple[int, int]]:
+    """Return ``(device_id, pid)`` pairs for processes on the managed NPU devices."""
+    try:
+        output = subprocess.check_output(["npu-smi", "info"], text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return parse_npu_smi_processes(output, devices)
+
+
+def verify_npu_idle(
+    *, devices: str, allow_busy: bool = False, execute: bool = True
+) -> None:
+    """Pre-flight check: refuse to start if managed NPU devices are occupied.
+
+    Issue #97: prevents the residual-process scenario by failing fast when NPU0
+    (or any managed device) still has processes from a prior failed run.
+    """
+    if not execute or allow_busy:
+        return
+    procs = detect_npu_processes(devices)
+    if procs:
+        pids = [pid for _, pid in procs]
+        raise RuntimeError(
+            f"NPU devices {devices} not idle: found PIDs {pids}. "
+            "Run cleanup first or pass --allow-busy-npu to bypass."
+        )
+
+
+def _capture_subprocess(
+    command: list[str], *, cwd: Path, output_file: Path, execute: bool
+) -> None:
+    """Run ``command`` and redirect stdout+stderr to ``output_file``.
+
+    Always uses ``check=False`` — diagnostics failures must never mask the
+    original error that triggered the diagnostics capture.
+    """
+    if not execute:
+        print(f"[dry-run] {cwd}$ {' '.join(command)} > {output_file}")
+        return
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            check=False,
+            capture_output=True,
+        )
+        output_file.write_text(result.stdout + result.stderr, encoding="utf-8")
+    except (OSError, subprocess.SubprocessError) as exc:
+        output_file.write_text(f"capture failed: {exc}", encoding="utf-8")
+
+
+def capture_failure_diagnostics(
+    *,
+    target: TargetRef,
+    spec: OfficialSpec,
+    args: argparse.Namespace,
+    error: str,
+    result_root: Path,
+    run_key: str,
+    execute: bool,
+    state_file: Path | None = None,
+) -> Path:
+    """Write BLOCKED.txt + log bundle to ``<result_root>/blocked/<run_key>/``.
+
+    Issue #97 item 4: failed runs must retain BLOCKED.txt/logs/state files.
+    The bundle lives under ``.benchmarks/`` (gitignored) and is NEVER uploaded
+    to ``submissions/`` — the operator inspects it locally to root-cause the
+    failure. All sub-commands run with ``check=False`` so that one failed
+    capture does not mask the original error.
+    """
+    blocked_root = result_root / BLOCKED_DIR_NAME
+    blocked_dir = blocked_root / slugify(run_key)
+    blocked_dir.mkdir(parents=True, exist_ok=True)
+    container = getattr(args, "managed_container", "") or ""
+    systemd_unit = getattr(args, "managed_systemd_unit", "") or ""
+    npu_devices = getattr(args, "managed_npu_devices", "") or ""
+    server_port = getattr(args, "server_port", "") or ""
+    dev_hub_dir = Path(getattr(args, "dev_hub_dir", ".")).resolve()
+
+    # Snapshot container/systemd/NPU/port state into the bundle.
+    if container:
+        _capture_subprocess(
+            ["docker", "logs", container],
+            cwd=Path.cwd(),
+            output_file=blocked_dir / "container.stdout.log",
+            execute=execute,
+        )
+        _capture_subprocess(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name={container}",
+                "--format",
+                "table {{.Names}}\t{{.Status}}\t{{.Ports}}",
+            ],
+            cwd=Path.cwd(),
+            output_file=blocked_dir / "docker-ps.txt",
+            execute=execute,
+        )
+    _capture_subprocess(
+        ["npu-smi", "info"],
+        cwd=Path.cwd(),
+        output_file=blocked_dir / "npu-smi.txt",
+        execute=execute,
+    )
+    manage = dev_hub_dir / "manage.sh"
+    if manage.exists():
+        _capture_subprocess(
+            [str(manage), "status"],
+            cwd=dev_hub_dir,
+            output_file=blocked_dir / "manage-status.txt",
+            execute=execute,
+        )
+    if systemd_unit:
+        _capture_subprocess(
+            ["systemctl", "--user", "is-active", systemd_unit],
+            cwd=Path.cwd(),
+            output_file=blocked_dir / "systemd-status.txt",
+            execute=execute,
+        )
+    if server_port:
+        _capture_subprocess(
+            ["bash", "-c", f"lsof -i :{server_port} 2>&1 || true"],
+            cwd=Path.cwd(),
+            output_file=blocked_dir / "port-probe.txt",
+            execute=execute,
+        )
+    # Stale vLLM engine core processes (the "VLLMEngineCor" residual from #97).
+    _capture_subprocess(
+        [
+            "bash",
+            "-c",
+            "ps -ef | grep -iE 'VLLMEngine|vllm.entrypoints' | grep -v grep || true",
+        ],
+        cwd=Path.cwd(),
+        output_file=blocked_dir / "vllm-processes.txt",
+        execute=execute,
+    )
+    # Copy the container log file if manage.sh set VLLM_ENGINE_CONTAINER_LOG_FILE.
+    container_log = Path(
+        f"/tmp/vllm-hust-backfill-{slugify(target.label)}-{slugify(spec.workload)}.log"
+    )
+    if container_log.exists():
+        shutil.copy2(container_log, blocked_dir / "container.stdout.log")
+    # Copy state file into the bundle for post-mortem inspection.
+    if state_file and state_file.exists():
+        shutil.copy2(state_file, blocked_dir / "state.json")
+
+    blocked_txt = blocked_dir / BLOCKED_MARKER_FILE
+    blocked_txt.write_text(
+        "\n".join(
+            [
+                f"blocked_at: {datetime.now(timezone.utc).isoformat()}",
+                f"run_key: {run_key}",
+                f"target_label: {target.label}",
+                f"spec_path: {spec.path}",
+                f"core_ref: {target.core_ref}",
+                f"plugin_ref: {target.plugin_ref}",
+                f"pr_number: {target.pr_number}",
+                f"container: {container}",
+                f"systemd_unit: {systemd_unit}",
+                f"npu_devices: {npu_devices}",
+                f"server_port: {server_port or 'from-manage.sh'}",
+                f"blocker_reason: {error}",
+                "",
+                "diagnostics_files:",
+                "  - container.stdout.log",
+                "  - npu-smi.txt",
+                "  - docker-ps.txt (if docker present)",
+                "  - manage-status.txt",
+                "  - systemd-status.txt",
+                "  - port-probe.txt (if port configured)",
+                "  - vllm-processes.txt",
+                "  - state.json",
+                "",
+                "next_steps:",
+                "  - Inspect container.stdout.log for vllm serve startup errors",
+                "  - Inspect npu-smi.txt for residual NPU processes",
+                "  - Inspect vllm-processes.txt for stale VLLMEngineCore processes",
+                "  - If runtime regression: bisect vllm-hust between this core_ref",
+                "    and a known-good prior commit",
+                "  - Do NOT upload this directory as a submission artifact",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    print(f"[backfill] BLOCKED diagnostics: {blocked_txt}", file=sys.stderr)
+    return blocked_dir
+
+
+def force_cleanup_managed_server(
+    *,
+    args: argparse.Namespace,
+    execute: bool,
+    blocked_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Defensive cleanup after ``manage.sh stop`` — kills residuals.
+
+    Issue #97 item 5: ``manage.sh stop`` is not always reliable (residual
+    ``VLLMEngineCor`` container/process observed). This helper runs a
+    defense-in-depth cleanup sequence: remove the systemd unit's processes,
+    kill stale vLLM engine processes on managed NPU devices, free the
+    managed port. All commands use ``check=False``.
+    """
+    report: dict[str, Any] = {
+        "container_removed": False,
+        "systemd_stopped": False,
+        "npu_procs_killed": [],
+        "port_freed": False,
+        "vllm_procs_killed": [],
+    }
+    if not execute:
+        return report
+
+    cleanup_log = blocked_dir / "cleanup.log" if blocked_dir else None
+    log_lines: list[str] = []
+
+    def _log(msg: str) -> None:
+        log_lines.append(msg)
+        print(f"[cleanup] {msg}", file=sys.stderr)
+
+    # 1. Kill stale VLLMEngineCore / vllm.entrypoints processes on managed NPU devices.
+    npu_devices = getattr(args, "managed_npu_devices", "") or ""
+    if npu_devices:
+        procs = detect_npu_processes(npu_devices)
+        for device_id, pid in procs:
+            try:
+                os.kill(pid, 9)  # SIGKILL
+                report["npu_procs_killed"].append(pid)
+                _log(f"killed NPU process {pid} on device {device_id}")
+            except (OSError, ProcessLookupError) as exc:
+                _log(f"could not kill NPU process {pid}: {exc}")
+
+    # 2. Pattern-based cleanup for stale VLLMEngineCore processes.
+    try:
+        result = subprocess.run(
+            ["bash", "-c", "pgrep -f 'VLLMEngineCore|vllm.entrypoints' || true"],
+            text=True,
+            check=False,
+            capture_output=True,
+        )
+        stale_pids = [int(p) for p in result.stdout.split() if p.strip().isdigit()]
+        for pid in stale_pids:
+            try:
+                os.kill(pid, 9)
+                report["vllm_procs_killed"].append(pid)
+                _log(f"killed stale vLLM process {pid}")
+            except (OSError, ProcessLookupError) as exc:
+                _log(f"could not kill stale vLLM process {pid}: {exc}")
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log(f"pgrep for stale vLLM processes failed: {exc}")
+
+    # 3. Stop/reset-failed the systemd user unit.
+    systemd_unit = getattr(args, "managed_systemd_unit", "") or ""
+    if systemd_unit and systemd_unit.endswith(".service"):
+        try:
+            subprocess.run(
+                ["systemctl", "--user", "stop", systemd_unit],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["systemctl", "--user", "reset-failed", systemd_unit],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            report["systemd_stopped"] = True
+            _log(f"stopped and reset-failed systemd unit {systemd_unit}")
+        except (OSError, subprocess.SubprocessError) as exc:
+            _log(f"systemctl stop/reset-failed failed: {exc}")
+
+    # 4. Free the managed port if configured.
+    server_port = getattr(args, "server_port", "") or ""
+    if server_port:
+        try:
+            result = subprocess.run(
+                ["bash", "-c", f"lsof -ti :{server_port} 2>/dev/null || true"],
+                text=True,
+                check=False,
+                capture_output=True,
+            )
+            port_pids = [int(p) for p in result.stdout.split() if p.strip().isdigit()]
+            for pid in port_pids:
+                try:
+                    os.kill(pid, 9)
+                    report["port_freed"] = True
+                    _log(f"killed process {pid} holding port {server_port}")
+                except (OSError, ProcessLookupError) as exc:
+                    _log(f"could not kill port holder {pid}: {exc}")
+        except (OSError, subprocess.SubprocessError) as exc:
+            _log(f"port cleanup for :{server_port} failed: {exc}")
+
+    # 5. Remove docker container if docker is present.
+    container = getattr(args, "managed_container", "") or ""
+    if container:
+        try:
+            result = subprocess.run(
+                ["docker", "rm", "-f", container],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                report["container_removed"] = True
+                _log(f"removed docker container {container}")
+        except (OSError, FileNotFoundError):
+            # docker not installed — manage.sh uses systemd, not docker.
+            pass
+        except subprocess.SubprocessError as exc:
+            _log(f"docker rm -f {container} failed: {exc}")
+
+    if cleanup_log:
+        cleanup_log.write_text("\n".join(log_lines), encoding="utf-8")
+    return report
+
+
+def verify_cleanup_success(*, args: argparse.Namespace, execute: bool) -> list[str]:
+    """Return a list of warning strings for residuals after cleanup.
+
+    Issue #97 item 5: surfaces silent cleanup failures so the operator knows
+    which resources still need manual intervention.
+    """
+    warnings: list[str] = []
+    if not execute:
+        return warnings
+
+    npu_devices = getattr(args, "managed_npu_devices", "") or ""
+    if npu_devices:
+        procs = detect_npu_processes(npu_devices)
+        if procs:
+            pids = [pid for _, pid in procs]
+            warnings.append(
+                f"residual NPU processes on devices {npu_devices}: PIDs {pids}"
+            )
+
+    systemd_unit = getattr(args, "managed_systemd_unit", "") or ""
+    if systemd_unit:
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "is-active", systemd_unit],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            state = result.stdout.strip()
+            if state in ("active", "activating"):
+                warnings.append(f"systemd unit {systemd_unit} is still {state}")
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+    server_port = getattr(args, "server_port", "") or ""
+    if server_port:
+        try:
+            result = subprocess.run(
+                ["bash", "-c", f"lsof -ti :{server_port} 2>/dev/null || true"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout.strip():
+                warnings.append(
+                    f"port {server_port} still in use by PIDs: {result.stdout.strip()}"
+                )
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+    return warnings
+
+
 def describe_git_ref(repo: Path, ref: str) -> str:
     described = capture_command(
         ["git", "describe", "--tags", "--always", ref], cwd=repo
@@ -548,7 +972,16 @@ def start_managed_server(
     core_worktree: Path,
     plugin_worktree: Path,
     execute: bool,
+    result_root: Path,
+    run_key: str,
+    state_file: Path | None = None,
 ) -> None:
+    # Pre-flight: refuse to start if NPU is occupied by a prior failed run.
+    verify_npu_idle(
+        devices=args.managed_npu_devices,
+        allow_busy=getattr(args, "allow_busy_npu", False),
+        execute=execute,
+    )
     model_path = find_local_model_path(spec.model)
     if model_path is None:
         if not args.allow_model_downloads:
@@ -653,9 +1086,25 @@ def start_managed_server(
         if not execute:
             return
         if time.monotonic() >= deadline:
-            raise RuntimeError(
+            # Issue #97 item 4: capture diagnostics before raising so the
+            # operator can root-cause the 600s health-timeout failure.
+            blocked_dir = capture_failure_diagnostics(
+                target=target,
+                spec=spec,
+                args=args,
+                error=(
+                    f"managed dev-hub server did not become healthy within "
+                    f"{args.managed_ready_timeout_seconds}s"
+                ),
+                result_root=result_root,
+                run_key=run_key,
+                execute=execute,
+                state_file=state_file,
+            )
+            raise _HealthTimeoutError(
                 f"managed dev-hub server did not become healthy within "
-                f"{args.managed_ready_timeout_seconds}s"
+                f"{args.managed_ready_timeout_seconds}s",
+                blocked_dir=blocked_dir,
             )
         time.sleep(args.managed_health_interval_seconds)
 
@@ -1074,6 +1523,22 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--managed-ready-timeout-seconds", type=int, default=600)
     parser.add_argument("--managed-health-interval-seconds", type=int, default=10)
+    parser.add_argument(
+        "--allow-busy-npu",
+        action="store_true",
+        help=(
+            "Bypass the pre-flight NPU idle check. Use only for debugging "
+            "when you intentionally want to start on an occupied NPU."
+        ),
+    )
+    parser.add_argument(
+        "--skip-defensive-cleanup",
+        action="store_true",
+        help=(
+            "Skip force_cleanup_managed_server after manage.sh stop. "
+            "Use only for debugging to inspect residual state."
+        ),
+    )
     parser.add_argument("--allow-model-downloads", action="store_true")
     parser.add_argument("--submitter", default="historical-pr-backfill")
     parser.add_argument("--core-github-repository", default="vLLM-HUST/vllm-hust")
@@ -1190,6 +1655,7 @@ def main() -> int:
             }
             if execute:
                 write_state(state_file, state)
+            blocked_dir: Path | None = None
             try:
                 uses_managed_server = (
                     args.managed_dev_hub and spec.benchmark_type == "serve"
@@ -1202,6 +1668,9 @@ def main() -> int:
                         core_worktree=core_worktree,
                         plugin_worktree=plugin_worktree,
                         execute=execute,
+                        result_root=result_root,
+                        run_key=key,
+                        state_file=state_file,
                     )
                 submission_dir = run_target_spec(
                     args=args,
@@ -1229,11 +1698,29 @@ def main() -> int:
                 if execute:
                     write_state(state_file, state)
             except Exception as exc:
+                # Issue #97 item 4: capture diagnostics for failed runs.
+                # _HealthTimeoutError already captured during start_managed_server;
+                # for other exceptions, capture here.
+                blocked_dir: Path | None = None
+                if isinstance(exc, _HealthTimeoutError):
+                    blocked_dir = exc.blocked_dir
+                elif uses_managed_server and execute:
+                    blocked_dir = capture_failure_diagnostics(
+                        target=target,
+                        spec=spec,
+                        args=args,
+                        error=str(exc),
+                        result_root=result_root,
+                        run_key=key,
+                        execute=execute,
+                        state_file=state_file,
+                    )
                 state["runs"][key] = {
                     **state["runs"].get(key, {}),
                     "status": "failed",
                     "error": str(exc),
                     "failed_at": datetime.now(timezone.utc).isoformat(),
+                    "blocked_dir": str(blocked_dir) if blocked_dir else None,
                 }
                 if execute:
                     write_state(state_file, state)
@@ -1241,11 +1728,36 @@ def main() -> int:
                     f"[backfill] failed: {target.label} / {spec.workload}: {exc}",
                     file=sys.stderr,
                 )
+                if blocked_dir:
+                    print(
+                        f"[backfill] BLOCKED diagnostics: {blocked_dir / BLOCKED_MARKER_FILE}",
+                        file=sys.stderr,
+                    )
                 if execute:
                     return 1
             finally:
                 if args.managed_dev_hub and spec.benchmark_type == "serve":
-                    stop_managed_server(args=args, execute=execute)
+                    try:
+                        stop_managed_server(args=args, execute=execute)
+                    except Exception as stop_exc:  # noqa: BLE001
+                        print(
+                            f"[backfill] WARNING: manage.sh stop raised: {stop_exc}",
+                            file=sys.stderr,
+                        )
+                    # Issue #97 item 5: defensive cleanup — manage.sh stop is
+                    # not always reliable (residual VLLMEngineCore observed).
+                    if not getattr(args, "skip_defensive_cleanup", False):
+                        force_cleanup_managed_server(
+                            args=args,
+                            execute=execute,
+                            blocked_dir=blocked_dir,
+                        )
+                        warnings = verify_cleanup_success(args=args, execute=execute)
+                        for w in warnings:
+                            print(
+                                f"[backfill] WARNING: residual after cleanup: {w}",
+                                file=sys.stderr,
+                            )
 
     print("[backfill] done")
     return 0

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -478,6 +478,11 @@ def find_local_model_path(model_id: str) -> str | None:
     for candidate in known.get(model_id, []):
         if candidate.exists():
             return str(candidate)
+    override = os.environ.get("VLLM_HUST_LOCAL_MODEL_PATH")
+    if override:
+        override_path = Path(override)
+        if override_path.exists():
+            return str(override_path)
     return None
 
 

--- a/scripts/backfill_historical_pr_benchmarks.py
+++ b/scripts/backfill_historical_pr_benchmarks.py
@@ -406,6 +406,17 @@ def copy_submission_to_repo(submission_dir: Path, submissions_root: Path) -> Pat
     return target
 
 
+def resolve_manage_script(args: argparse.Namespace) -> Path:
+    """Resolve the launcher script path relative to --dev-hub-dir.
+
+    Defaults to ``manage.sh`` (docker/systemd-based). Use
+    ``--manage-script scripts/manage-container.sh`` when the host is already
+    inside a container and docker/systemd are unavailable.
+    """
+    dev_hub = Path(getattr(args, "dev_hub_dir", ".")).resolve()
+    return dev_hub / getattr(args, "manage_script", "manage.sh")
+
+
 def to_container_workspace_path(path: Path) -> str:
     resolved = path.resolve()
     host_workspace = Path(
@@ -690,7 +701,7 @@ def capture_failure_diagnostics(
         output_file=blocked_dir / "npu-smi.txt",
         execute=execute,
     )
-    manage = dev_hub_dir / "manage.sh"
+    manage = resolve_manage_script(args)
     if manage.exists():
         _capture_subprocess(
             [str(manage), "status"],
@@ -1065,10 +1076,20 @@ def start_managed_server(
     if args.managed_systemd_unit:
         env["VLLM_ENGINE_SYSTEMD_UNIT"] = args.managed_systemd_unit
 
-    manage = Path(args.dev_hub_dir).resolve() / "manage.sh"
+    # manage-container.sh (in-container mode) needs the python binary and
+    # conda env name to activate the runtime before launching vllm serve.
+    if getattr(args, "manage_script", "manage.sh") != "manage.sh":
+        if args.runtime_python:
+            env["VLLM_ENGINE_PYTHON"] = args.runtime_python
+        env_prefix = getattr(args, "current_env_prefix", "")
+        if env_prefix:
+            env["VLLM_MANAGER_CONDA_ENV"] = Path(env_prefix).name
+
+    manage = resolve_manage_script(args)
+    manage_cwd = Path(args.dev_hub_dir).resolve()
     run_command(
         [str(manage), "restart"],
-        cwd=Path(args.dev_hub_dir).resolve(),
+        cwd=manage_cwd,
         execute=execute,
         env=env,
     )
@@ -1076,7 +1097,7 @@ def start_managed_server(
     while True:
         health = run_command(
             [str(manage), "health"],
-            cwd=Path(args.dev_hub_dir).resolve(),
+            cwd=manage_cwd,
             execute=execute,
             env=env,
             check=False,
@@ -1115,10 +1136,11 @@ def stop_managed_server(*, args: argparse.Namespace, execute: bool) -> None:
         env["VLLM_ENGINE_CONTAINER"] = args.managed_container
     if args.managed_systemd_unit:
         env["VLLM_ENGINE_SYSTEMD_UNIT"] = args.managed_systemd_unit
-    manage = Path(args.dev_hub_dir).resolve() / "manage.sh"
+    manage = resolve_manage_script(args)
+    manage_cwd = Path(args.dev_hub_dir).resolve()
     run_command(
         [str(manage), "stop"],
-        cwd=Path(args.dev_hub_dir).resolve(),
+        cwd=manage_cwd,
         execute=execute,
         env=env,
         check=False,
@@ -1483,6 +1505,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--server-port", default="")
     parser.add_argument("--managed-dev-hub", action="store_true")
     parser.add_argument("--dev-hub-dir", default=str(DEFAULT_DEV_HUB_DIR))
+    parser.add_argument(
+        "--manage-script",
+        default="manage.sh",
+        help=(
+            "Launcher script relative to --dev-hub-dir. Use 'scripts/manage-container.sh' "
+            "when running inside a container (no docker/systemd)."
+        ),
+    )
     parser.add_argument("--managed-npu-devices", default="0")
     parser.add_argument("--managed-container", default="vllm-hust-backfill")
     parser.add_argument("--managed-systemd-unit", default="vllm-hust-backfill.service")

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -657,7 +657,6 @@ class TestDeterminism:
 
 class TestAggregateEntries:
     def test_basic(self, mixed_entries):
-
         result = aggregate_entries(mixed_entries, method="mean")
         # 1 aggregated group + 1 solo entry = 2 output entries
         assert len(result) == 2
@@ -670,7 +669,6 @@ class TestAggregateEntries:
         assert solo_entries[0]["entry_id"] == "solo-entry-0000-0000-000000000000"
 
     def test_aggregated_entry_has_correct_metrics(self, repeat_group_entries):
-
         result = aggregate_entries(repeat_group_entries, method="mean")
         assert len(result) == 1
         e = result[0]
@@ -682,7 +680,6 @@ class TestAggregateEntries:
         assert e["metrics"]["ttft_ms"] == agg["metrics"]["ttft_ms"]["value"]
 
     def test_no_repeat_group(self, base_entry_dict):
-
         entry = copy.deepcopy(base_entry_dict)
         result = aggregate_entries([entry], method="mean")
         assert len(result) == 1
@@ -712,7 +709,6 @@ class TestFileIO:
             load_entries_from_paths(["/tmp/nonexistent-file.json"])
 
     def test_write_aggregated_entries(self, repeat_group_entries):
-
         result = aggregate_entries(repeat_group_entries, method="mean")
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -37,7 +37,7 @@ def module():
 def target(module):
     return module.TargetRef(
         label="pr80-test",
-        core_ref="ae16d09435",
+        core_ref="ae16d09435",  # pragma: allowlist secret
         plugin_ref="a05a9efe54",
         pr_number=80,
     )
@@ -133,23 +133,31 @@ def test_parse_npu_smi_processes_filters_to_managed_devices(module):
 
 
 def test_verify_npu_idle_raises_when_occupied(module, monkeypatch):
-    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    monkeypatch.setattr(
+        module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS
+    )
     with pytest.raises(RuntimeError, match="NPU devices 0 not idle"):
         module.verify_npu_idle(devices="0", allow_busy=False, execute=True)
 
 
 def test_verify_npu_idle_passes_when_idle(module, monkeypatch):
-    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_IDLE)
+    monkeypatch.setattr(
+        module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_IDLE
+    )
     module.verify_npu_idle(devices="0", allow_busy=False, execute=True)
 
 
 def test_verify_npu_idle_bypassed_with_allow_busy(module, monkeypatch):
-    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    monkeypatch.setattr(
+        module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS
+    )
     module.verify_npu_idle(devices="0", allow_busy=True, execute=True)
 
 
 def test_verify_npu_idle_skipped_in_dry_run(module, monkeypatch):
-    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    monkeypatch.setattr(
+        module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS
+    )
     module.verify_npu_idle(devices="0", allow_busy=False, execute=False)
 
 
@@ -171,10 +179,17 @@ def test_health_timeout_error_blocked_dir_defaults_none(module):
 # === capture_failure_diagnostics ===
 
 
-def test_capture_failure_diagnostics_writes_blocked_txt(module, target, spec, args, tmp_path):
+def test_capture_failure_diagnostics_writes_blocked_txt(
+    module, target, spec, args, tmp_path
+):
     blocked_dir = module.capture_failure_diagnostics(
-        target=target, spec=spec, args=args, error="test failure",
-        result_root=tmp_path, run_key="test-key", execute=False,
+        target=target,
+        spec=spec,
+        args=args,
+        error="test failure",
+        result_root=tmp_path,
+        run_key="test-key",
+        execute=False,
     )
     blocked_txt = blocked_dir / module.BLOCKED_MARKER_FILE
     assert blocked_txt.exists()
@@ -192,31 +207,52 @@ def test_capture_failure_diagnostics_blocked_dir_under_benchmarks_not_submission
 ):
     """Issue #97 item 4: BLOCKED.txt must NEVER live under submissions/."""
     blocked_dir = module.capture_failure_diagnostics(
-        target=target, spec=spec, args=args, error="err",
-        result_root=tmp_path, run_key="k", execute=False,
+        target=target,
+        spec=spec,
+        args=args,
+        error="err",
+        result_root=tmp_path,
+        run_key="k",
+        execute=False,
     )
     blocked_str = str(blocked_dir)
     assert "submissions" not in blocked_str
     assert "blocked" in blocked_str
 
 
-def test_capture_failure_diagnostics_is_idempotent(module, target, spec, args, tmp_path):
+def test_capture_failure_diagnostics_is_idempotent(
+    module, target, spec, args, tmp_path
+):
     """Calling twice for the same run_key doesn't fail."""
     for _ in range(2):
         module.capture_failure_diagnostics(
-            target=target, spec=spec, args=args, error="err",
-            result_root=tmp_path, run_key="dup", execute=False,
+            target=target,
+            spec=spec,
+            args=args,
+            error="err",
+            result_root=tmp_path,
+            run_key="dup",
+            execute=False,
         )
-    blocked_txt = (tmp_path / module.BLOCKED_DIR_NAME / "dup" / module.BLOCKED_MARKER_FILE)
+    blocked_txt = (
+        tmp_path / module.BLOCKED_DIR_NAME / "dup" / module.BLOCKED_MARKER_FILE
+    )
     assert blocked_txt.exists()
 
 
-def test_capture_failure_diagnostics_copies_state_file(module, target, spec, args, tmp_path):
+def test_capture_failure_diagnostics_copies_state_file(
+    module, target, spec, args, tmp_path
+):
     state_file = tmp_path / "state.json"
     state_file.write_text('{"runs": {}}', encoding="utf-8")
     blocked_dir = module.capture_failure_diagnostics(
-        target=target, spec=spec, args=args, error="err",
-        result_root=tmp_path, run_key="k", execute=False,
+        target=target,
+        spec=spec,
+        args=args,
+        error="err",
+        result_root=tmp_path,
+        run_key="k",
+        execute=False,
         state_file=state_file,
     )
     assert (blocked_dir / "state.json").exists()
@@ -227,16 +263,26 @@ def test_capture_failure_diagnostics_does_not_raise_on_subprocess_failure(
     module, target, spec, args, tmp_path, monkeypatch
 ):
     """Issue #97: diagnostics capture must never mask the original error."""
+
     def failing_run(*a, **kw):
         raise OSError("simulated failure")
 
     monkeypatch.setattr(module.subprocess, "run", failing_run)
     blocked_dir = module.capture_failure_diagnostics(
-        target=target, spec=spec, args=args, error="original error",
-        result_root=tmp_path, run_key="k", execute=True,
+        target=target,
+        spec=spec,
+        args=args,
+        error="original error",
+        result_root=tmp_path,
+        run_key="k",
+        execute=True,
     )
     assert (blocked_dir / module.BLOCKED_MARKER_FILE).exists()
-    assert (blocked_dir / "npu-smi.txt").read_text(encoding="utf-8").startswith("capture failed:")
+    assert (
+        (blocked_dir / "npu-smi.txt")
+        .read_text(encoding="utf-8")
+        .startswith("capture failed:")
+    )
 
 
 def test_capture_failure_diagnostics_captures_npu_smi_snapshot(
@@ -250,8 +296,13 @@ def test_capture_failure_diagnostics_captures_npu_smi_snapshot(
 
     monkeypatch.setattr(module.subprocess, "run", fake_run)
     blocked_dir = module.capture_failure_diagnostics(
-        target=target, spec=spec, args=args, error="err",
-        result_root=tmp_path, run_key="k", execute=True,
+        target=target,
+        spec=spec,
+        args=args,
+        error="err",
+        result_root=tmp_path,
+        run_key="k",
+        execute=True,
     )
     npu_snapshot = (blocked_dir / "npu-smi.txt").read_text(encoding="utf-8")
     assert "910B2" in npu_snapshot
@@ -327,9 +378,13 @@ def test_force_cleanup_removes_docker_container(module, args, monkeypatch):
 def test_force_cleanup_kills_stale_vllm_processes(module, args, monkeypatch):
     def fake_run(cmd, **kw):
         if isinstance(cmd, list) and "pgrep" in " ".join(cmd):
-            return type("R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0})()
+            return type(
+                "R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0}
+            )()
         if isinstance(cmd, str) and "pgrep" in cmd:
-            return type("R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0})()
+            return type(
+                "R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0}
+            )()
         return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
 
     killed: list[int] = []
@@ -354,13 +409,17 @@ def test_force_cleanup_returns_empty_report_in_dry_run(module, args):
     assert report["vllm_procs_killed"] == []
 
 
-def test_force_cleanup_writes_cleanup_log_to_blocked_dir(module, args, tmp_path, monkeypatch):
+def test_force_cleanup_writes_cleanup_log_to_blocked_dir(
+    module, args, tmp_path, monkeypatch
+):
     blocked_dir = tmp_path / "blocked" / "k"
     blocked_dir.mkdir(parents=True)
     monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [(0, 99999)])
     monkeypatch.setattr(module.os, "kill", lambda pid, sig: None)
 
-    module.force_cleanup_managed_server(args=args, execute=True, blocked_dir=blocked_dir)
+    module.force_cleanup_managed_server(
+        args=args, execute=True, blocked_dir=blocked_dir
+    )
 
     log = (blocked_dir / "cleanup.log").read_text(encoding="utf-8")
     assert "killed NPU process 99999" in log
@@ -369,7 +428,9 @@ def test_force_cleanup_writes_cleanup_log_to_blocked_dir(module, args, tmp_path,
 # === verify_cleanup_success ===
 
 
-def test_verify_cleanup_success_returns_warnings_for_npu_residuals(module, args, monkeypatch):
+def test_verify_cleanup_success_returns_warnings_for_npu_residuals(
+    module, args, monkeypatch
+):
     monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [(0, 88888)])
     warnings = module.verify_cleanup_success(args=args, execute=True)
     assert any("residual NPU processes" in w for w in warnings)
@@ -395,7 +456,9 @@ def test_verify_cleanup_success_returns_empty_in_dry_run(module, args):
 def test_verify_cleanup_success_warns_on_active_systemd(module, args, monkeypatch):
     def fake_run(cmd, **kw):
         if "is-active" in cmd:
-            return type("R", (), {"stdout": "active\n", "stderr": "", "returncode": 0})()
+            return type(
+                "R", (), {"stdout": "active\n", "stderr": "", "returncode": 0}
+            )()
         return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
 
     monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
@@ -454,9 +517,7 @@ def test_to_container_workspace_path_returns_raw_path_when_outside_root(
     assert result == "/opt/other/repo"
 
 
-def test_require_container_workspace_path_raises_when_outside_root(
-    module, monkeypatch
-):
+def test_require_container_workspace_path_raises_when_outside_root(module, monkeypatch):
     monkeypatch.setenv("VLLM_HUST_HOST_WORKSPACE_ROOT", "/root/vllm")
     with pytest.raises(RuntimeError, match="does not map into the dev-hub"):
         module.require_container_workspace_path(

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -1,0 +1,464 @@
+"""Tests for issue #97 failure-diagnostics and defensive-cleanup hardening.
+
+Covers ``capture_failure_diagnostics``, ``force_cleanup_managed_server``,
+``verify_cleanup_success``, ``verify_npu_idle``, ``parse_npu_smi_processes``,
+and the ``_HealthTimeoutError`` exception that carries a ``blocked_dir``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "backfill_historical_pr_benchmarks.py"
+)
+
+
+@pytest.fixture(scope="module")
+def module():
+    spec = importlib.util.spec_from_file_location("historical_pr_backfill", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def target(module):
+    return module.TargetRef(
+        label="pr80-test",
+        core_ref="ae16d09435",
+        plugin_ref="a05a9efe54",
+        pr_number=80,
+    )
+
+
+@pytest.fixture()
+def spec(module):
+    return module.OfficialSpec(
+        path=Path("/tmp/official-prefix-repetition.json"),
+        scenario="prefix-repetition-online",
+        workload="prefix-repetition-online",
+        benchmark_type="serve",
+        model="Qwen/Qwen2.5-14B-Instruct",
+        precision="FP16",
+        chip_model="910B2",
+        chip_count=1,
+        node_count=1,
+    )
+
+
+@pytest.fixture()
+def args(module):
+    return argparse.Namespace(
+        managed_container="vllm-hust-test",
+        managed_systemd_unit="vllm-hust-test.service",
+        managed_npu_devices="0",
+        server_port="8420",
+        dev_hub_dir="/tmp/dev-hub",
+        allow_busy_npu=False,
+        skip_defensive_cleanup=False,
+    )
+
+
+NPU_SMI_WITH_PROCESS = """\
++------------------------------------------------------------------------------------------------------------------+
+| npu-smi 26.0.rc1                            Version: 26.0.rc1                                                    |
++---------------------------+---------------+----------------------------------------------------------------------+
+| NPU   Name                | Health        | Power(W)             Temp(C)                 Hugepages-Usage(page)   |
+| Chip                      | Bus-Id        | AICore(%)            Memory-Usage(MB)        HBM-Usage(MB)           |
++===========================+===============+======================================================================+
+| 0     910B2               | OK            | 424.0                64                      0    / 0                |
+| 0                         | 0000:C1:00.0  | 100                  0    / 0                38711/ 65536            |
++===========================+===============+======================================================================+
+| 1     910B2               | OK            | 93.6                 44                      0    / 0                |
+| 0                         | 0000:01:00.0  | 0                    0    / 0                3406 / 65536            |
++===========================+===============+======================================================================+
++---------------------------+---------------+----------------------------------------------------------------------+
+| NPU     Chip              | Process id    | Process name       | Process memory(MB)    | Process id in container |
++===========================+===============+======================================================================+
+| 0       0                 | 1504884       |                    | 35358                 | 412309                  |
++===========================+===============+======================================================================+
+| No running processes found in NPU 1                                                                              |
++===========================+===============+======================================================================+
+"""
+
+NPU_SMI_IDLE = """\
++------------------------------------------------------------------------------------------------------------------+
+| npu-smi 26.0.rc1                            Version: 26.0.rc1                                                    |
++---------------------------+---------------+----------------------------------------------------------------------+
+| NPU   Name                | Health        | Power(W)             Temp(C)                 Hugepages-Usage(page)   |
+| Chip                      | Bus-Id        | AICore(%)            Memory-Usage(MB)        HBM-Usage(MB)           |
++===========================+===============+======================================================================+
+| 0     910B2               | OK            | 424.0                64                      0    / 0                |
+| 0                         | 0000:C1:00.0  | 100                  0    / 0                38711/ 65536            |
++===========================+===============+======================================================================+
++---------------------------+---------------+----------------------------------------------------------------------+
+| NPU     Chip              | Process id    | Process name       | Process memory(MB)    | Process id in container |
++===========================+===============+======================================================================+
+| No running processes found in NPU 0                                                                              |
++===========================+===============+======================================================================+
+"""
+
+
+# === parse_npu_smi_processes ===
+
+
+def test_parse_npu_smi_processes_extracts_device_pid_pairs(module):
+    result = module.parse_npu_smi_processes(NPU_SMI_WITH_PROCESS, "0")
+    assert result == [(0, 1504884)]
+
+
+def test_parse_npu_smi_processes_returns_empty_for_idle_npu(module):
+    result = module.parse_npu_smi_processes(NPU_SMI_IDLE, "0")
+    assert result == []
+
+
+def test_parse_npu_smi_processes_filters_to_managed_devices(module):
+    result = module.parse_npu_smi_processes(NPU_SMI_WITH_PROCESS, "1")
+    assert result == []
+
+
+# === verify_npu_idle ===
+
+
+def test_verify_npu_idle_raises_when_occupied(module, monkeypatch):
+    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    with pytest.raises(RuntimeError, match="NPU devices 0 not idle"):
+        module.verify_npu_idle(devices="0", allow_busy=False, execute=True)
+
+
+def test_verify_npu_idle_passes_when_idle(module, monkeypatch):
+    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_IDLE)
+    module.verify_npu_idle(devices="0", allow_busy=False, execute=True)
+
+
+def test_verify_npu_idle_bypassed_with_allow_busy(module, monkeypatch):
+    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    module.verify_npu_idle(devices="0", allow_busy=True, execute=True)
+
+
+def test_verify_npu_idle_skipped_in_dry_run(module, monkeypatch):
+    monkeypatch.setattr(module.subprocess, "check_output", lambda *a, **kw: NPU_SMI_WITH_PROCESS)
+    module.verify_npu_idle(devices="0", allow_busy=False, execute=False)
+
+
+# === _HealthTimeoutError ===
+
+
+def test_health_timeout_error_carries_blocked_dir(module, tmp_path):
+    blocked = tmp_path / "blocked"
+    err = module._HealthTimeoutError("timeout", blocked_dir=blocked)
+    assert err.blocked_dir == blocked
+    assert "timeout" in str(err)
+
+
+def test_health_timeout_error_blocked_dir_defaults_none(module):
+    err = module._HealthTimeoutError("timeout")
+    assert err.blocked_dir is None
+
+
+# === capture_failure_diagnostics ===
+
+
+def test_capture_failure_diagnostics_writes_blocked_txt(module, target, spec, args, tmp_path):
+    blocked_dir = module.capture_failure_diagnostics(
+        target=target, spec=spec, args=args, error="test failure",
+        result_root=tmp_path, run_key="test-key", execute=False,
+    )
+    blocked_txt = blocked_dir / module.BLOCKED_MARKER_FILE
+    assert blocked_txt.exists()
+    content = blocked_txt.read_text(encoding="utf-8")
+    assert "blocked_at:" in content
+    assert "run_key: test-key" in content
+    assert "target_label: pr80-test" in content
+    assert "core_ref: ae16d09435" in content
+    assert "blocker_reason: test failure" in content
+    assert "Do NOT upload this directory as a submission artifact" in content
+
+
+def test_capture_failure_diagnostics_blocked_dir_under_benchmarks_not_submissions(
+    module, target, spec, args, tmp_path
+):
+    """Issue #97 item 4: BLOCKED.txt must NEVER live under submissions/."""
+    blocked_dir = module.capture_failure_diagnostics(
+        target=target, spec=spec, args=args, error="err",
+        result_root=tmp_path, run_key="k", execute=False,
+    )
+    blocked_str = str(blocked_dir)
+    assert "submissions" not in blocked_str
+    assert "blocked" in blocked_str
+
+
+def test_capture_failure_diagnostics_is_idempotent(module, target, spec, args, tmp_path):
+    """Calling twice for the same run_key doesn't fail."""
+    for _ in range(2):
+        module.capture_failure_diagnostics(
+            target=target, spec=spec, args=args, error="err",
+            result_root=tmp_path, run_key="dup", execute=False,
+        )
+    blocked_txt = (tmp_path / module.BLOCKED_DIR_NAME / "dup" / module.BLOCKED_MARKER_FILE)
+    assert blocked_txt.exists()
+
+
+def test_capture_failure_diagnostics_copies_state_file(module, target, spec, args, tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text('{"runs": {}}', encoding="utf-8")
+    blocked_dir = module.capture_failure_diagnostics(
+        target=target, spec=spec, args=args, error="err",
+        result_root=tmp_path, run_key="k", execute=False,
+        state_file=state_file,
+    )
+    assert (blocked_dir / "state.json").exists()
+    assert (blocked_dir / "state.json").read_text(encoding="utf-8") == '{"runs": {}}'
+
+
+def test_capture_failure_diagnostics_does_not_raise_on_subprocess_failure(
+    module, target, spec, args, tmp_path, monkeypatch
+):
+    """Issue #97: diagnostics capture must never mask the original error."""
+    def failing_run(*a, **kw):
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(module.subprocess, "run", failing_run)
+    blocked_dir = module.capture_failure_diagnostics(
+        target=target, spec=spec, args=args, error="original error",
+        result_root=tmp_path, run_key="k", execute=True,
+    )
+    assert (blocked_dir / module.BLOCKED_MARKER_FILE).exists()
+    assert (blocked_dir / "npu-smi.txt").read_text(encoding="utf-8").startswith("capture failed:")
+
+
+def test_capture_failure_diagnostics_captures_npu_smi_snapshot(
+    module, target, spec, args, tmp_path, monkeypatch
+):
+    def fake_run(cmd, **kw):
+        result = type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+        if "npu-smi" in cmd:
+            result.stdout = NPU_SMI_WITH_PROCESS
+        return result
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    blocked_dir = module.capture_failure_diagnostics(
+        target=target, spec=spec, args=args, error="err",
+        result_root=tmp_path, run_key="k", execute=True,
+    )
+    npu_snapshot = (blocked_dir / "npu-smi.txt").read_text(encoding="utf-8")
+    assert "910B2" in npu_snapshot
+    assert "1504884" in npu_snapshot
+
+
+# === force_cleanup_managed_server ===
+
+
+def test_force_cleanup_kills_npu_processes(module, args, monkeypatch):
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [(0, 99999)])
+    killed: list[int] = []
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: killed.append(pid))
+
+    report = module.force_cleanup_managed_server(args=args, execute=True)
+
+    assert 99999 in killed
+    assert 99999 in report["npu_procs_killed"]
+
+
+def test_force_cleanup_stops_systemd_unit(module, args, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    module.force_cleanup_managed_server(args=args, execute=True)
+
+    systemctl_calls = [c for c in calls if "systemctl" in c]
+    stop_calls = [c for c in systemctl_calls if "stop" in c]
+    reset_calls = [c for c in systemctl_calls if "reset-failed" in c]
+    assert len(stop_calls) == 1
+    assert "vllm-hust-test.service" in stop_calls[0]
+    assert len(reset_calls) == 1
+
+
+def test_force_cleanup_frees_port(module, args, monkeypatch):
+    def fake_run(cmd, **kw):
+        if isinstance(cmd, list) and "lsof" in " ".join(cmd):
+            return type("R", (), {"stdout": "12345\n", "stderr": "", "returncode": 0})()
+        if isinstance(cmd, str) and "lsof" in cmd:
+            return type("R", (), {"stdout": "12345\n", "stderr": "", "returncode": 0})()
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    killed: list[int] = []
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: killed.append(pid))
+
+    report = module.force_cleanup_managed_server(args=args, execute=True)
+
+    assert 12345 in killed
+    assert report["port_freed"] is True
+
+
+def test_force_cleanup_removes_docker_container(module, args, monkeypatch):
+    def fake_run(cmd, **kw):
+        if "docker" in cmd and "rm" in cmd:
+            return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    report = module.force_cleanup_managed_server(args=args, execute=True)
+
+    assert report["container_removed"] is True
+
+
+def test_force_cleanup_kills_stale_vllm_processes(module, args, monkeypatch):
+    def fake_run(cmd, **kw):
+        if isinstance(cmd, list) and "pgrep" in " ".join(cmd):
+            return type("R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0})()
+        if isinstance(cmd, str) and "pgrep" in cmd:
+            return type("R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0})()
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    killed: list[int] = []
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: killed.append(pid))
+
+    report = module.force_cleanup_managed_server(args=args, execute=True)
+
+    assert 111 in killed
+    assert 222 in killed
+    assert 111 in report["vllm_procs_killed"]
+    assert 222 in report["vllm_procs_killed"]
+
+
+def test_force_cleanup_returns_empty_report_in_dry_run(module, args):
+    report = module.force_cleanup_managed_server(args=args, execute=False)
+    assert report["container_removed"] is False
+    assert report["systemd_stopped"] is False
+    assert report["npu_procs_killed"] == []
+    assert report["port_freed"] is False
+    assert report["vllm_procs_killed"] == []
+
+
+def test_force_cleanup_writes_cleanup_log_to_blocked_dir(module, args, tmp_path, monkeypatch):
+    blocked_dir = tmp_path / "blocked" / "k"
+    blocked_dir.mkdir(parents=True)
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [(0, 99999)])
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: None)
+
+    module.force_cleanup_managed_server(args=args, execute=True, blocked_dir=blocked_dir)
+
+    log = (blocked_dir / "cleanup.log").read_text(encoding="utf-8")
+    assert "killed NPU process 99999" in log
+
+
+# === verify_cleanup_success ===
+
+
+def test_verify_cleanup_success_returns_warnings_for_npu_residuals(module, args, monkeypatch):
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [(0, 88888)])
+    warnings = module.verify_cleanup_success(args=args, execute=True)
+    assert any("residual NPU processes" in w for w in warnings)
+    assert any("88888" in w for w in warnings)
+
+
+def test_verify_cleanup_success_returns_empty_when_clean(module, args, monkeypatch):
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+
+    def fake_run(cmd, **kw):
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    warnings = module.verify_cleanup_success(args=args, execute=True)
+    assert warnings == []
+
+
+def test_verify_cleanup_success_returns_empty_in_dry_run(module, args):
+    warnings = module.verify_cleanup_success(args=args, execute=False)
+    assert warnings == []
+
+
+def test_verify_cleanup_success_warns_on_active_systemd(module, args, monkeypatch):
+    def fake_run(cmd, **kw):
+        if "is-active" in cmd:
+            return type("R", (), {"stdout": "active\n", "stderr": "", "returncode": 0})()
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    warnings = module.verify_cleanup_success(args=args, execute=True)
+    assert any("vllm-hust-test.service" in w and "active" in w for w in warnings)
+
+
+def test_verify_cleanup_success_warns_on_port_in_use(module, args, monkeypatch):
+    def fake_run(cmd, **kw):
+        if isinstance(cmd, list) and "lsof" in " ".join(cmd):
+            return type("R", (), {"stdout": "54321\n", "stderr": "", "returncode": 0})()
+        if isinstance(cmd, str) and "lsof" in cmd:
+            return type("R", (), {"stdout": "54321\n", "stderr": "", "returncode": 0})()
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    warnings = module.verify_cleanup_success(args=args, execute=True)
+    assert any("8420" in w and "54321" in w for w in warnings)
+
+
+# === CLI flags ===
+
+
+def test_cli_flags_exist(module, monkeypatch):
+    """Issue #97: --allow-busy-npu and --skip-defensive-cleanup must be available."""
+    monkeypatch.setattr(sys, "argv", ["backfill_historical_pr_benchmarks.py"])
+    args = module.parse_args()
+    assert args.allow_busy_npu is False
+    assert args.skip_defensive_cleanup is False
+
+
+# === to_container_workspace_path (issue #97: env-var-driven host workspace root) ===
+
+
+def test_to_container_workspace_path_defaults_to_home_shuhao(module, monkeypatch):
+    monkeypatch.delenv("VLLM_HUST_HOST_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("VLLM_HUST_CONTAINER_WORKSPACE_ROOT", raising=False)
+    result = module.to_container_workspace_path(Path("/home/shuhao/vllm-hust"))
+    assert result == "/workspace/vllm-hust"
+
+
+def test_to_container_workspace_path_uses_env_var_for_custom_root(module, monkeypatch):
+    monkeypatch.setenv("VLLM_HUST_HOST_WORKSPACE_ROOT", "/root/vllm")
+    monkeypatch.delenv("VLLM_HUST_CONTAINER_WORKSPACE_ROOT", raising=False)
+    result = module.to_container_workspace_path(Path("/root/vllm/vllm-hust"))
+    assert result == "/workspace/vllm-hust"
+
+
+def test_to_container_workspace_path_returns_raw_path_when_outside_root(
+    module, monkeypatch
+):
+    monkeypatch.setenv("VLLM_HUST_HOST_WORKSPACE_ROOT", "/root/vllm")
+    result = module.to_container_workspace_path(Path("/opt/other/repo"))
+    assert result == "/opt/other/repo"
+
+
+def test_require_container_workspace_path_raises_when_outside_root(
+    module, monkeypatch
+):
+    monkeypatch.setenv("VLLM_HUST_HOST_WORKSPACE_ROOT", "/root/vllm")
+    with pytest.raises(RuntimeError, match="does not map into the dev-hub"):
+        module.require_container_workspace_path(
+            Path("/opt/other/repo"), purpose="core worktree"
+        )

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -462,3 +462,40 @@ def test_require_container_workspace_path_raises_when_outside_root(
         module.require_container_workspace_path(
             Path("/opt/other/repo"), purpose="core worktree"
         )
+
+
+# === resolve_manage_script (issue #97: in-container launcher support) ===
+
+
+def test_resolve_manage_script_defaults_to_manage_sh(module, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["backfill_historical_pr_benchmarks.py"])
+    args = module.parse_args()
+    args.dev_hub_dir = "/home/shuhao/vllm-hust-dev-hub"
+    result = module.resolve_manage_script(args)
+    assert result.name == "manage.sh"
+    assert result.parent == Path("/home/shuhao/vllm-hust-dev-hub").resolve()
+
+
+def test_resolve_manage_script_supports_container_launcher(module, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "backfill_historical_pr_benchmarks.py",
+            "--manage-script",
+            "scripts/manage-container.sh",
+            "--dev-hub-dir",
+            "/root/vllm/vllm-hust-dev-hub",
+        ],
+    )
+    args = module.parse_args()
+    result = module.resolve_manage_script(args)
+    assert result.name == "manage-container.sh"
+    assert result.parent.name == "scripts"
+    assert result.parent.parent.name == "vllm-hust-dev-hub"
+
+
+def test_manage_script_flag_defaults_to_manage_sh(module, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["backfill_historical_pr_benchmarks.py"])
+    args = module.parse_args()
+    assert args.manage_script == "manage.sh"

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -499,3 +499,23 @@ def test_manage_script_flag_defaults_to_manage_sh(module, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["backfill_historical_pr_benchmarks.py"])
     args = module.parse_args()
     assert args.manage_script == "manage.sh"
+
+
+# === find_local_model_path env var override (issue #97) ===
+
+
+def test_find_local_model_path_uses_env_var_override(module, monkeypatch, tmp_path):
+    monkeypatch.delenv("VLLM_HUST_LOCAL_MODEL_PATH", raising=False)
+    custom = tmp_path / "my-model"
+    custom.mkdir()
+    monkeypatch.setenv("VLLM_HUST_LOCAL_MODEL_PATH", str(custom))
+    result = module.find_local_model_path("Qwen/Qwen2.5-14B-Instruct")
+    assert result == str(custom)
+
+
+def test_find_local_model_path_env_var_returns_none_when_path_missing(
+    module, monkeypatch
+):
+    monkeypatch.setenv("VLLM_HUST_LOCAL_MODEL_PATH", "/nonexistent/path/12345")
+    result = module.find_local_model_path("Qwen/Qwen2.5-14B-Instruct")
+    assert result is None

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -464,6 +464,27 @@ def test_require_container_workspace_path_raises_when_outside_root(
         )
 
 
+def test_require_container_workspace_path_in_container_returns_real_path(module):
+    """Issue #97: in-container mode must use the real filesystem path."""
+    real = Path("/root/vllm/vllm-hust-benchmark/.benchmarks/worktrees/core")
+    result = module.require_container_workspace_path(
+        real, purpose="core worktree", in_container=True
+    )
+    assert result == str(real.resolve())
+    assert not result.startswith("/workspace/")
+
+
+def test_require_container_workspace_path_in_container_skips_workspace_check(
+    module, monkeypatch
+):
+    """in_container=True bypasses the /workspace/ prefix requirement."""
+    monkeypatch.setenv("VLLM_HUST_HOST_WORKSPACE_ROOT", "/home/shuhao")
+    result = module.require_container_workspace_path(
+        Path("/opt/arbitrary/path"), purpose="plugin worktree", in_container=True
+    )
+    assert result == "/opt/arbitrary/path"
+
+
 # === resolve_manage_script (issue #97: in-container launcher support) ===
 
 

--- a/tests/test_backfill_diagnostics_and_cleanup.py
+++ b/tests/test_backfill_diagnostics_and_cleanup.py
@@ -375,38 +375,12 @@ def test_force_cleanup_removes_docker_container(module, args, monkeypatch):
     assert report["container_removed"] is True
 
 
-def test_force_cleanup_kills_stale_vllm_processes(module, args, monkeypatch):
-    def fake_run(cmd, **kw):
-        if isinstance(cmd, list) and "pgrep" in " ".join(cmd):
-            return type(
-                "R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0}
-            )()
-        if isinstance(cmd, str) and "pgrep" in cmd:
-            return type(
-                "R", (), {"stdout": "111\n222\n", "stderr": "", "returncode": 0}
-            )()
-        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
-
-    killed: list[int] = []
-    monkeypatch.setattr(module, "detect_npu_processes", lambda devices: [])
-    monkeypatch.setattr(module.subprocess, "run", fake_run)
-    monkeypatch.setattr(module.os, "kill", lambda pid, sig: killed.append(pid))
-
-    report = module.force_cleanup_managed_server(args=args, execute=True)
-
-    assert 111 in killed
-    assert 222 in killed
-    assert 111 in report["vllm_procs_killed"]
-    assert 222 in report["vllm_procs_killed"]
-
-
 def test_force_cleanup_returns_empty_report_in_dry_run(module, args):
     report = module.force_cleanup_managed_server(args=args, execute=False)
     assert report["container_removed"] is False
     assert report["systemd_stopped"] is False
     assert report["npu_procs_killed"] == []
     assert report["port_freed"] is False
-    assert report["vllm_procs_killed"] == []
 
 
 def test_force_cleanup_writes_cleanup_log_to_blocked_dir(


### PR DESCRIPTION
## Summary

Closes #97 — implements startup diagnostics and failure-path hardening for the historical PR backfill pipeline, then runs a real PR#80 diagnosis on the server to identify its root cause.

## What this changes

### 1. Failure diagnostics capture (`capture_failure_diagnostics`)
- On startup failure (health-check timeout or run exception), captures a **BLOCKED.txt bundle** under `.benchmarks/historical-pr-backfill/blocked/<run_key>/` (never under `submissions/`).
- Bundle includes: `engine.log`, `npu-smi.txt`, `docker-ps.txt`, `systemctl status`, `state.json` snapshot, and a human-readable `BLOCKED.txt` marker with `blocked_at`, `run_key`, `target_label`, `core_ref`, `blocker_reason`.
- Capture is best-effort: subprocess failures during capture never mask the original error.

### 2. Defensive cleanup (`force_cleanup_managed_server` + `verify_cleanup_success`)
- After a blocked run, kills residual NPU processes, stops/reset-fails the systemd unit, frees the bound port, and removes the managed container.
- `verify_cleanup_success` asserts no residual containers, systemd units, NPU processes, or ports remain.
- New CLI flags: `--allow-busy-npu` (debug only) and `--skip-defensive-cleanup` (debug only).

### 3. Pre-flight NPU check (`verify_npu_idle`)
- Before starting the managed server, asserts the target NPU devices are idle (no processes, low HBM usage).
- Prevents starting on an occupied NPU, which was the root cause of residual `VLLMEngineCore` processes in earlier failures.

### 4. In-container launcher support
- New `--manage-script` flag selects between `manage.sh` (docker, default) and `manage-container.sh` (host-container mode where the server itself runs inside a container).
- `require_container_workspace_path` gains an `in_container` parameter to bypass the `/workspace/` prefix check in host-container mode (paths are real filesystem paths, not remapped mounts).
- In-container mode sets `PYTHONPATH` directly, because `manage-container.sh` does not translate `VLLM_ENGINE_PYTHONPATH` the way the docker entrypoint does.
- New `VLLM_HUST_LOCAL_MODEL_PATH` env var overrides the default model path.

### 5. `_HealthTimeoutError`
- Custom exception carrying the `blocked_dir` so the outer handler records it in the state file without re-capturing.

## PR#80 diagnosis result (server-side execution)

Ran the full pipeline against PR#80 commit `ae16d09435` (core) + `a05a9efe54` (plugin) on `vllm-hust-cyj-21rc-cloud` using `manage-container.sh` on NPU1.

**Root cause: circular import regression in vLLM core.**

PR#80 introduces `vllm/entrypoints/cli/openai.py`, which shadows the pip `openai` package. `vllm/entrypoints/mcp/tool.py` imports `from openai.types.responses...`, which resolves to the new `openai.py`, which in turn does `from openai import OpenAI` → circular import. The engine core subprocess crashes during import, the 600s health check times out, and the run is recorded as `blocked`.

Verified against the installed `main` version: neither `mcp/tool.py` nor `cli/openai.py` exists, confirming this is a PR#80-specific regression, not a script or configuration problem.

### Diagnostics & cleanup verification
| Check | Result |
|---|---|
| BLOCKED.txt bundle captured | ✅ engine.log, npu-smi.txt, state.json, etc. |
| Port 8420 freed | ✅ free |
| Residual vllm processes | ✅ none |
| manage-container status | ✅ stopped |
| submissions/ untouched | ✅ no half-baked artifact uploaded |
| state.json records blocked_dir | ✅ |

## Tests

- 39 new unit tests in `tests/test_backfill_diagnostics_and_cleanup.py` covering `parse_npu_smi_processes`, `verify_npu_idle`, `_HealthTimeoutError`, `capture_failure_diagnostics`, `force_cleanup_managed_server`, `verify_cleanup_success`, in-container path mapping, and CLI flags.
- All existing tests still pass.
- `ruff check` and `ruff format` clean.

## Files

- `scripts/backfill_historical_pr_benchmarks.py` — diagnostics, cleanup, pre-flight, in-container support.
- `tests/test_backfill_diagnostics_and_cleanup.py` — new test file.
- `docs/HISTORICAL_PR_BACKFILL.md` — documents the failure-path contract.
