### PR TITLE
feat: publish versioned official target registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Reject non-compliant public leaderboard records
         run: python scripts/validate_public_leaderboard_snapshots.py
 
+      - name: Verify generated official target registry
+        run: python -m vllm_hust_benchmark.official_targets --check --repo-root .
+
       - name: Validate trend admission fixtures (valid entries must pass)
         run: python scripts/validate_trend_entries.py --input tests/fixtures/trend_coverage/valid
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,10 +59,10 @@ repos:
     # secrets. Regenerate the baseline via:
     #
     #   detect-secrets scan --all-files \
-    #     --exclude-files '^(submissions|leaderboard-data|schemas|reports|docs/official-baselines)/.*\.json$|^tests/fixtures/.*|^archive/.*|^agent\.md$|^CHANGELOG\.md$|^\.(git|pytest_cache|ruff_cache|venv|benchmarks)/' \
+    #     --exclude-files '^(submissions|leaderboard-data|schemas|reports|docs/official-baselines)/.*\.json$|^src/vllm_hust_benchmark/data/official_target.*\.json$|^tests/fixtures/.*|^archive/.*|^agent\.md$|^CHANGELOG\.md$|^\.(git|pytest_cache|ruff_cache|venv|benchmarks)/' \
     #     --exclude-lines 'pragma: allowlist secret' \
     #     > .secrets.baseline
     #
     # Then audit any new entries with `detect-secrets audit .secrets.baseline`.
     args: [--baseline, .secrets.baseline]
-    exclude: ^(submissions/.*\.json|leaderboard-data/.*\.json|schemas/.*\.json|reports/.*\.json|docs/.*\.json|tests/fixtures/.*|archive/.*|agent\.md|CHANGELOG\.md)$
+    exclude: ^(submissions/.*\.json|leaderboard-data/.*\.json|schemas/.*\.json|reports/.*\.json|docs/.*\.json|src/vllm_hust_benchmark/data/official_target.*\.json|tests/fixtures/.*|archive/.*|agent\.md|CHANGELOG\.md)$

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Within that boundary, the important design point is:
 - `src/vllm_hust_benchmark/registry.py`: official scenario loading and lookup
 - `src/vllm_hust_benchmark/leaderboard_export.py`: website-compatible artifact and manifest exporter
 - `src/vllm_hust_benchmark/data/official_scenarios.json`: initial official scenario mirror
+- `leaderboard-data/official-targets.json`: versioned machine-readable official target registry
+- `docs/OFFICIAL_TARGETS.zh-CN.md`: generated Chinese official target matrix
+- `docs/OFFICIAL_TARGETS.md`: generated English official target matrix
 - `docs/UPSTREAM_ANALYSIS.md`: analysis of upstream benchmark architecture and why this repo is
   structured this way
 - `docs/LEADERBOARD_ALIGNMENT.md`: scenario taxonomy and exact mapping to website leaderboard schema
