### PR TITLE
infra: enforce watchdog ownership for Docker NPU jobs

### DIFF
--- a/docs/RUNNER_DOCKER_OWNERSHIP.md
+++ b/docs/RUNNER_DOCKER_OWNERSHIP.md
@@ -24,6 +24,20 @@ python scripts/run-watchdog-owned-npu-container.py \
 - `ASCEND_RT_VISIBLE_DEVICES`
 - `ASCEND_VISIBLE_DEVICES`
 
+### Volume / mount 约束
+
+Volume 入口若不约束，可以通过 `--volume /dev:/dev` 或 `--volume /:/host` 绕过单卡容器的设备隔离。启动脚本和
+`validate_container_inspect` 双层校验所有 volume：
+
+- **宿主机源路径黑名单**：禁止 bind-mount
+  `/`、`/dev`、`/dev/davinci*`、`/sys`、`/proc`、`/var/run/docker.sock`、`/usr/local/Ascend`、`/etc/dcmi*`
+  等路径，这些路径会暴露宿主机设备节点、NPU 驱动 sysfs 或 Docker socket，从而绕过隔离。
+- **容器目标路径白名单**：只允许挂载到 `/workspace`、`/tmp`、`/data`、`/root/.cache`、`/home`、`/opt/models` 及其子目录。
+- **禁止危险选项**：`shared`/`slave` propagation、privileged 模式、`SYS_ADMIN`/`SYS_PTRACE`/`SYS_MODULE`
+  capabilities 均被拒绝。
+- **Docker inspect 双重校验**：`validate_container_inspect` 同时检查 `Mounts` 数组和旧式 `HostConfig.Binds`
+  列表，确保运行时配置与构建时一致。
+
 `job.container` 目前无法通过该脚本完成创建前校验。在 GitHub Actions 能可靠写入 上述 label 和设备映射以前，不得把 `job.container` 作业调度到
 `linux-aarch64-a2b3-pool`。
 

--- a/docs/RUNNER_DOCKER_OWNERSHIP.md
+++ b/docs/RUNNER_DOCKER_OWNERSHIP.md
@@ -1,0 +1,30 @@
+# Docker NPU 作业归属契约
+
+poy-180 的 GitHub Actions runner 使用 `poy-180-21rc-npu0` 至 `poy-180-21rc-npu3` 四个名称。通过宿主机 Docker
+socket 启动的容器必须显式携带 runner 归属，否则 watchdog 会把其中的 NPU 进程视为无主进程。
+
+统一使用 `scripts/run-watchdog-owned-npu-container.py` 启动这类作业：
+
+```bash
+python scripts/run-watchdog-owned-npu-container.py \
+  --name "benchmark-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+  --image quay.io/ascend/vllm-ascend:21rc \
+  --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+  -- python /workspace/run_benchmark.py
+```
+
+脚本从 `RUNNER_NAME` 解析物理卡，只把对应的 `/dev/davinciN` 映射为容器内 `/dev/davinci0`，并固定
+`ASCEND_RT_VISIBLE_DEVICES=0`。创建后会读取 Docker inspect，核验 runner label、物理卡 label、设备映射和逻辑设备环境，再启动容器。
+
+作业不得自行覆盖以下字段：
+
+- `org.vllm-hust.runner`
+- `org.vllm-hust.npu-physical`
+- `org.vllm-hust.npu-logical`
+- `ASCEND_RT_VISIBLE_DEVICES`
+- `ASCEND_VISIBLE_DEVICES`
+
+`job.container` 目前无法通过该脚本完成创建前校验。在 GitHub Actions 能可靠写入 上述 label 和设备映射以前，不得把 `job.container` 作业调度到
+`linux-aarch64-a2b3-pool`。
+
+代码合并前仍需在真实 runner 上分别验证成功、失败和取消路径，并确认两轮 watchdog 扫描后正确标记的容器仍存活；错误 label 或错误设备映射的告警记录在 #125。