@@ -79,6 +82,12 @@ Within that boundary, the important design point is:
 ## Quick Start
 
 ```bash
+# show the active public target matrix; 3B perfgate profiles are excluded
+official-targets
+
+# inspect the complete machine-readable registry
+official-targets --json
+
 # inspect the resolved sibling repositories
 python -m vllm_hust_benchmark.cli show-repos --validate
 

--- a/docs/OFFICIAL_TARGETS.md
+++ b/docs/OFFICIAL_TARGETS.md
@@ -1,0 +1,111 @@
+# vLLM-HUST Official Targets
+
+> This file is generated from the official specs. Do not edit it manually.
+
+- Registry version: `1.0.0`
+- Effective from: `2026-07-31`
+
+Public leaderboard targets and 3B perfgate profiles are separate contracts. Provisional entries are
+not valid public-result comparison targets.
+
+| Use | Status | Profile | Workload | Model | Hardware | Precision | Memory util. | Max length |
+Spec | | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | | public-leaderboard | active |
+code | instructcoder-online | Qwen/Qwen2.5-Coder-14B-Instruct | 910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json)
+| | public-leaderboard | active | core-text | agent-research-online | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | prefix-repetition-online | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | random-latency | Qwen/Qwen2.5-14B-Instruct | 910B2 × 1
+| FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | random-online | Qwen/Qwen2.5-14B-Instruct | 910B2 × 1
+| FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sharegpt-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sharegpt-throughput | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sonnet-throughput | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json)
+| | public-leaderboard | active | multimodal | visionarena-online | Qwen/Qwen2.5-VL-7B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json)
+| | perfgate | provisional | perfgate-code | instructcoder-online | Qwen/Qwen2.5-Coder-3B-Instruct |
+910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json)
+| | perfgate | provisional | perfgate-multimodal | visionarena-online | Qwen/Qwen2.5-VL-3B-Instruct
+| 910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | agent-research-online | Qwen/Qwen2.5-3B-Instruct |
+910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-agent-research-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | prefix-repetition-online | Qwen/Qwen2.5-3B-Instruct |
+910B2 × 1 | BF16 | — | 1280 |
+[`perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | random-latency | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1 |
+BF16 | — | 1280 |
+[`perfgate-ascend-random-latency-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | random-online | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1 |
+BF16 | — | 256 |
+[`perfgate-ascend-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sharegpt-online | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1
+| BF16 | — | — |
+[`perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sharegpt-throughput | Qwen/Qwen2.5-3B-Instruct | 910B2
+× 1 | BF16 | — | — |
+[`perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sonnet-throughput | Qwen/Qwen2.5-3B-Instruct | 910B2 ×
+1 | BF16 | — | — |
+[`perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json)
+| | specialty | provisional | multi-chip | agent-research-online-2chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | agent-research-online-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | prefix-repetition-online-2chip |
+Qwen/Qwen2.5-14B-Instruct | 910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | prefix-repetition-online-4chip |
+Qwen/Qwen2.5-14B-Instruct | 910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | random-online-2chip | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | random-online-4chip | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sharegpt-online-2chip | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | sharegpt-online-4chip | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-2chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-8chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 8 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json)
+| | specialty | provisional | specialty | kv-tiering-prefix-online | Qwen/Qwen2.5-7B-Instruct |
+910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json)
+| | specialty | provisional | specialty | ngram-instructcoder-online | Qwen/Qwen2.5-7B-Instruct |
+910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json)
+| | specialty | provisional | specialty-text | logprobs-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json)
+|
+
+Machine-readable snapshot:
+[`leaderboard-data/official-targets.json`](../leaderboard-data/official-targets.json)

--- a/docs/OFFICIAL_TARGETS.zh-CN.md
+++ b/docs/OFFICIAL_TARGETS.zh-CN.md
@@ -1,0 +1,109 @@
+# vLLM-HUST 官方固定靶
+
+> 本文件由 official specs 自动生成，请勿手工修改。
+
+- Registry version: `1.0.0`
+- Effective from: `2026-07-31`
+
+公开排行榜固定靶与 3B 快速门禁是不同契约；provisional 记录不得作为公开成果对比。
+
+| 用途 | 状态 | Profile | Workload | 模型 | 硬件 | 精度 | 显存比例 | 最大长度 | Spec | | --- | --- | --- | --- | --- |
+--- | --- | --- | --- | --- | | public-leaderboard | active | code | instructcoder-online |
+Qwen/Qwen2.5-Coder-14B-Instruct | 910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json)
+| | public-leaderboard | active | core-text | agent-research-online | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | prefix-repetition-online | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | random-latency | Qwen/Qwen2.5-14B-Instruct | 910B2 × 1
+| FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | random-online | Qwen/Qwen2.5-14B-Instruct | 910B2 × 1
+| FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sharegpt-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sharegpt-throughput | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json)
+| | public-leaderboard | active | core-text | sonnet-throughput | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json)
+| | public-leaderboard | active | multimodal | visionarena-online | Qwen/Qwen2.5-VL-7B-Instruct |
+910B2 × 1 | FP16 | 0.6 | 32768 |
+[`official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json)
+| | perfgate | provisional | perfgate-code | instructcoder-online | Qwen/Qwen2.5-Coder-3B-Instruct |
+910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json)
+| | perfgate | provisional | perfgate-multimodal | visionarena-online | Qwen/Qwen2.5-VL-3B-Instruct
+| 910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | agent-research-online | Qwen/Qwen2.5-3B-Instruct |
+910B2 × 1 | BF16 | — | — |
+[`perfgate-ascend-agent-research-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | prefix-repetition-online | Qwen/Qwen2.5-3B-Instruct |
+910B2 × 1 | BF16 | — | 1280 |
+[`perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | random-latency | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1 |
+BF16 | — | 1280 |
+[`perfgate-ascend-random-latency-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | random-online | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1 |
+BF16 | — | 256 |
+[`perfgate-ascend-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sharegpt-online | Qwen/Qwen2.5-3B-Instruct | 910B2 × 1
+| BF16 | — | — |
+[`perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sharegpt-throughput | Qwen/Qwen2.5-3B-Instruct | 910B2
+× 1 | BF16 | — | — |
+[`perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json)
+| | perfgate | provisional | perfgate-text | sonnet-throughput | Qwen/Qwen2.5-3B-Instruct | 910B2 ×
+1 | BF16 | — | — |
+[`perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json`](../docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json)
+| | specialty | provisional | multi-chip | agent-research-online-2chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | agent-research-online-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | prefix-repetition-online-2chip |
+Qwen/Qwen2.5-14B-Instruct | 910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | prefix-repetition-online-4chip |
+Qwen/Qwen2.5-14B-Instruct | 910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | random-online-2chip | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | random-online-4chip | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sharegpt-online-2chip | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | sharegpt-online-4chip | Qwen/Qwen2.5-14B-Instruct | 910B2
+× 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-2chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 2 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json)
+| | specialty | provisional | multi-chip | sonnet-throughput-8chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 8 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json)
+| | specialty | provisional | specialty | kv-tiering-prefix-online | Qwen/Qwen2.5-7B-Instruct |
+910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json)
+| | specialty | provisional | specialty | ngram-instructcoder-online | Qwen/Qwen2.5-7B-Instruct |
+910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json)
+| | specialty | provisional | specialty-text | logprobs-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
+1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json)
+|
+
+机器可读快照：[`leaderboard-data/official-targets.json`](../leaderboard-data/official-targets.json)

--- a/docs/OFFICIAL_TARGETS_CHANGELOG.md
+++ b/docs/OFFICIAL_TARGETS_CHANGELOG.md
@@ -1,0 +1,10 @@
+# Official target registry changelog
+
+> Generated from `official_target_versions.json`. Do not edit manually.
+
+## 1.0.0 — 2026-07-31
+
+- English: Initial public 14B text, 14B code, and 7B multimodal target contract.
+- 中文：首次发布 14B 文本、14B 代码和 7B 多模态公开固定靶契约。
+- Source set: `54d31914a6ceae39fb5a58b972b979f417dd654ff51aa72d1b4b4b8535dc0d36`
+- Supersedes: `none`

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -1,0 +1,1991 @@
+{
+  "effective_from": "2026-07-31",
+  "registry_version": "1.0.0",
+  "schema_version": "official-target-registry/v1",
+  "source_set_sha256": "54d31914a6ceae39fb5a58b972b979f417dd654ff51aa72d1b4b4b8535dc0d36",
+  "targets": [
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-Coder-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "code",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json",
+        "sha256": "4ff7fc34318e4dd27c1e63f94a5bb5f567ccd1ff1b732d55c3a9348fe2398ce1"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "no_stream": true,
+          "num_prompts": 2048,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+        "sha256": "3ac31e7917b73558ba33ce1ad09c1871371c8f53a1496ab4bda1dc4699ae266a"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+        "sha256": "e27ce2ba69ffea08938dd052b4ba88ef9f1569f21383fe934a1a71fdd63463ec"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "no_stream": false,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json",
+        "sha256": "ebdd125f8fd61c0331cf80305c665d8151107c32d8fe566089407dbe662b3080"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "batch_size": 8,
+          "gpu_memory_utilization": 0.6,
+          "input_len": 1024,
+          "num_iters": 30,
+          "num_iters_warmup": 10,
+          "output_len": 128
+        },
+        "name": "random-latency"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+        "sha256": "446744f2790968015a933aff7cf84fc096438ba5246eb3db155d808e7010527b"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "no_stream": false,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+        "sha256": "c738c8a2a1c1fdbd3a53ec7c3891634fb63152f230386fab73e5257e79df822f"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "no_stream": false,
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json",
+        "sha256": "d5c4b7fa9d0911b04e69deeafbec5cc56386732dec8113074850ac7daa7a9a29"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0
+        },
+        "name": "sharegpt-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json",
+        "sha256": "a9905ce7c45fab8c3dd186ec5b7ccb1a0dd6efbc1a8f89afef7f47c9cd596858"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0
+        },
+        "name": "sonnet-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "multimodal",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "limit_mm_per_prompt": {
+          "image": 1
+        },
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json",
+        "sha256": "e9e4a87ad44eb5531989623f28c3d8110bfed2969776b80b1310cab3aa8fd234"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "hf",
+          "dataset_path": "lmarena-ai/VisionArena-Chat",
+          "endpoint": "/v1/chat/completions",
+          "hf_split": "train",
+          "host": "127.0.0.1",
+          "no_stream": false,
+          "num_prompts": 1000,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "visionarena-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-Coder-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-code",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json",
+        "sha256": "5b6e0b2b3e35048692cc8590655af620bc572d1feec537d311c83d5c2897a224"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "no_stream": true,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-multimodal",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "limit_mm_per_prompt": {
+          "image": 1
+        },
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json",
+        "sha256": "c788a8bb58f2967f353d6847385f50a3ae6d506538178c7905c692f77ad76f28"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "hf",
+          "dataset_path": "lmarena-ai/VisionArena-Chat",
+          "endpoint": "/v1/chat/completions",
+          "hf_split": "train",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "visionarena-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json",
+        "sha256": "6cdd0da3a5645bbf5b7cc1c7775a17503f1d5a535474845337687bcf21631cd5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enable_prefix_caching": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_model_len": 1280,
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
+        "sha256": "41e3e89b72248b24418f320f8f498050c0a78fd177e5476d7fd4872f2a867a2d"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "output_len": 64,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_model_len": 1280,
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json",
+        "sha256": "7d756cef6b41c981ac6251cfecc15ef134abe150fad645e2c5555916f2b9ad7e"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "batch_size": 1,
+          "input_len": 1024,
+          "num_iters": 3,
+          "num_iters_warmup": 1,
+          "output_len": 128
+        },
+        "name": "random-latency"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_model_len": 256,
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json",
+        "sha256": "ca565ec11083923474d2c1b382d37696476a3e41835bb3feeacb719d65c6bf88"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 64,
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "output_len": 16,
+          "port": 8000,
+          "request_rate": "inf"
+        },
+        "name": "random-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json",
+        "sha256": "e3f7f113bc6938b2ee3f78d446a6fed10da47468faf829d25a4ff1ce73d496f1"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json",
+        "sha256": "512f93fd576716411b3b5d02a0a8f462d496335c880aa5b59eba900982b93bff"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "num_prompts": 8,
+          "num_warmups": 0
+        },
+        "name": "sharegpt-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json",
+        "sha256": "d0f111a2950d74dc2ab8462d84c9dc4c197d36808da6ea063cfb45ba514a1d1a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "num_prompts": 8,
+          "num_warmups": 0
+        },
+        "name": "sonnet-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "64ef2c1277673f492e13080c1c48c25ae8b2ab3e45c2e10d2e9135f2ca6740d7"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "7aaf74c294aebee6d093fd67a019049019608ac36343aa3c1f550b6e16ee8b9f"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "ab2ed65bd1da3e57db3ae77bc22a5c9da3975f66da681f5abbe8d5419e08b16d"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "9a54e8a024c4264c46a8b8e5f7fb760d5ecb5f6e647cd94bc3e2f1f5e4928e1e"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "1eaf7f6f30d78a0157a66aa2df0ea93449686a85fa24190d258c94e385a992e5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "fe3964a1143a537d576da81a284913d94592fe776532b4e189099155c291da71"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "a3f6e0f7d428b61bf55234e14472562762364c01d287be7d6fef7017cad41d68"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "2d5967153a9496e73adbe84b444949a0125b6ef7cd16e42ab06038cbb5f802e2"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json",
+        "sha256": "9b3c4078711b4c9d6b749256aec6293dd5b3181e3f4813a89f2c248fb0769838"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 2
+        },
+        "name": "sonnet-throughput-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json",
+        "sha256": "be037624bb01323a0caec4070f0ab7638dabbc55d5a2acbc2c40e98e52ee325a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 4
+        },
+        "name": "sonnet-throughput-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 8,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 8,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json",
+        "sha256": "5e4bf8f9dcc17947f1c19e25fb10810a038827998236595824ffc9f23afc63a4"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "kv_cache_memory_bytes": 21474836480,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 8
+        },
+        "name": "sonnet-throughput-8chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "specialty",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json",
+        "sha256": "1c5c5dffcc15e6daae58979cbd27ff71f8ac15841ae50e2507642174a40f75a5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "prefix_repetition_num_prefixes": 10,
+          "prefix_repetition_prefix_len": 3840,
+          "prefix_repetition_suffix_len": 256,
+          "request_rate": 1
+        },
+        "name": "kv-tiering-prefix-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "specialty",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json",
+        "sha256": "e6fb4881acebdd68d22983f0332f4511a72a2f6a94f2238f79d4a9343b9815ea"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "ngram-instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "specialty-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json",
+        "sha256": "02698550fa0131655841e7aff0d306049dd69467378499590e2a48dbeea4df24"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "logprobs": 20,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "logprobs-online"
+      }
+    }
+  ]
+}

--- a/leaderboard-data/official-targets.sha256
+++ b/leaderboard-data/official-targets.sha256
@@ -1,0 +1,1 @@
+2073283467797cbe4a74682249b4e40c7c5ded4ebd393392161e038dd9bdb94c  official-targets.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = []
 test = [
   "pytest>=8",
   "jsonschema>=4",
+  "mdformat==1.0.0",
+  "mdformat-gfm",
 ]
 publish = ["huggingface_hub>=0.20"]
 
@@ -25,6 +27,7 @@ publish = ["huggingface_hub>=0.20"]
 vllm-hust-benchmark = "vllm_hust_benchmark.cli:main"
 perfgate = "vllm_hust_benchmark.perfgate:main"
 perfgate-baseline = "vllm_hust_benchmark.perfgate_baselines:main"