--- a/scripts/run-watchdog-owned-npu-container.py
+++ b/scripts/run-watchdog-owned-npu-container.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+
+from vllm_hust_benchmark.runner_ownership import (
+    build_docker_create_command,
+    resolve_runner_device,
+    validate_container_inspect,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run one watchdog-owned NPU container from a poy-180 runner."
+    )
+    parser.add_argument("--runner-name", default=os.environ.get("RUNNER_NAME", ""))
+    parser.add_argument("--name", required=True, help="Unique Docker container name")
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--volume", action="append", default=[])
+    parser.add_argument("--env", action="append", default=[])
+    parser.add_argument("--keep-container", action="store_true")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    try:
+        assignment = resolve_runner_device(args.runner_name)
+        create_command = build_docker_create_command(
+            assignment=assignment,
+            container_name=args.name,
+            image=args.image,
+            command=command,
+            volumes=args.volume,
+            extra_env=args.env,
+        )
+    except ValueError as exc:
+        print(f"preflight failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        "runner ownership: "
+        f"runner={assignment.runner_name} "
+        f"physical={assignment.physical_device} "
+        f"container-logical={assignment.logical_device}"
+    )
+    container_id = ""
+    try:
+        created = subprocess.run(
+            create_command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        container_id = created.stdout.strip()
+        if not container_id:
+            raise RuntimeError("docker create returned an empty container ID")
+
+        inspected = subprocess.run(
+            ["docker", "inspect", container_id],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(inspected.stdout)
+        if len(payload) != 1:
+            raise RuntimeError("docker inspect did not return exactly one container")
+        validate_container_inspect(payload[0], assignment)
+        print("watchdog ownership preflight: ok")
+
+        subprocess.run(["docker", "start", container_id], check=True)
+        wait_result = subprocess.run(
+            ["docker", "wait", container_id],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(["docker", "logs", container_id], check=False)
+        return int(wait_result.stdout.strip())
+    except (
+        json.JSONDecodeError,
+        OSError,
+        RuntimeError,
+        ValueError,
+        subprocess.CalledProcessError,
+    ) as exc:
+        print(f"container execution failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if container_id and not args.keep_container:
+            subprocess.run(
+                ["docker", "rm", "--force", container_id],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/src/vllm_hust_benchmark/runner_ownership.py
+++ b/src/vllm_hust_benchmark/runner_ownership.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+RUNNER_LABEL = "org.vllm-hust.runner"
+PHYSICAL_DEVICE_LABEL = "org.vllm-hust.npu-physical"
+LOGICAL_DEVICE_LABEL = "org.vllm-hust.npu-logical"
+RUNNER_PATTERN = re.compile(r"^.+-npu(?P<device>[0-3])$")
+CONTROL_DEVICES = (
+    "/dev/davinci_manager",
+    "/dev/devmm_svm",
+    "/dev/hisi_hdc",
+)
+RESERVED_ENV_NAMES = {
+    "ASCEND_RT_VISIBLE_DEVICES",
+    "ASCEND_VISIBLE_DEVICES",
+}
+
+
+@dataclass(frozen=True)
+class RunnerDeviceAssignment:
+    runner_name: str
+    physical_device: int
+    logical_device: int = 0
+
+    @property
+    def host_device_path(self) -> str:
+        return f"/dev/davinci{self.physical_device}"
+
+    @property
+    def container_device_path(self) -> str:
+        return f"/dev/davinci{self.logical_device}"
+
+
+def resolve_runner_device(runner_name: str) -> RunnerDeviceAssignment:
+    normalized = runner_name.strip()
+    match = RUNNER_PATTERN.fullmatch(normalized)
+    if match is None:
+        raise ValueError(
+            f"runner name must end in npu0, npu1, npu2, or npu3; got {runner_name!r}"
+        )
+    return RunnerDeviceAssignment(
+        runner_name=normalized,
+        physical_device=int(match.group("device")),
+    )
+
+
+def _validate_extra_env(extra_env: Iterable[str]) -> list[str]:
+    validated: list[str] = []
+    for item in extra_env:
+        name, separator, _ = item.partition("=")
+        if not separator or not name:
+            raise ValueError(f"container environment must use NAME=value: {item!r}")
+        if name in RESERVED_ENV_NAMES:
+            raise ValueError(f"container environment {name} is managed by the launcher")
+        validated.append(item)
+    return validated
+
+
+def build_docker_create_command(
+    *,
+    assignment: RunnerDeviceAssignment,
+    container_name: str,
+    image: str,
+    command: Sequence[str],
+    volumes: Iterable[str] = (),
+    extra_env: Iterable[str] = (),
+    docker_bin: str = "docker",
+) -> list[str]:
+    if not container_name.strip():
+        raise ValueError("container name is required")
+    if not image.strip():
+        raise ValueError("container image is required")
+
+    docker_command = [
+        docker_bin,
+        "create",
+        "--name",
+        container_name,
+        "--label",
+        f"{RUNNER_LABEL}={assignment.runner_name}",
+        "--label",
+        f"{PHYSICAL_DEVICE_LABEL}={assignment.physical_device}",
+        "--label",
+        f"{LOGICAL_DEVICE_LABEL}={assignment.logical_device}",
+        "--device",
+        f"{assignment.host_device_path}:{assignment.container_device_path}",
+    ]
+    for device in CONTROL_DEVICES:
+        docker_command.extend(("--device", f"{device}:{device}"))
+    docker_command.extend(
+        ("--env", f"ASCEND_RT_VISIBLE_DEVICES={assignment.logical_device}")
+    )
+    docker_command.extend(
+        ("--env", f"ASCEND_VISIBLE_DEVICES={assignment.logical_device}")
+    )
+    for volume in volumes:
+        docker_command.extend(("--volume", volume))
+    for environment in _validate_extra_env(extra_env):
+        docker_command.extend(("--env", environment))
+    docker_command.append(image)
+    docker_command.extend(command)
+    return docker_command
+
+
+def validate_container_inspect(
+    inspect_payload: Mapping[str, Any], assignment: RunnerDeviceAssignment
+) -> None:
+    config = inspect_payload.get("Config") or {}
+    labels = config.get("Labels") or {}
+    expected_labels = {
+        RUNNER_LABEL: assignment.runner_name,
+        PHYSICAL_DEVICE_LABEL: str(assignment.physical_device),
+        LOGICAL_DEVICE_LABEL: str(assignment.logical_device),
+    }
+    for name, expected in expected_labels.items():
+        actual = labels.get(name)
+        if actual != expected:
+            raise ValueError(
+                f"container label {name}={actual!r}, expected {expected!r}"
+            )
+
+    devices = (inspect_payload.get("HostConfig") or {}).get("Devices") or []
+    mapped_devices = {
+        (device.get("PathOnHost"), device.get("PathInContainer")) for device in devices
+    }
+    expected_mapping = (
+        assignment.host_device_path,
+        assignment.container_device_path,
+    )
+    if expected_mapping not in mapped_devices:
+        raise ValueError(
+            "container NPU mapping is missing or incorrect: "
+            f"expected {expected_mapping[0]} -> {expected_mapping[1]}"
+        )
+
+    environment = config.get("Env") or []
+    expected_environment = {
+        f"ASCEND_RT_VISIBLE_DEVICES={assignment.logical_device}",
+        f"ASCEND_VISIBLE_DEVICES={assignment.logical_device}",
+    }
+    missing_environment = expected_environment.difference(environment)
+    if missing_environment:
+        raise ValueError(
+            "container logical-device environment is incomplete: "
+            + ", ".join(sorted(missing_environment))
+        )

--- a/src/vllm_hust_benchmark/runner_ownership.py
+++ b/src/vllm_hust_benchmark/runner_ownership.py
@@ -19,6 +19,105 @@ RESERVED_ENV_NAMES = {
     "ASCEND_VISIBLE_DEVICES",
 }
 
+# Host paths that must never be bind-mounted into a container, because doing
+# so would bypass single-card NPU device isolation or expose host resources.
+FORBIDDEN_HOST_PATH_PATTERNS = (
+    re.compile(r"^/+$"),  # root filesystem
+    re.compile(r"^/dev/?$"),  # /dev exposes all device nodes
+    re.compile(r"^/dev/davinci\d+$"),  # NPU device nodes
+    re.compile(r"^/dev/davinci_manager$"),  # NPU management device
+    re.compile(r"^/dev/devmm_svm$"),  # NPU memory management device
+    re.compile(r"^/dev/hisi_hdc$"),  # NPU debug device
+    re.compile(r"^/sys/?$"),  # sysfs (NPU driver sysfs)
+    re.compile(r"^/sys/class/devdrv.*"),  # NPU driver sysfs entries
+    re.compile(r"^/proc/?$"),  # procfs
+    re.compile(r"^/(var/)?run/docker\.sock$"),  # Docker socket (container escape)
+    re.compile(r"^/usr/local/Ascend/?$"),  # CANN installation
+    re.compile(r"^/usr/local/slog/?$"),  # NPU log directory
+    re.compile(r"^/etc/dcmi.*"),  # NPU DCMI configuration
+)
+
+# Container destinations allowed for bind mounts. Keeps the attack surface
+# small by only permitting work-related paths inside the container.
+ALLOWED_CONTAINER_DESTINATIONS = (
+    "/workspace",
+    "/tmp",
+    "/data",
+    "/root/.cache",
+    "/home",
+    "/opt/models",
+)
+
+# Mount options that weaken isolation.
+FORBIDDEN_MOUNT_OPTIONS = {"shared", "slave"}
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize a POSIX path for comparison (strip trailing slash)."""
+    if path == "/":
+        return "/"
+    return path.rstrip("/")
+
+
+def _is_forbidden_host_path(host_path: str) -> bool:
+    """Return True if bind-mounting host_path would bypass isolation."""
+    normalized = _normalize_path(host_path)
+    return any(pattern.match(normalized) for pattern in FORBIDDEN_HOST_PATH_PATTERNS)
+
+
+def _is_allowed_container_destination(container_path: str) -> bool:
+    """Return True if container_path is an allowed mount destination."""
+    normalized = _normalize_path(container_path)
+    for allowed in ALLOWED_CONTAINER_DESTINATIONS:
+        allowed_norm = _normalize_path(allowed)
+        if normalized == allowed_norm or normalized.startswith(allowed_norm + "/"):
+            return True
+    return False
+
+
+def _validate_volume_spec(volume_spec: str) -> None:
+    """Validate a Docker volume spec before it reaches docker create.
+
+    Format: [HOST_PATH:]CONTAINER_PATH[:OPTIONS].
+
+    Raises ValueError when the spec would bypass single-card device isolation
+    or mount into a non-allowlisted container path.
+    """
+    parts = volume_spec.split(":")
+    if len(parts) == 1:
+        # Anonymous volume (container path only, Docker-managed) — safe.
+        return
+    if len(parts) not in (2, 3):
+        raise ValueError(
+            f"invalid volume spec (expected 1-3 colon-separated parts): {volume_spec!r}"
+        )
+    host_path, container_path = parts[0], parts[1]
+    options = parts[2] if len(parts) == 3 else ""
+
+    # A leading "/" marks a bind mount (host path). Named volumes (e.g.
+    # "my_vol:/workspace") are Docker-managed and safe.
+    if host_path.startswith("/"):
+        if _is_forbidden_host_path(host_path):
+            raise ValueError(
+                f"forbidden host path in volume spec {volume_spec!r}: "
+                f"mounting {host_path!r} would bypass device isolation or "
+                f"expose host resources; use --device for device access"
+            )
+
+    if not _is_allowed_container_destination(container_path):
+        raise ValueError(
+            f"forbidden container destination in volume spec {volume_spec!r}: "
+            f"only {ALLOWED_CONTAINER_DESTINATIONS} are allowed, "
+            f"got {container_path!r}"
+        )
+
+    if options:
+        for opt in options.split(","):
+            if opt.strip() in FORBIDDEN_MOUNT_OPTIONS:
+                raise ValueError(
+                    f"forbidden mount option in volume spec {volume_spec!r}: {opt!r}"
+                )
+
 
 @dataclass(frozen=True)
 class RunnerDeviceAssignment:
@@ -98,12 +197,45 @@ def build_docker_create_command(
         ("--env", f"ASCEND_VISIBLE_DEVICES={assignment.logical_device}")
     )
     for volume in volumes:
+        _validate_volume_spec(volume)
         docker_command.extend(("--volume", volume))
     for environment in _validate_extra_env(extra_env):
         docker_command.extend(("--env", environment))
     docker_command.append(image)
     docker_command.extend(command)
     return docker_command
+
+
+def _validate_mount_entry(mount: Mapping[str, Any]) -> None:
+    """Validate a single Mounts entry from docker inspect."""
+    mount_type = mount.get("Type", "")
+    # tmpfs mounts have no host source and are safe.
+    if mount_type == "tmpfs":
+        return
+
+    source = mount.get("Source", "")
+    destination = mount.get("Destination", "")
+    propagation = mount.get("Propagation", "")
+
+    if mount_type == "bind" and source.startswith("/"):
+        if _is_forbidden_host_path(source):
+            raise ValueError(
+                f"forbidden bind mount source {source!r} -> {destination!r}: "
+                f"this path would bypass NPU device isolation; "
+                f"use --device for device access"
+            )
+
+    if destination and not _is_allowed_container_destination(destination):
+        raise ValueError(
+            f"forbidden mount destination {destination!r}: "
+            f"only {ALLOWED_CONTAINER_DESTINATIONS} are allowed"
+        )
+
+    if propagation in FORBIDDEN_MOUNT_OPTIONS:
+        raise ValueError(
+            f"forbidden mount propagation {propagation!r} for "
+            f"{source!r} -> {destination!r}"
+        )
 
 
 def validate_container_inspect(
@@ -123,7 +255,30 @@ def validate_container_inspect(
                 f"container label {name}={actual!r}, expected {expected!r}"
             )
 
-    devices = (inspect_payload.get("HostConfig") or {}).get("Devices") or []
+    host_config = inspect_payload.get("HostConfig") or {}
+
+    # Reject bind mounts that would bypass device isolation. Docker inspect
+    # exposes both the modern Mounts array and the legacy Binds list.
+    mounts = inspect_payload.get("Mounts") or []
+    for mount in mounts:
+        _validate_mount_entry(mount)
+
+    binds = host_config.get("Binds") or []
+    for bind_spec in binds:
+        _validate_volume_spec(bind_spec)
+
+    # Privileged mode and dangerous capabilities bypass all isolation.
+    if host_config.get("Privileged"):
+        raise ValueError("container must not run in privileged mode")
+    cap_add = host_config.get("CapAdd") or []
+    dangerous_caps = {"SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE"}
+    present = dangerous_caps.intersection(cap_add)
+    if present:
+        raise ValueError(
+            f"container must not have dangerous capabilities: {sorted(present)}"
+        )
+
+    devices = host_config.get("Devices") or []
     mapped_devices = {
         (device.get("PathOnHost"), device.get("PathInContainer")) for device in devices
     }

--- a/tests/test_runner_ownership.py
+++ b/tests/test_runner_ownership.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_hust_benchmark.runner_ownership import (
+    LOGICAL_DEVICE_LABEL,
+    PHYSICAL_DEVICE_LABEL,
+    RUNNER_LABEL,
+    build_docker_create_command,
+    resolve_runner_device,
+    validate_container_inspect,
+)
+
+
+def _inspect_payload(runner_name: str, physical_device: int) -> dict:
+    return {
+        "Config": {
+            "Labels": {
+                RUNNER_LABEL: runner_name,
+                PHYSICAL_DEVICE_LABEL: str(physical_device),
+                LOGICAL_DEVICE_LABEL: "0",
+            },
+            "Env": ["ASCEND_RT_VISIBLE_DEVICES=0", "ASCEND_VISIBLE_DEVICES=0"],
+        },
+        "HostConfig": {
+            "Devices": [
+                {
+                    "PathOnHost": f"/dev/davinci{physical_device}",
+                    "PathInContainer": "/dev/davinci0",
+                }
+            ]
+        },
+    }
+
+
+@pytest.mark.parametrize("physical_device", range(4))
+def test_resolve_runner_device(physical_device: int) -> None:
+    assignment = resolve_runner_device(f"poy-180-21rc-npu{physical_device}")
+    assert assignment.physical_device == physical_device
+    assert assignment.logical_device == 0
+
+
+@pytest.mark.parametrize("runner_name", ["", "npu4", "poy-180", "npu-2"])
+def test_resolve_runner_device_rejects_unknown_runner(runner_name: str) -> None:
+    with pytest.raises(ValueError, match="runner name must end"):
+        resolve_runner_device(runner_name)
+
+
+def test_docker_command_carries_watchdog_contract() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu2")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=["python", "run.py"],
+        volumes=["/workspace:/workspace:ro"],
+        extra_env=["BENCHMARK_SCENARIO=sharegpt-online"],  # pragma: allowlist secret
+    )
+    joined = " ".join(command)
+    assert "org.vllm-hust.runner=poy-180-21rc-npu2" in joined
+    assert "org.vllm-hust.npu-physical=2" in joined
+    assert "/dev/davinci2:/dev/davinci0" in joined
+    assert "ASCEND_RT_VISIBLE_DEVICES=0" in joined
+    assert command[-3:] == ["example/ascend:latest", "python", "run.py"]
+
+
+def test_docker_command_rejects_logical_device_override() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="managed by the launcher"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            extra_env=["ASCEND_RT_VISIBLE_DEVICES=3"],
+        )
+
+
+def test_validate_container_inspect_accepts_matching_contract() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu3")
+    validate_container_inspect(_inspect_payload(assignment.runner_name, 3), assignment)
+
+
+def test_validate_container_inspect_rejects_wrong_device() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu3")
+    payload = _inspect_payload(assignment.runner_name, 3)
+    payload["HostConfig"]["Devices"][0]["PathOnHost"] = "/dev/davinci2"
+    with pytest.raises(ValueError, match="mapping is missing or incorrect"):
+        validate_container_inspect(payload, assignment)

--- a/tests/test_runner_ownership.py
+++ b/tests/test_runner_ownership.py
@@ -87,3 +87,191 @@ def test_validate_container_inspect_rejects_wrong_device() -> None:
     payload["HostConfig"]["Devices"][0]["PathOnHost"] = "/dev/davinci2"
     with pytest.raises(ValueError, match="mapping is missing or incorrect"):
         validate_container_inspect(payload, assignment)
+
+
+# --- mount constraint tests (issue #127 review feedback) ---
+
+
+@pytest.mark.parametrize(
+    "volume_spec",
+    [
+        "/dev:/dev",  # exposes all device nodes
+        "/dev/davinci1:/dev/davinci1",  # bypasses single-card isolation
+        "/:/host",  # exposes host root filesystem
+        "/sys:/sys",  # exposes NPU driver sysfs
+        "/var/run/docker.sock:/var/run/docker.sock",  # container escape
+        "/usr/local/Ascend:/usr/local/Ascend",  # exposes CANN stack
+    ],
+)
+def test_docker_command_rejects_bypass_volume(volume_spec: str) -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="forbidden host path"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=[volume_spec],
+        )
+
+
+@pytest.mark.parametrize(
+    "volume_spec",
+    [
+        "/host/data:/etc",  # non-allowlisted destination
+        "/host/data:/usr/bin",  # non-allowlisted destination
+    ],
+)
+def test_docker_command_rejects_non_allowlisted_destination(volume_spec: str) -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="forbidden container destination"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=[volume_spec],
+        )
+
+
+def test_docker_command_rejects_invalid_volume_format() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="invalid volume spec"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=["a:b:c:d"],
+        )
+
+
+def test_docker_command_accepts_workspace_volume() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["/host/ws:/workspace", "/host/cache:/root/.cache"],
+    )
+    joined = " ".join(command)
+    assert "/host/ws:/workspace" in joined
+    assert "/host/cache:/root/.cache" in joined
+
+
+def test_docker_command_accepts_named_and_anonymous_volumes() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["my_vol:/workspace", "/tmp"],
+    )
+    joined = " ".join(command)
+    assert "my_vol:/workspace" in joined
+    assert "/tmp" in joined
+
+
+def test_docker_command_accepts_readonly_option() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["/host/ws:/workspace:ro"],
+    )
+    assert "/host/ws:/workspace:ro" in " ".join(command)
+
+
+def test_inspect_rejects_dev_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/dev",
+            "Destination": "/dev",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    with pytest.raises(ValueError, match="forbidden bind mount source"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_root_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/",
+            "Destination": "/host",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    with pytest.raises(ValueError, match="forbidden"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_privileged_mode() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["Privileged"] = True
+    with pytest.raises(ValueError, match="privileged"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_dangerous_capabilities() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["CapAdd"] = ["SYS_ADMIN"]
+    with pytest.raises(ValueError, match="dangerous capabilities"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_legacy_binds() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["Binds"] = ["/dev:/dev"]
+    with pytest.raises(ValueError, match="forbidden host path"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_shared_propagation() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/host/data",
+            "Destination": "/workspace",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "shared",
+        }
+    ]
+    with pytest.raises(ValueError, match="propagation"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_accepts_workspace_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/home/user/workspace",
+            "Destination": "/workspace",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    validate_container_inspect(payload, assignment)


### PR DESCRIPTION
## 修改内容

- 根据 `RUNNER_NAME` 严格解析 `poy-180-21rc-npu0` 至 `npu3` 的物理卡归属。
- Docker 容器统一写入 runner、物理卡和逻辑卡 label，只把对应的 `/dev/davinciN` 映射为容器内 `/dev/davinci0`。
- 容器创建后、启动前读取 Docker inspect，校验 label、设备映射和逻辑设备环境；不一致时 fail closed。
- 启动日志只打印 runner、物理卡和容器逻辑卡，不打印用户传入的环境变量值或完整命令。
- 增加维护文档，明确 `job.container` 在支持归属 label 前不能进入单卡 runner 池。

## 验证

- `uv run --extra test python -m pytest -q tests`：538 passed
- `uvx pre-commit run --files docs/RUNNER_DOCKER_OWNERSHIP.md scripts/run-watchdog-owned-npu-container.py src/vllm_hust_benchmark/runner_ownership.py tests/test_runner_ownership.py`：通过
- `git diff --check`：通过

## 合并前仍需完成

请在真实 runner 上分别跑一次成功、失败和取消路径，并确认：

- 正确 label 的兄弟容器经过两轮 watchdog 扫描仍存活；
- 错误 label 或设备映射会被拒绝或产生 #125 告警；
- 作业结束后对应 NPU 回到空闲状态。

代码和静态校验已完成，真实 runner 验收仍由 #127 负责人执行。

Refs #127