+official-targets = "vllm_hust_benchmark.official_targets:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/schemas/official_target_registry_v1.schema.json
+++ b/schemas/official_target_registry_v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/vLLM-HUST/vllm-hust-benchmark/schemas/official_target_registry_v1.schema.json",
+  "title": "vLLM-HUST official target registry v1",
+  "type": "object",
+  "required": ["schema_version", "registry_version", "effective_from", "source_set_sha256", "targets"],
+  "properties": {
+    "schema_version": {"const": "official-target-registry/v1"},
+    "registry_version": {"type": "string", "minLength": 1},
+    "effective_from": {"type": "string", "format": "date"},
+    "source_set_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/target"}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "target": {
+      "type": "object",
+      "required": [
+        "target_id",
+        "target_version",
+        "status",
+        "effective_from",
+        "supersedes",
+        "profile",
+        "intended_use",
+        "baseline_runtime",
+        "model",
+        "hardware",
+        "server_parameters",
+        "workload",
+        "source_spec",
+        "compatibility_policy"
+      ],
+      "properties": {
+        "target_id": {"type": "string", "minLength": 1},
+        "target_version": {"type": "string", "minLength": 1},
+        "status": {"enum": ["active", "provisional", "retired"]},
+        "effective_from": {"type": "string", "format": "date"},
+        "supersedes": {"type": "array", "items": {"type": "string"}},
+        "profile": {"type": "string", "minLength": 1},
+        "intended_use": {"enum": ["public-leaderboard", "perfgate", "specialty"]},
+        "baseline_runtime": {"type": "object"},
+        "model": {"type": "object"},
+        "hardware": {"type": "object"},
+        "server_parameters": {"type": "object"},
+        "workload": {"type": "object"},
+        "source_spec": {
+          "type": "object",
+          "required": ["path", "sha256"],
+          "properties": {
+            "path": {"type": "string", "minLength": 1},
+            "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+          },
+          "additionalProperties": false
+        },
+        "compatibility_policy": {"type": "object"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/vllm_hust_benchmark/data/official_target_versions.json
+++ b/src/vllm_hust_benchmark/data/official_target_versions.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "official-target-version-history/v1",
+  "versions": [
+    {
+      "version": "1.0.0",
+      "effective_from": "2026-07-31",
+      "source_set_sha256": "54d31914a6ceae39fb5a58b972b979f417dd654ff51aa72d1b4b4b8535dc0d36",
+      "supersedes": null,
+      "summary_en": "Initial public 14B text, 14B code, and 7B multimodal target contract.",
+      "summary_zh": "首次发布 14B 文本、14B 代码和 7B 多模态公开固定靶契约。"
+    }
+  ]
+}

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -1,0 +1,1991 @@
+{
+  "effective_from": "2026-07-31",
+  "registry_version": "1.0.0",
+  "schema_version": "official-target-registry/v1",
+  "source_set_sha256": "54d31914a6ceae39fb5a58b972b979f417dd654ff51aa72d1b4b4b8535dc0d36",
+  "targets": [
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-Coder-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "code",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json",
+        "sha256": "4ff7fc34318e4dd27c1e63f94a5bb5f567ccd1ff1b732d55c3a9348fe2398ce1"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "no_stream": true,
+          "num_prompts": 2048,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+        "sha256": "3ac31e7917b73558ba33ce1ad09c1871371c8f53a1496ab4bda1dc4699ae266a"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+        "sha256": "e27ce2ba69ffea08938dd052b4ba88ef9f1569f21383fe934a1a71fdd63463ec"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "no_stream": false,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json",
+        "sha256": "ebdd125f8fd61c0331cf80305c665d8151107c32d8fe566089407dbe662b3080"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "batch_size": 8,
+          "gpu_memory_utilization": 0.6,
+          "input_len": 1024,
+          "num_iters": 30,
+          "num_iters_warmup": 10,
+          "output_len": 128
+        },
+        "name": "random-latency"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+        "sha256": "446744f2790968015a933aff7cf84fc096438ba5246eb3db155d808e7010527b"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "no_stream": false,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+        "sha256": "c738c8a2a1c1fdbd3a53ec7c3891634fb63152f230386fab73e5257e79df822f"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "no_stream": false,
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json",
+        "sha256": "d5c4b7fa9d0911b04e69deeafbec5cc56386732dec8113074850ac7daa7a9a29"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0
+        },
+        "name": "sharegpt-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "core-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json",
+        "sha256": "a9905ce7c45fab8c3dd186ec5b7ccb1a0dd6efbc1a8f89afef7f47c9cd596858"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0
+        },
+        "name": "sonnet-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "public-leaderboard",
+      "model": {
+        "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "multimodal",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "gpu_memory_utilization": 0.6,
+        "host": "0.0.0.0",
+        "limit_mm_per_prompt": {
+          "image": 1
+        },
+        "max_model_len": 32768,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json",
+        "sha256": "e9e4a87ad44eb5531989623f28c3d8110bfed2969776b80b1310cab3aa8fd234"
+      },
+      "status": "active",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "hf",
+          "dataset_path": "lmarena-ai/VisionArena-Chat",
+          "endpoint": "/v1/chat/completions",
+          "hf_split": "train",
+          "host": "127.0.0.1",
+          "no_stream": false,
+          "num_prompts": 1000,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "visionarena-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-Coder-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-code",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2.json",
+        "sha256": "5b6e0b2b3e35048692cc8590655af620bc572d1feec537d311c83d5c2897a224"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "no_stream": true,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-multimodal",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "limit_mm_per_prompt": {
+          "image": 1
+        },
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2.json",
+        "sha256": "c788a8bb58f2967f353d6847385f50a3ae6d506538178c7905c692f77ad76f28"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "hf",
+          "dataset_path": "lmarena-ai/VisionArena-Chat",
+          "endpoint": "/v1/chat/completions",
+          "hf_split": "train",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "visionarena-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-agent-research-online-qwen25-3b-910b2.json",
+        "sha256": "6cdd0da3a5645bbf5b7cc1c7775a17503f1d5a535474845337687bcf21631cd5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enable_prefix_caching": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_model_len": 1280,
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
+        "sha256": "41e3e89b72248b24418f320f8f498050c0a78fd177e5476d7fd4872f2a867a2d"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "output_len": 64,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_model_len": 1280,
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-random-latency-qwen25-3b-910b2.json",
+        "sha256": "7d756cef6b41c981ac6251cfecc15ef134abe150fad645e2c5555916f2b9ad7e"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "batch_size": 1,
+          "input_len": 1024,
+          "num_iters": 3,
+          "num_iters_warmup": 1,
+          "output_len": 128
+        },
+        "name": "random-latency"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_model_len": 256,
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-qwen25-3b-910b2.json",
+        "sha256": "ca565ec11083923474d2c1b382d37696476a3e41835bb3feeacb719d65c6bf88"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 64,
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "output_len": 16,
+          "port": 8000,
+          "request_rate": "inf"
+        },
+        "name": "random-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "max_num_seqs": 1,
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sharegpt-online-qwen25-3b-910b2.json",
+        "sha256": "e3f7f113bc6938b2ee3f78d446a6fed10da47468faf829d25a4ff1ce73d496f1"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "max_concurrency": 4,
+          "num_prompts": 8,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2.json",
+        "sha256": "512f93fd576716411b3b5d02a0a8f462d496335c880aa5b59eba900982b93bff"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "num_prompts": 8,
+          "num_warmups": 0
+        },
+        "name": "sharegpt-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm-hust",
+        "engine_version": "main",
+        "git_commit": null,
+        "github_repository": "vLLM-HUST/vllm-hust",
+        "vllm_ascend_ref": "main",
+        "vllm_ref": "main"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "perfgate",
+      "model": {
+        "id": "Qwen/Qwen2.5-3B-Instruct",
+        "parameters": "3B",
+        "precision": "BF16"
+      },
+      "profile": "perfgate-text",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "dtype": "bfloat16",
+        "enforce_eager": "",
+        "max_num_seqs": 1,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/perfgate-ascend-sonnet-throughput-qwen25-3b-910b2.json",
+        "sha256": "d0f111a2950d74dc2ab8462d84c9dc4c197d36808da6ea063cfb45ba514a1d1a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "num_prompts": 8,
+          "num_warmups": 0
+        },
+        "name": "sonnet-throughput"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "64ef2c1277673f492e13080c1c48c25ae8b2ab3e45c2e10d2e9135f2ca6740d7"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "7aaf74c294aebee6d093fd67a019049019608ac36343aa3c1f550b6e16ee8b9f"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "openai-chat",
+          "dataset_name": "custom",
+          "dataset_path": "scripts/traces/evoscientist-workload-custom.jsonl",
+          "endpoint": "/v1/chat/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 32,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "agent-research-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "ab2ed65bd1da3e57db3ae77bc22a5c9da3975f66da681f5abbe8d5419e08b16d"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "9a54e8a024c4264c46a8b8e5f7fb760d5ecb5f6e647cd94bc3e2f1f5e4928e1e"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 4096,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "prefix-repetition-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "1eaf7f6f30d78a0157a66aa2df0ea93449686a85fa24190d258c94e385a992e5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "fe3964a1143a537d576da81a284913d94592fe776532b4e189099155c291da71"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "random-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json",
+        "sha256": "a3f6e0f7d428b61bf55234e14472562762364c01d287be7d6fef7017cad41d68"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "2d5967153a9496e73adbe84b444949a0125b6ef7cd16e42ab06038cbb5f802e2"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sharegpt",
+          "dataset_path": "ShareGPT_V3_unfiltered_cleaned_split.json",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "sharegpt-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 2,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 2,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-2chip-910b2.json",
+        "sha256": "9b3c4078711b4c9d6b749256aec6293dd5b3181e3f4813a89f2c248fb0769838"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 2
+        },
+        "name": "sonnet-throughput-2chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-4chip-910b2.json",
+        "sha256": "be037624bb01323a0caec4070f0ab7638dabbc55d5a2acbc2c40e98e52ee325a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "gpu_memory_utilization": 0.6,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 4
+        },
+        "name": "sonnet-throughput-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 8,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "tensor_parallel_size": 8,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-8chip-910b2.json",
+        "sha256": "5e4bf8f9dcc17947f1c19e25fb10810a038827998236595824ffc9f23afc63a4"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "sonnet",
+          "dataset_path": "benchmarks/sonnet.txt",
+          "dtype": "float16",
+          "kv_cache_memory_bytes": 21474836480,
+          "num_prompts": 200,
+          "num_warmups": 0,
+          "tensor_parallel_size": 8
+        },
+        "name": "sonnet-throughput-8chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "specialty",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json",
+        "sha256": "1c5c5dffcc15e6daae58979cbd27ff71f8ac15841ae50e2507642174a40f75a5"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "prefix_repetition",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "prefix_repetition_num_prefixes": 10,
+          "prefix_repetition_prefix_len": 3840,
+          "prefix_repetition_suffix_len": 256,
+          "request_rate": 1
+        },
+        "name": "kv-tiering-prefix-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-7B-Instruct",
+        "parameters": "7B",
+        "precision": "FP16"
+      },
+      "profile": "specialty",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-ngram-instructcoder-online-qwen25-7b-910b2.json",
+        "sha256": "e6fb4881acebdd68d22983f0332f4511a72a2f6a94f2238f79d4a9343b9815ea"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "hf",
+          "dataset_path": "likaixin/InstructCoder",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "num_prompts": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "ngram-instructcoder-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-07-31",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "specialty-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-logprobs-online-qwen25-14b-910b2.json",
+        "sha256": "02698550fa0131655841e7aff0d306049dd69467378499590e2a48dbeea4df24"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "logprobs": 20,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "logprobs-online"
+      }
+    }
+  ]
+}

--- a/src/vllm_hust_benchmark/official_targets.py
+++ b/src/vllm_hust_benchmark/official_targets.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "official-target-registry/v1"
+REGISTRY_VERSION = "1.0.0"
+EFFECTIVE_FROM = "2026-07-31"
+PUBLIC_TEXT_MODEL = "Qwen/Qwen2.5-14B-Instruct"
+PUBLIC_CODE_MODEL = "Qwen/Qwen2.5-Coder-14B-Instruct"
+PUBLIC_VISION_MODEL = "Qwen/Qwen2.5-VL-7B-Instruct"
+PUBLIC_TEXT_SCENARIOS = {
+    "agent-research-online",
+    "prefix-repetition-online",
+    "random-latency",
+    "random-online",
+    "sharegpt-online",
+    "sharegpt-throughput",
+    "sonnet-throughput",
+}
+PACKAGE_REGISTRY_PATH = Path(__file__).parent / "data" / "official_targets.json"
+VERSION_HISTORY_RELATIVE_PATH = (
+    Path("src") / "vllm_hust_benchmark" / "data" / "official_target_versions.json"
+)
+
+
+def _json_text(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _load_spec(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"spec must be a JSON object: {path}")
+    required = {
+        "id",
+        "baseline_target",
+        "scenario",
+        "model",
+        "model_precision",
+        "hardware_vendor",
+        "hardware_chip_model",
+        "chip_count",
+        "node_count",
+        "server_parameters",
+        "client_parameters",
+        "export",
+    }
+    missing = sorted(required.difference(payload))
+    if missing:
+        raise ValueError(f"spec {path} is missing: {', '.join(missing)}")
+    return payload
+
+
+def _classify_spec(path: Path, spec: dict[str, Any]) -> tuple[str, str, str]:
+    scenario = str(spec["scenario"])
+    model = str(spec["model"])
+    chip_count = int(spec["chip_count"])
+
+    if path.name.startswith("perfgate-"):
+        if "Coder" in model:
+            profile = "perfgate-code"
+        elif "VL" in model:
+            profile = "perfgate-multimodal"
+        else:
+            profile = "perfgate-text"
+        return "perfgate", "provisional", profile
+
+    if chip_count == 1 and model == PUBLIC_TEXT_MODEL:
+        if scenario in PUBLIC_TEXT_SCENARIOS:
+            return "public-leaderboard", "active", "core-text"
+        return "specialty", "provisional", "specialty-text"
+    if (
+        chip_count == 1
+        and model == PUBLIC_CODE_MODEL
+        and scenario == "instructcoder-online"
+    ):
+        return "public-leaderboard", "active", "code"
+    if (
+        chip_count == 1
+        and model == PUBLIC_VISION_MODEL
+        and scenario == "visionarena-online"
+    ):
+        return "public-leaderboard", "active", "multimodal"
+    if chip_count > 1:
+        return "specialty", "provisional", "multi-chip"
+    return "specialty", "provisional", "specialty"
+
+
+def _validate_public_target(spec: dict[str, Any], path: Path) -> None:
+    server = spec["server_parameters"]
+    expected = {
+        "tensor_parallel_size": 1,
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 32768,
+    }
+    for name, value in expected.items():
+        if server.get(name) != value:
+            raise ValueError(
+                f"public target {path} requires {name}={value!r}, "
+                f"got {server.get(name)!r}"
+            )
+    if int(spec["chip_count"]) != 1 or int(spec["node_count"]) != 1:
+        raise ValueError(f"public target must be single-node/single-chip: {path}")
+    if str(spec["model_precision"]) != "FP16":
+        raise ValueError(f"public target must use FP16: {path}")
+
+    baseline = spec["baseline_target"]
+    if baseline.get("vllm_ref") != "v0.18.0":
+        raise ValueError(f"public target must use vLLM v0.18.0: {path}")
+    if baseline.get("vllm_ascend_ref") != "v0.18.0":
+        raise ValueError(f"public target must use vLLM-Ascend v0.18.0: {path}")
+
+
+def _source_set_sha256(targets: list[dict[str, Any]]) -> str:
+    sources = sorted(
+        (target["source_spec"] for target in targets), key=lambda source: source["path"]
+    )
+    canonical = json.dumps(sources, sort_keys=True, separators=(",", ":")) + "\n"
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _load_version_history(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / VERSION_HISTORY_RELATIVE_PATH
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != "official-target-version-history/v1":
+        raise ValueError(f"invalid official target version history: {path}")
+    versions = payload.get("versions")
+    if not isinstance(versions, list) or not versions:
+        raise ValueError(f"official target version history is empty: {path}")
+    return payload
+
+
+def _validate_version_history(
+    repo_root: Path, *, source_set_sha256: str
+) -> dict[str, Any]:
+    history = _load_version_history(repo_root)
+    current = history["versions"][-1]
+    if current.get("version") != REGISTRY_VERSION:
+        raise ValueError("REGISTRY_VERSION must match the latest version history entry")
+    if current.get("effective_from") != EFFECTIVE_FROM:
+        raise ValueError("EFFECTIVE_FROM must match the latest version history entry")
+    if current.get("source_set_sha256") != source_set_sha256:
+        raise ValueError(
+            "official specs changed without a new registry version; add a version "
+            "history entry and update REGISTRY_VERSION"
+        )
+    return history
+
+
+def build_registry(repo_root: Path) -> dict[str, Any]:
+    spec_root = repo_root / "docs" / "official-baselines"
+    spec_paths = sorted(
+        path
+        for path in spec_root.glob("*.json")
+        if path.name != "official-ascend-constraints.stub.json"
+    )
+    if not spec_paths:
+        raise ValueError(f"no official target specs found under {spec_root}")
+
+    targets: list[dict[str, Any]] = []
+    for path in spec_paths:
+        spec = _load_spec(path)
+        intended_use, status, profile = _classify_spec(path, spec)
+        if status == "active":
+            _validate_public_target(spec, path)
+
+        baseline = spec["baseline_target"]
+        export = spec["export"]
+        relative_path = path.relative_to(repo_root).as_posix()
+        targets.append(
+            {
+                "target_id": spec["id"],
+                "target_version": REGISTRY_VERSION,
+                "status": status,
+                "effective_from": EFFECTIVE_FROM,
+                "supersedes": [],
+                "profile": profile,
+                "intended_use": intended_use,
+                "baseline_runtime": {
+                    "engine": baseline["engine"],
+                    "engine_version": baseline["engine_version"],
+                    "github_repository": baseline["github_repository"],
+                    "vllm_ref": baseline["vllm_ref"],
+                    "vllm_ascend_ref": baseline["vllm_ascend_ref"],
+                    "git_commit": export.get("git_commit"),
+                },
+                "model": {
+                    "id": spec["model"],
+                    "parameters": spec.get("model_parameters"),
+                    "precision": spec["model_precision"],
+                },
+                "hardware": {
+                    "vendor": spec["hardware_vendor"],
+                    "chip_model": spec["hardware_chip_model"],
+                    "chip_count": spec["chip_count"],
+                    "node_count": spec["node_count"],
+                },
+                "server_parameters": spec["server_parameters"],
+                "workload": {
+                    "name": spec["scenario"],
+                    "client_parameters": spec["client_parameters"],
+                },
+                "source_spec": {
+                    "path": relative_path,
+                    "sha256": _sha256_bytes(path.read_bytes()),
+                },
+                "compatibility_policy": {
+                    "model": "exact",
+                    "hardware": "exact",
+                    "server_parameters": "exact",
+                    "workload_parameters": "exact",
+                    "exceptions": "new-target-version-required",
+                },
+            }
+        )
+
+    use_order = {"public-leaderboard": 0, "perfgate": 1, "specialty": 2}
+    targets.sort(
+        key=lambda target: (
+            use_order[target["intended_use"]],
+            target["profile"],
+            target["workload"]["name"],
+            target["hardware"]["chip_count"],
+        )
+    )
+    source_set_sha256 = _source_set_sha256(targets)
+    _validate_version_history(repo_root, source_set_sha256=source_set_sha256)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "registry_version": REGISTRY_VERSION,
+        "effective_from": EFFECTIVE_FROM,
+        "source_set_sha256": source_set_sha256,
+        "targets": targets,
+    }
+
+
+def _format_value(value: Any) -> str:
+    if value is None or value == "":
+        return "—"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def render_document(registry: dict[str, Any], *, language: str) -> str:
+    import mdformat
+
+    chinese = language == "zh-CN"
+    title = "vLLM-HUST 官方固定靶" if chinese else "vLLM-HUST Official Targets"
+    generated = (
+        "本文件由 official specs 自动生成，请勿手工修改。"
+        if chinese
+        else "This file is generated from the official specs. Do not edit it manually."
+    )
+    public_note = (
+        "公开排行榜固定靶与 3B 快速门禁是不同契约；provisional 记录不得作为公开成果对比。"
+        if chinese
+        else "Public leaderboard targets and 3B perfgate profiles are separate contracts. "
+        "Provisional entries are not valid public-result comparison targets."
+    )
+    headers = (
+        [
+            "用途",
+            "状态",
+            "Profile",
+            "Workload",
+            "模型",
+            "硬件",
+            "精度",
+            "显存比例",
+            "最大长度",
+            "Spec",
+        ]
+        if chinese
+        else [
+            "Use",
+            "Status",
+            "Profile",
+            "Workload",
+            "Model",
+            "Hardware",
+            "Precision",
+            "Memory util.",
+            "Max length",
+            "Spec",
+        ]
+    )
+    lines = [
+        f"# {title}",
+        "",
+        f"> {generated}",
+        "",
+        f"- Registry version: `{registry['registry_version']}`",
+        f"- Effective from: `{registry['effective_from']}`",
+        "",
+        public_note,
+        "",
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for target in registry["targets"]:
+        server = target["server_parameters"]
+        hardware = target["hardware"]
+        row = [
+            target["intended_use"],
+            target["status"],
+            target["profile"],
+            target["workload"]["name"],
+            target["model"]["id"],
+            f"{hardware['chip_model']} × {hardware['chip_count']}",
+            target["model"]["precision"],
+            _format_value(server.get("gpu_memory_utilization")),
+            _format_value(server.get("max_model_len")),
+            f"[`{Path(target['source_spec']['path']).name}`](../{target['source_spec']['path']})",
+        ]
+        lines.append("| " + " | ".join(row) + " |")
+    lines.extend(
+        [
+            "",
+            (
+                "机器可读快照：[`leaderboard-data/official-targets.json`](../leaderboard-data/official-targets.json)"
+                if chinese
+                else "Machine-readable snapshot: [`leaderboard-data/official-targets.json`](../leaderboard-data/official-targets.json)"
+            ),
+            "",
+        ]
+    )
+    return mdformat.text("\n".join(lines), options={"wrap": 100})
+
+
+def render_changelog(repo_root: Path) -> str:
+    import mdformat
+
+    history = _load_version_history(repo_root)
+    lines = [
+        "# Official target registry changelog",
+        "",
+        "> Generated from `official_target_versions.json`. Do not edit manually.",
+        "",
+    ]
+    for version in reversed(history["versions"]):
+        lines.extend(
+            [
+                f"## {version['version']} — {version['effective_from']}",
+                "",
+                f"- English: {version['summary_en']}",
+                f"- 中文：{version['summary_zh']}",
+                f"- Source set: `{version['source_set_sha256']}`",
+                f"- Supersedes: `{version['supersedes'] or 'none'}`",
+                "",
+            ]
+        )
+    return mdformat.text("\n".join(lines), options={"wrap": 100})
+
+
+def generated_outputs(repo_root: Path) -> dict[Path, str]:
+    registry = build_registry(repo_root)
+    registry_text = _json_text(registry)
+    digest = _sha256_bytes(registry_text.encode("utf-8"))
+    return {
+        repo_root / "leaderboard-data" / "official-targets.json": registry_text,
+        repo_root / "leaderboard-data" / "official-targets.sha256": (
+            f"{digest}  official-targets.json\n"
+        ),
+        repo_root
+        / "src"
+        / "vllm_hust_benchmark"
+        / "data"
+        / "official_targets.json": registry_text,
+        repo_root / "docs" / "OFFICIAL_TARGETS.md": render_document(
+            registry, language="en"
+        ),
+        repo_root / "docs" / "OFFICIAL_TARGETS.zh-CN.md": render_document(
+            registry, language="zh-CN"
+        ),
+        repo_root / "docs" / "OFFICIAL_TARGETS_CHANGELOG.md": render_changelog(
+            repo_root
+        ),
+    }
+
+
+def write_generated_outputs(repo_root: Path, *, check: bool) -> None:
+    stale: list[str] = []
+    for path, expected in generated_outputs(repo_root).items():
+        if check:
+            actual = path.read_text(encoding="utf-8") if path.exists() else None
+            if actual != expected:
+                stale.append(path.relative_to(repo_root).as_posix())
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(expected, encoding="utf-8")
+    if stale:
+        raise SystemExit(
+            "official target outputs are stale; regenerate: " + ", ".join(stale)
+        )
+
+
+def load_packaged_registry() -> dict[str, Any]:
+    return json.loads(PACKAGE_REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def render_active_targets(registry: dict[str, Any]) -> str:
+    active = [target for target in registry["targets"] if target["status"] == "active"]
+    lines = [
+        "USE                PROFILE      WORKLOAD                    MODEL",
+    ]
+    for target in active:
+        lines.append(
+            f"{target['intended_use']:<18} "
+            f"{target['profile']:<12} "
+            f"{target['workload']['name']:<27} "
+            f"{target['model']['id']}"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect or generate official targets."
+    )
+    parser.add_argument("--generate", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--repo-root", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.generate or args.check:
+        repo_root = (args.repo_root or Path.cwd()).resolve()
+        write_generated_outputs(repo_root, check=args.check)
+        print(
+            "official target outputs: ok"
+            if args.check
+            else "official target outputs: generated"
+        )
+        return 0
+
+    registry = load_packaged_registry()
+    if args.as_json:
+        print(_json_text(registry), end="")
+    else:
+        print(render_active_targets(registry))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_official_targets.py
+++ b/tests/test_official_targets.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from vllm_hust_benchmark.official_targets import (
+    PUBLIC_CODE_MODEL,
+    PUBLIC_TEXT_MODEL,
+    PUBLIC_VISION_MODEL,
+    build_registry,
+    generated_outputs,
+    render_active_targets,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_generated_outputs_are_current() -> None:
+    for path, expected in generated_outputs(REPO_ROOT).items():
+        assert path.read_text(encoding="utf-8") == expected
+
+
+def test_registry_matches_schema() -> None:
+    registry = build_registry(REPO_ROOT)
+    schema = json.loads(
+        (REPO_ROOT / "schemas" / "official_target_registry_v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    jsonschema.Draft202012Validator(schema).validate(registry)
+
+
+def test_public_target_matrix_is_exact() -> None:
+    registry = build_registry(REPO_ROOT)
+    active = [target for target in registry["targets"] if target["status"] == "active"]
+    assert len(active) == 9
+    assert {target["model"]["id"] for target in active} == {
+        PUBLIC_TEXT_MODEL,
+        PUBLIC_CODE_MODEL,
+        PUBLIC_VISION_MODEL,
+    }
+    assert {target["intended_use"] for target in active} == {"public-leaderboard"}
+    for target in active:
+        assert target["hardware"]["chip_model"] == "910B2"
+        assert target["hardware"]["chip_count"] == 1
+        assert target["model"]["precision"] == "FP16"
+        assert target["server_parameters"]["tensor_parallel_size"] == 1
+        assert target["server_parameters"]["gpu_memory_utilization"] == 0.6
+        assert target["server_parameters"]["max_model_len"] == 32768
+
+
+def test_perfgate_never_appears_as_active_public_target() -> None:
+    registry = build_registry(REPO_ROOT)
+    perfgate = [
+        target for target in registry["targets"] if target["intended_use"] == "perfgate"
+    ]
+    assert perfgate
+    assert {target["status"] for target in perfgate} == {"provisional"}
+    assert all(target["model"]["parameters"] == "3B" for target in perfgate)
+
+
+def test_source_spec_hashes_match() -> None:
+    registry = build_registry(REPO_ROOT)
+    for target in registry["targets"]:
+        path = REPO_ROOT / target["source_spec"]["path"]
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        assert target["source_spec"]["sha256"] == digest
+
+
+def test_target_ids_are_unique() -> None:
+    registry = build_registry(REPO_ROOT)
+    target_ids = [target["target_id"] for target in registry["targets"]]
+    assert len(target_ids) == len(set(target_ids))
+
+
+def test_active_target_output_excludes_provisional_profiles() -> None:
+    output = render_active_targets(build_registry(REPO_ROOT))
+    assert "Qwen/Qwen2.5-14B-Instruct" in output
+    assert "Qwen/Qwen2.5-3B-Instruct" not in output
+
+
+def test_public_target_drift_fails_closed(tmp_path: Path) -> None:
+    source = (
+        REPO_ROOT
+        / "docs"
+        / "official-baselines"
+        / "official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"
+    )
+    spec_root = tmp_path / "docs" / "official-baselines"
+    spec_root.mkdir(parents=True)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    payload["server_parameters"]["gpu_memory_utilization"] = 0.9
+    (spec_root / source.name).write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="gpu_memory_utilization=0.6"):
+        build_registry(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -222,6 +222,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdformat"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -684,6 +745,8 @@ publish = [
 ]
 test = [
     { name = "jsonschema" },
+    { name = "mdformat" },
+    { name = "mdformat-gfm" },
     { name = "pytest" },
 ]
 
@@ -691,6 +754,17 @@ test = [
 requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.20" },
     { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4" },
+    { name = "mdformat", marker = "extra == 'test'", specifier = "==1.0.0" },
+    { name = "mdformat-gfm", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
 ]
 provides-extras = ["test", "publish"]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]


### PR DESCRIPTION
## 解决的问题

当前官方固定靶分散在 spec、脚本和 CI 默认值中，公开页面无法引用一个稳定版本。本 PR 从当前 main 重新实现 registry，不携带 #119 的 merge gate、数据清理或 mock workflow。

## 修改内容

- 以 `docs/official-baselines/*.json` 为唯一参数源，生成版本化机器 registry、SHA256、中英文矩阵和 changelog。
- 明确区分三类用途：
  - `public-leaderboard`：9 个 active 公开固定靶；
  - `perfgate`：3B 快速 CI profile，标记为 provisional；
  - `specialty`：多卡和专项 workload，配置未齐时保持 provisional。
- active 公开靶强制检查 Ascend 910B2 单卡、FP16、TP=1、`gpu_memory_utilization=0.6`、`max_model_len=32768` 和 v0.18.0 基线。
- 每条记录包含完整 server/client 参数、模型、硬件、基线 runtime、源 spec 路径与 checksum。
- 版本历史绑定完整 source-set hash；spec 改变但不增加 registry 版本时 CI 会失败。
- 新增 `official-targets` 命令，默认只显示 active 公开矩阵，`--json` 输出完整契约。
- CI 校验所有生成文件，禁止 spec、registry 和文档静默漂移。

## 验证

- `uv run --extra test python -m pytest -q tests`：534 passed
- `uvx pre-commit run --files ...`：通过
- `uv run --extra test python -m vllm_hust_benchmark.official_targets --check --repo-root .`：通过
- `git diff --check`：通过

## 后续边界

本 PR 先落唯一契约和生成/校验链路。合并后由 #104 负责人继续完成：

- 网站、core/Ascend PR bot 和 merge gate 改为读取该 registry；
- HF 与 website 发布时核对 `official-targets.sha256`；
- 删除各消费端重复维护的固定靶常量。

Refs #104
