### PR TITLE
feat: add SimLLM saturated warm-cache benchmark

### DIFF
--- a/docs/SIMLLM_OFFICIAL_BENCHMARK_REQUIREMENT.md
+++ b/docs/SIMLLM_OFFICIAL_BENCHMARK_REQUIREMENT.md
@@ -11,9 +11,9 @@
 它适合在线延迟基线，但不适合评估 SimLLM 的 warm-cache 吞吐收益，原因如下：
 
 1. 1 req/s 的客户端到达率可能低于 Baseline 和 SimLLM 的服务能力，最终测到的是请求发生器上限，而不是引擎吞吐上限。
-2. SimLLM 主要减少可复用长 prompt 的 prefill 工作量。短输入、长输出会弱化其目标负载特征。
-3. SimLLM 的 measured pass 必须复用 warmup pass 建立的缓存；重启服务或变更 prompt、seed、token budget 都会破坏可比性。
-4. 只记录最终 req/s 不足以证明收益来自 SimLLM 命中，需要同时提供 cache hit 和 scheduler rewrite 证据。
+1. SimLLM 主要减少可复用长 prompt 的 prefill 工作量。短输入、长输出会弱化其目标负载特征。
+1. SimLLM 的 measured pass 必须复用 warmup pass 建立的缓存；重启服务或变更 prompt、seed、token budget 都会破坏可比性。
+1. 只记录最终 req/s 不足以证明收益来自 SimLLM 命中，需要同时提供 cache hit 和 scheduler rewrite 证据。
 
 ## 参考脚本
 
@@ -32,14 +32,14 @@ scripts/run_simllm_random_online_warm_cache.sh
 工程师在编写官方脚本前应阅读并验证这两个脚本。官方实现应继承以下已经过 Ascend device 5 实机验证的逻辑：
 
 1. 从现有 official random-online baseline spec 派生 saturated same-spec。
-2. Baseline 和 SimLLM measured pass 使用相同 seed、prompt、模型、server 参数和 client 参数。
-3. measured pass 设置 `request_rate=inf` 和有界 `max_concurrency`，解除 1 req/s 的客户端限速。
-4. SimLLM 组先执行低速 warmup，且 warmup 与 measured pass 使用相同 seed 和 prompt 数；两者之间不重启服务。
-5. 显式设置 `temperature=0`，避免模型 generation config 自动启用不适合该测试的采样路径。
-6. 强制 `max_num_batched_tokens >= input_len`，防止 prompt 分块造成 warmup hash 与 measured hash 不一致。
-7. SimLLM KV cache 容量默认与 prompt 数量一致，避免为未使用的 cache entries 占用 HBM。
-8. 分别保存 Baseline 和 SimLLM 原始 benchmark JSON，并自动生成 JSON/Markdown 对比结果。
-9. 检查两组 `completed == num_prompts`；结果不完整时非零退出，不允许使用成功请求子集计算收益。
+1. Baseline 和 SimLLM measured pass 使用相同 seed、prompt、模型、server 参数和 client 参数。
+1. measured pass 设置 `request_rate=inf` 和有界 `max_concurrency`，解除 1 req/s 的客户端限速。
+1. SimLLM 组先执行低速 warmup，且 warmup 与 measured pass 使用相同 seed 和 prompt 数；两者之间不重启服务。
+1. 显式设置 `temperature=0`，避免模型 generation config 自动启用不适合该测试的采样路径。
+1. 强制 `max_num_batched_tokens >= input_len`，防止 prompt 分块造成 warmup hash 与 measured hash 不一致。
+1. SimLLM KV cache 容量默认与 prompt 数量一致，避免为未使用的 cache entries 占用 HBM。
+1. 分别保存 Baseline 和 SimLLM 原始 benchmark JSON，并自动生成 JSON/Markdown 对比结果。
+1. 检查两组 `completed == num_prompts`；结果不完整时非零退出，不允许使用成功请求子集计算收益。
 
 参考脚本的默认实测入口为：
 
@@ -61,9 +61,7 @@ bash scripts/run_simllm_saturated_throughput_warm_cache.sh
 └── throughput_comparison.md
 ```
 
-
 ## 3. 测试目标
-
 
 在同一硬件、模型、代码版本和请求集合下，对比以下两组：
 
@@ -72,44 +70,43 @@ bash scripts/run_simllm_saturated_throughput_warm_cache.sh
 
 主要指标为成功请求吞吐量 `request_throughput`，辅助指标包括 total token throughput、TTFT 和 TPOT。
 
-
-
 ## 4. 官方主测试规格
 
 ### 4.1 固定环境
 
-| 项目 | 要求 |
-| --- | --- |
-| 硬件 | 单张 Huawei Ascend 910B2 |
-| 模型 | `Qwen/Qwen2.5-14B-Instruct` |
-| 精度 | FP16 |
-| Tensor Parallel | 1 |
-| 服务端 | vLLM-HUST + vLLM-Ascend-HUST，版本和 commit 必须写入 artifact |
-| SimLLM | 使用被测 commit，不得在 Baseline 与 SimLLM 组之间切换其他代码 |
-| 设备选择 | 由官方 runner 分配；必须记录实际 device id 和芯片型号，不能从文件名推断 |
+| 项目            | 要求                                                                    |
+| --------------- | ----------------------------------------------------------------------- |
+| 硬件            | 单张 Huawei Ascend 910B2                                                |
+| 模型            | `Qwen/Qwen2.5-14B-Instruct`                                             |
+| 精度            | FP16                                                                    |
+| Tensor Parallel | 1                                                                       |
+| 服务端          | vLLM-HUST + vLLM-Ascend-HUST，版本和 commit 必须写入 artifact           |
+| SimLLM          | 使用被测 commit，不得在 Baseline 与 SimLLM 组之间切换其他代码           |
+| 设备选择        | 由官方 runner 分配；必须记录实际 device id 和芯片型号，不能从文件名推断 |
 
 ### 4.2 固定请求规格
 
-| 参数 | 值 |
-| --- | ---: |
-| scenario | `random-online`，使用独立的 SimLLM saturated warm-cache profile 标识 |
-| endpoint | `/v1/completions` |
-| dataset | deterministic random |
-| seed | `0` |
-| num_prompts | `32` |
-| input_len | `4096` |
-| output_len | `32` |
-| temperature | `0` |
-| measured request_rate | `inf` |
-| measured max_concurrency | `16` |
-| warmup request_rate | `1` |
-| warmup passes | `1` |
-| warmup seed | 与 measured seed 相同 |
-| warmup num_prompts | 与 measured num_prompts 相同 |
-| max_num_batched_tokens | 不小于 `4096`，主规格固定为 `4096` |
-| SimLLM KV cache entries | 不小于 `32`，主规格固定为 `32` |
+| 参数                     |                                                                   值 |
+| ------------------------ | -------------------------------------------------------------------: |
+| scenario                 | `random-online`，使用独立的 SimLLM saturated warm-cache profile 标识 |
+| endpoint                 |                                                    `/v1/completions` |
+| dataset                  |                                                 deterministic random |
+| seed                     |                                                                  `0` |
+| num_prompts              |                                                                 `32` |
+| input_len                |                                                               `4096` |
+| output_len               |                                                                 `32` |
+| temperature              |                                                                  `0` |
+| measured request_rate    |                                                                `inf` |
+| measured max_concurrency |                                                                 `16` |
+| warmup request_rate      |                                                                  `1` |
+| warmup passes            |                                                                  `1` |
+| warmup seed              |                                                与 measured seed 相同 |
+| warmup num_prompts       |                                         与 measured num_prompts 相同 |
+| max_num_batched_tokens   |                                   不小于 `4096`，主规格固定为 `4096` |
+| SimLLM KV cache entries  |                                       不小于 `32`，主规格固定为 `32` |
 
-选择 4096-token 输入是为了让负载以 prefill 为主；选择 32 个请求和 16 并发，是当前实现已验证能够稳定完成 warm-cache 饱和测试的主规格。该规格不是通用扩展性结论，因此还必须执行第 8 节的稳定性测试。
+选择 4096-token 输入是为了让负载以 prefill 为主；选择 32 个请求和 16 并发，是当前实现已验证能够稳定完成 warm-cache
+饱和测试的主规格。该规格不是通用扩展性结论，因此还必须执行第 8 节的稳定性测试。
 
 ## 5. A/B 执行流程
 
@@ -118,21 +115,21 @@ bash scripts/run_simllm_saturated_throughput_warm_cache.sh
 ### 5.1 Baseline
 
 1. 确认目标 device 空闲并记录初始 HBM。
-2. 启动 SimLLM disabled 服务。
-3. 等待 `/health` ready，并执行一个不计入结果的健康检查请求。
-4. 使用第 4.2 节的 measured 参数执行饱和压测。
-5. 保存原始结果、服务日志、resolved same-spec 和运行元数据。
-6. 停止完整服务进程树，并确认端口和 NPU 内存释放。
+1. 启动 SimLLM disabled 服务。
+1. 等待 `/health` ready，并执行一个不计入结果的健康检查请求。
+1. 使用第 4.2 节的 measured 参数执行饱和压测。
+1. 保存原始结果、服务日志、resolved same-spec 和运行元数据。
+1. 停止完整服务进程树，并确认端口和 NPU 内存释放。
 
 ### 5.2 SimLLM warm cache
 
 1. 使用相同代码、模型和 server 参数启动 SimLLM enabled 服务。
-2. 等待服务 ready。
-3. 使用与 measured pass 完全相同的 prompt 集合、顺序和 seed 执行一次低速 warmup。
-4. warmup 完成后不得重启服务、清空缓存或改变请求集合。
-5. 执行 `request_rate=inf`、`max_concurrency=16` 的 measured pass。
-6. 保存 warmup 结果、measured 原始结果、cache hit/rewrite 统计、服务日志和运行元数据。
-7. 停止完整服务进程树，并确认资源释放。
+1. 等待服务 ready。
+1. 使用与 measured pass 完全相同的 prompt 集合、顺序和 seed 执行一次低速 warmup。
+1. warmup 完成后不得重启服务、清空缓存或改变请求集合。
+1. 执行 `request_rate=inf`、`max_concurrency=16` 的 measured pass。
+1. 保存 warmup 结果、measured 原始结果、cache hit/rewrite 统计、服务日志和运行元数据。
+1. 停止完整服务进程树，并确认资源释放。
 
 ### 5.3 重复次数
 
@@ -174,14 +171,13 @@ Baseline 与 SimLLM measured pass 之间，以下字段必须一致：
 improvement_percent = (simllm_median - baseline_median) / baseline_median * 100
 ```
 
-
 ## 本地可行性结果，仅供参考
 
 以下结果来自非官方本地脚本，说明能够体现 SimLLM 吞吐差异：
 
-| 指标 | Baseline | SimLLM warm cache | 差异 |
-| --- | ---: | ---: | ---: |
-| Requests/s | 1.4055 | 4.7897 | +240.78% |
-| Total tokens/s | 5801.86 | 19771.68 | +240.78% |
-| Mean TTFT | 3616.75 ms | 547.20 ms | -84.87% |
-| 成功请求 | 32/32 | 32/32 | 均无失败 |
+| 指标           |   Baseline | SimLLM warm cache |     差异 |
+| -------------- | ---------: | ----------------: | -------: |
+| Requests/s     |     1.4055 |            4.7897 | +240.78% |
+| Total tokens/s |    5801.86 |          19771.68 | +240.78% |
+| Mean TTFT      | 3616.75 ms |         547.20 ms |  -84.87% |
+| 成功请求       |      32/32 |             32/32 | 均无失败 |

--- a/docs/SIMLLM_OFFICIAL_BENCHMARK_REQUIREMENT.md
+++ b/docs/SIMLLM_OFFICIAL_BENCHMARK_REQUIREMENT.md
@@ -1,0 +1,187 @@
+# SimLLM 官方 Warm-Cache 吞吐测试需求
+
+## 背景与问题
+
+当前通用 `random-online` 官方规格使用：
+
+- `request_rate=1`
+- 1024 input tokens
+- 256 output tokens
+
+它适合在线延迟基线，但不适合评估 SimLLM 的 warm-cache 吞吐收益，原因如下：
+
+1. 1 req/s 的客户端到达率可能低于 Baseline 和 SimLLM 的服务能力，最终测到的是请求发生器上限，而不是引擎吞吐上限。
+2. SimLLM 主要减少可复用长 prompt 的 prefill 工作量。短输入、长输出会弱化其目标负载特征。
+3. SimLLM 的 measured pass 必须复用 warmup pass 建立的缓存；重启服务或变更 prompt、seed、token budget 都会破坏可比性。
+4. 只记录最终 req/s 不足以证明收益来自 SimLLM 命中，需要同时提供 cache hit 和 scheduler rewrite 证据。
+
+## 参考脚本
+
+本需求以仓库中的以下脚本作为工程参考：
+
+```text
+scripts/run_simllm_saturated_throughput_warm_cache.sh
+```
+
+参考脚本调用现有 warm-cache runner：
+
+```text
+scripts/run_simllm_random_online_warm_cache.sh
+```
+
+工程师在编写官方脚本前应阅读并验证这两个脚本。官方实现应继承以下已经过 Ascend device 5 实机验证的逻辑：
+
+1. 从现有 official random-online baseline spec 派生 saturated same-spec。
+2. Baseline 和 SimLLM measured pass 使用相同 seed、prompt、模型、server 参数和 client 参数。
+3. measured pass 设置 `request_rate=inf` 和有界 `max_concurrency`，解除 1 req/s 的客户端限速。
+4. SimLLM 组先执行低速 warmup，且 warmup 与 measured pass 使用相同 seed 和 prompt 数；两者之间不重启服务。
+5. 显式设置 `temperature=0`，避免模型 generation config 自动启用不适合该测试的采样路径。
+6. 强制 `max_num_batched_tokens >= input_len`，防止 prompt 分块造成 warmup hash 与 measured hash 不一致。
+7. SimLLM KV cache 容量默认与 prompt 数量一致，避免为未使用的 cache entries 占用 HBM。
+8. 分别保存 Baseline 和 SimLLM 原始 benchmark JSON，并自动生成 JSON/Markdown 对比结果。
+9. 检查两组 `completed == num_prompts`；结果不完整时非零退出，不允许使用成功请求子集计算收益。
+
+参考脚本的默认实测入口为：
+
+```bash
+cd /workspace/vllm-hust-benchmark
+ASCEND_RT_VISIBLE_DEVICES=5 \
+CURRENT_MODEL_PATH=/data/shared_models/Qwen2.5-14B-Instruct \
+bash scripts/run_simllm_saturated_throughput_warm_cache.sh
+```
+
+参考脚本当前产生的主要文件包括：
+
+```text
+.benchmarks/simllm-saturated-throughput-warm-cache/
+├── saturated-same-spec.json
+├── baseline-disabled/raw_benchmark_result.json
+├── enabled-warm-cache/raw_benchmark_result.json
+├── throughput_comparison.json
+└── throughput_comparison.md
+```
+
+
+## 3. 测试目标
+
+
+在同一硬件、模型、代码版本和请求集合下，对比以下两组：
+
+- Baseline：SimLLM 关闭，不执行 SimLLM warmup。
+- SimLLM warm cache：SimLLM 开启，先暖缓存，再在不重启服务的情况下执行正式测量。
+
+主要指标为成功请求吞吐量 `request_throughput`，辅助指标包括 total token throughput、TTFT 和 TPOT。
+
+
+
+## 4. 官方主测试规格
+
+### 4.1 固定环境
+
+| 项目 | 要求 |
+| --- | --- |
+| 硬件 | 单张 Huawei Ascend 910B2 |
+| 模型 | `Qwen/Qwen2.5-14B-Instruct` |
+| 精度 | FP16 |
+| Tensor Parallel | 1 |
+| 服务端 | vLLM-HUST + vLLM-Ascend-HUST，版本和 commit 必须写入 artifact |
+| SimLLM | 使用被测 commit，不得在 Baseline 与 SimLLM 组之间切换其他代码 |
+| 设备选择 | 由官方 runner 分配；必须记录实际 device id 和芯片型号，不能从文件名推断 |
+
+### 4.2 固定请求规格
+
+| 参数 | 值 |
+| --- | ---: |
+| scenario | `random-online`，使用独立的 SimLLM saturated warm-cache profile 标识 |
+| endpoint | `/v1/completions` |
+| dataset | deterministic random |
+| seed | `0` |
+| num_prompts | `32` |
+| input_len | `4096` |
+| output_len | `32` |
+| temperature | `0` |
+| measured request_rate | `inf` |
+| measured max_concurrency | `16` |
+| warmup request_rate | `1` |
+| warmup passes | `1` |
+| warmup seed | 与 measured seed 相同 |
+| warmup num_prompts | 与 measured num_prompts 相同 |
+| max_num_batched_tokens | 不小于 `4096`，主规格固定为 `4096` |
+| SimLLM KV cache entries | 不小于 `32`，主规格固定为 `32` |
+
+选择 4096-token 输入是为了让负载以 prefill 为主；选择 32 个请求和 16 并发，是当前实现已验证能够稳定完成 warm-cache 饱和测试的主规格。该规格不是通用扩展性结论，因此还必须执行第 8 节的稳定性测试。
+
+## 5. A/B 执行流程
+
+每次 repetition 必须执行完整、相互隔离的 A/B 流程。
+
+### 5.1 Baseline
+
+1. 确认目标 device 空闲并记录初始 HBM。
+2. 启动 SimLLM disabled 服务。
+3. 等待 `/health` ready，并执行一个不计入结果的健康检查请求。
+4. 使用第 4.2 节的 measured 参数执行饱和压测。
+5. 保存原始结果、服务日志、resolved same-spec 和运行元数据。
+6. 停止完整服务进程树，并确认端口和 NPU 内存释放。
+
+### 5.2 SimLLM warm cache
+
+1. 使用相同代码、模型和 server 参数启动 SimLLM enabled 服务。
+2. 等待服务 ready。
+3. 使用与 measured pass 完全相同的 prompt 集合、顺序和 seed 执行一次低速 warmup。
+4. warmup 完成后不得重启服务、清空缓存或改变请求集合。
+5. 执行 `request_rate=inf`、`max_concurrency=16` 的 measured pass。
+6. 保存 warmup 结果、measured 原始结果、cache hit/rewrite 统计、服务日志和运行元数据。
+7. 停止完整服务进程树，并确认资源释放。
+
+### 5.3 重复次数
+
+- 正式采集至少执行 3 个有效 repetitions，建议 5 个。
+- 每个 repetition 都必须重新启动 Baseline 和 SimLLM 服务，不能复用上一轮缓存。
+- 官方汇总采用各 repetition 的中位数，同时报告最小值、最大值和变异系数。
+- 若主指标变异系数大于 5%，不得直接发布单一官方结果；应继续运行或定位环境抖动。
+
+## 6. 公平性与 same-spec 要求
+
+Baseline 与 SimLLM measured pass 之间，以下字段必须一致：
+
+- model、dtype、tensor parallel、block size 和服务端内存参数
+- dataset、prompt token ids、seed 和请求顺序
+- input/output token length
+- temperature、endpoint、request rate 和 max concurrency
+- max_num_batched_tokens
+- vLLM-HUST 与 vLLM-Ascend-HUST commits
+- CANN、torch、torch-npu 和 Python 环境
+
+唯一允许的功能性差异是 SimLLM enable/config 环境变量，以及 SimLLM 组在 measured pass 前执行 warmup。
+
+脚本必须生成 resolved same-spec 文件及稳定的 spec hash。汇总程序在发现 A/B setting signature 不一致时必须失败，不能只打印 warning。
+
+## 7. 指标和证据
+
+- successful requests / failed requests
+- benchmark duration
+- request throughput，req/s，主指标
+- input、output、total token throughput
+- mean、median、P99 TTFT
+- mean、median、P99 TPOT 或 ITL
+- Peak concurrent requests
+- 每轮和汇总后的提升百分比
+
+提升计算方式：
+
+```text
+improvement_percent = (simllm_median - baseline_median) / baseline_median * 100
+```
+
+
+## 本地可行性结果，仅供参考
+
+以下结果来自非官方本地脚本，说明能够体现 SimLLM 吞吐差异：
+
+| 指标 | Baseline | SimLLM warm cache | 差异 |
+| --- | ---: | ---: | ---: |
+| Requests/s | 1.4055 | 4.7897 | +240.78% |
+| Total tokens/s | 5801.86 | 19771.68 | +240.78% |
+| Mean TTFT | 3616.75 ms | 547.20 ms | -84.87% |
+| 成功请求 | 32/32 | 32/32 | 均无失败 |

--- a/scripts/run_simllm_random_online_warm_cache.sh
+++ b/scripts/run_simllm_random_online_warm_cache.sh
@@ -1,0 +1,714 @@
+#!/bin/bash
+set -euo pipefail
+
+# SimLLM random-online A/B runner with a warm-cache phase.
+#
+# Flow:
+#   1. Baseline: run the official same-spec benchmark with SimLLM disabled.
+#   2. SimLLM: start one server, run an unmeasured warmup pass, then run the
+#      measured benchmark against the still-live server so KVManager remains hot.
+#
+# Example:
+#   cd /workspace/vllm-hust-benchmark
+#   ASCEND_RT_VISIBLE_DEVICES=6 \
+#   CURRENT_MODEL_PATH=/data/shared_models/Qwen2.5-14B-Instruct \
+#   RESULT_DIR=/workspace/vllm-hust-benchmark/.benchmarks/simllm-random-online-warm-cache \
+#   bash scripts/run_simllm_random_online_warm_cache.sh
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
+BENCHMARK_REPO=${VLLM_HUST_BENCHMARK_REPO:-"$WORKSPACE_ROOT/vllm-hust-benchmark"}
+DEFAULT_SPEC_FILE="$BENCHMARK_REPO/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"
+VLLM_CLI_COMPAT=${VLLM_CLI_COMPAT:-"$BENCHMARK_REPO/scripts/run_vllm_cli_compat.py"}
+SPEC_FILE=${1:-"$DEFAULT_SPEC_FILE"}
+CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$BENCHMARK_REPO/docs/official-baselines/official-ascend-constraints.stub.json"}
+
+CURRENT_RUNTIME_CWD=${CURRENT_RUNTIME_CWD:-"/tmp"}
+CURRENT_VLLM_HUST_REPO=${CURRENT_VLLM_HUST_REPO:-"$WORKSPACE_ROOT/vllm-hust"}
+CURRENT_VLLM_ASCEND_HUST_REPO=${CURRENT_VLLM_ASCEND_HUST_REPO:-"$WORKSPACE_ROOT/vllm-ascend-hust"}
+CURRENT_ENV_PREFIX=${CURRENT_ENV_PREFIX:-"/root/miniconda3/envs/vllm-hust-dev"}
+CURRENT_RUNTIME_PYTHON=${CURRENT_RUNTIME_PYTHON:-"$CURRENT_ENV_PREFIX/bin/python"}
+CURRENT_VLLM_CACHE_ROOT=${CURRENT_VLLM_CACHE_ROOT:-"$REPO_ROOT/.cache/simllm-warm-cache"}
+CURRENT_ENGINE=${CURRENT_ENGINE:-"vllm-hust"}
+CURRENT_BASELINE_ENGINE=${CURRENT_BASELINE_ENGINE:-"vllm"}
+CURRENT_DATA_SOURCE=${CURRENT_DATA_SOURCE:-"vllm-hust-benchmark"}
+CURRENT_SUBMITTER=${CURRENT_SUBMITTER:-"simllm-warm-cache"}
+CURRENT_GITHUB_REPOSITORY=${CURRENT_GITHUB_REPOSITORY:-"vLLM-HUST/vllm-hust"}
+CURRENT_GITHUB_REF=${CURRENT_GITHUB_REF:-$(git -C "$CURRENT_VLLM_HUST_REPO" branch --show-current 2>/dev/null || echo main)}
+CURRENT_GIT_COMMIT=${CURRENT_GIT_COMMIT:-$(git -C "$CURRENT_VLLM_HUST_REPO" rev-parse HEAD 2>/dev/null || true)}
+CURRENT_PLUGIN_ENGINE=${CURRENT_PLUGIN_ENGINE:-"vllm-ascend-hust"}
+CURRENT_PLUGIN_GITHUB_REPOSITORY=${CURRENT_PLUGIN_GITHUB_REPOSITORY:-"vLLM-HUST/vllm-ascend-hust"}
+CURRENT_PLUGIN_GITHUB_REF=${CURRENT_PLUGIN_GITHUB_REF:-$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" branch --show-current 2>/dev/null || echo main)}
+CURRENT_PLUGIN_GIT_COMMIT=${CURRENT_PLUGIN_GIT_COMMIT:-$(git -C "$CURRENT_VLLM_ASCEND_HUST_REPO" rev-parse HEAD 2>/dev/null || true)}
+
+ASCEND_TOOLKIT_SET_ENV=${ASCEND_TOOLKIT_SET_ENV:-"/usr/local/Ascend/ascend-toolkit/set_env.sh"}
+ASCEND_ATB_SET_ENV=${ASCEND_ATB_SET_ENV:-"/usr/local/Ascend/nnal/atb/set_env.sh"}
+ASCEND_ATB_CXX_ABI=${ASCEND_ATB_CXX_ABI:-"1"}
+READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-600}
+READY_STATUS_INTERVAL_SECONDS=${READY_STATUS_INTERVAL_SECONDS:-30}
+CLIENT_READY_CHECK_TIMEOUT_SECONDS=${CLIENT_READY_CHECK_TIMEOUT_SECONDS:-$READY_TIMEOUT_SECONDS}
+
+CURRENT_SERVER_HOST=${CURRENT_SERVER_HOST:-}
+CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-"8021"}
+CURRENT_CLIENT_HOST=${CURRENT_CLIENT_HOST:-}
+CURRENT_CLIENT_PORT=${CURRENT_CLIENT_PORT:-$CURRENT_SERVER_PORT}
+CURRENT_CLIENT_TEMPERATURE=${CURRENT_CLIENT_TEMPERATURE:-}
+CURRENT_DTYPE=${CURRENT_DTYPE:-}
+CURRENT_MODEL_NAME=${CURRENT_MODEL_NAME:-}
+CURRENT_MODEL_PARAMETERS=${CURRENT_MODEL_PARAMETERS:-}
+CURRENT_MODEL_PRECISION=${CURRENT_MODEL_PRECISION:-}
+CURRENT_MODEL_QUANTIZATION=${CURRENT_MODEL_QUANTIZATION:-}
+CURRENT_HARDWARE_CHIP_MODEL=${CURRENT_HARDWARE_CHIP_MODEL:-}
+BASELINE_SERVER_PORT=${BASELINE_SERVER_PORT:-$CURRENT_SERVER_PORT}
+SIMLLM_SERVER_PORT=${SIMLLM_SERVER_PORT:-$CURRENT_SERVER_PORT}
+
+RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/simllm-random-online-warm-cache"}
+BASELINE_DIR=${BASELINE_DIR:-"$RESULT_DIR/baseline-disabled"}
+SIMLLM_DIR=${SIMLLM_DIR:-"$RESULT_DIR/enabled-warm-cache"}
+RUN_BASELINE=${RUN_BASELINE:-1}
+RUN_SIMLLM=${RUN_SIMLLM:-1}
+RUN_TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+
+SIMLLM_COSINE_THRESHOLD=${VLLM_ASCEND_SIMLLM_COSINE_THRESHOLD:-${SIMLLM_COSINE_THRESHOLD:-0.8}}
+SIMLLM_LSH_NUM_BITS=${VLLM_ASCEND_SIMLLM_LSH_NUM_BITS:-${SIMLLM_LSH_NUM_BITS:-64}}
+SIMLLM_LSH_BATCH_THRESHOLD=${VLLM_ASCEND_SIMLLM_LSH_BATCH_THRESHOLD:-${SIMLLM_LSH_BATCH_THRESHOLD:-32}}
+SIMLLM_KV_CACHE_SIZE=${VLLM_ASCEND_SIMLLM_KV_CACHE_SIZE:-${SIMLLM_KV_CACHE_SIZE:-1024}}
+SIMLLM_SANDWICH_BOTTOM=${VLLM_ASCEND_SIMLLM_SANDWICH_BOTTOM:-${SIMLLM_SANDWICH_BOTTOM:-3}}
+SIMLLM_SANDWICH_TOP=${VLLM_ASCEND_SIMLLM_SANDWICH_TOP:-${SIMLLM_SANDWICH_TOP:-3}}
+SIMLLM_UNMATCHED_STORE_MODE=${VLLM_ASCEND_SIMLLM_UNMATCHED_STORE_MODE:-${SIMLLM_UNMATCHED_STORE_MODE:-top}}
+SIMLLM_PROFILE=${VLLM_ASCEND_SIMLLM_PROFILE:-${SIMLLM_PROFILE:-0}}
+SIMLLM_PROFILE_INTERVAL=${VLLM_ASCEND_SIMLLM_PROFILE_INTERVAL:-${SIMLLM_PROFILE_INTERVAL:-20}}
+
+SIMLLM_WARMCACHE_PASSES=${SIMLLM_WARMCACHE_PASSES:-1}
+SIMLLM_WARMCACHE_NUM_PROMPTS=${SIMLLM_WARMCACHE_NUM_PROMPTS:-}
+SIMLLM_WARMCACHE_REQUEST_RATE=${SIMLLM_WARMCACHE_REQUEST_RATE:-}
+SIMLLM_WARMCACHE_SEED=${SIMLLM_WARMCACHE_SEED:-0}
+SIMLLM_MEASURE_SEED=${SIMLLM_MEASURE_SEED:-$SIMLLM_WARMCACHE_SEED}
+SIMLLM_WARMCACHE_PAUSE_SECONDS=${SIMLLM_WARMCACHE_PAUSE_SECONDS:-5}
+
+ACTIVE_SERVER_PID=""
+CURRENT_RUNTIME_SOURCE_PYTHONPATH="$BENCHMARK_REPO/src:$CURRENT_VLLM_ASCEND_HUST_REPO:$CURRENT_VLLM_HUST_REPO"
+CURRENT_RUNTIME_PYTHONPATH="${CURRENT_RUNTIME_SOURCE_PYTHONPATH}${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}"
+
+disable_proxy_env() {
+  unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+  export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost,::1}"
+  export no_proxy="$NO_PROXY"
+}
+
+usage() {
+  echo "Usage: $0 [random-online-official-spec.json]" >&2
+}
+
+if [[ -z "$SPEC_FILE" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -d "$BENCHMARK_REPO" ]]; then
+  echo "Benchmark repo not found: $BENCHMARK_REPO" >&2
+  echo "Set VLLM_HUST_BENCHMARK_REPO to the vllm-hust-benchmark checkout." >&2
+  exit 2
+fi
+SPEC_FILE=$(cd "$(dirname "$SPEC_FILE")" && pwd)/$(basename "$SPEC_FILE")
+if [[ ! -f "$SPEC_FILE" ]]; then
+  echo "Spec file not found: $SPEC_FILE" >&2
+  exit 2
+fi
+if [[ ! -f "$CONSTRAINTS_FILE" ]]; then
+  echo "Constraints stub not found: $CONSTRAINTS_FILE" >&2
+  exit 2
+fi
+if [[ ! -x "$CURRENT_RUNTIME_PYTHON" ]]; then
+  echo "CURRENT_RUNTIME_PYTHON is not executable: $CURRENT_RUNTIME_PYTHON" >&2
+  exit 2
+fi
+if [[ ! -f "$VLLM_CLI_COMPAT" ]]; then
+  echo "CLI compatibility wrapper not found: $VLLM_CLI_COMPAT" >&2
+  exit 2
+fi
+
+run_in_runtime() {
+  local pythonpath_prefix=${1:-$CURRENT_RUNTIME_PYTHONPATH}
+  shift
+  (
+    cd "$CURRENT_RUNTIME_CWD"
+    disable_proxy_env
+    export ZSH_VERSION=""
+    if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_TOOLKIT_SET_ENV"
+      set -u
+    fi
+    if [[ -f "$ASCEND_ATB_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
+      set -u
+    fi
+    export VLLM_CACHE_ROOT="$CURRENT_VLLM_CACHE_ROOT"
+    PYTHONPATH="$pythonpath_prefix${PYTHONPATH:+:$PYTHONPATH}" "$@"
+  )
+}
+
+json2args() {
+  local json_string=$1
+  echo "$json_string" | jq -r '
+    to_entries
+    | map(if (.value | tostring) == ""
+          then "--" + (.key | gsub("_"; "-"))
+          else "--" + (.key | gsub("_"; "-")) + " " + (.value | tostring)
+          end)
+    | join(" ")
+  '
+}
+
+maybe_git_describe() {
+  local repo=$1
+  local commit=${2:-}
+  local described=""
+
+  if [[ -n "$commit" ]]; then
+    described=$(git -C "$repo" describe --tags --always "$commit" 2>/dev/null || true)
+  fi
+  if [[ -z "$described" ]]; then
+    described=$(git -C "$repo" describe --tags --always HEAD 2>/dev/null || true)
+  fi
+  printf '%s' "${described:-unknown}"
+}
+
+append_export_arg_if_present() {
+  local flag=$1
+  local value=$2
+
+  if [[ -n "$value" && "$value" != "null" ]]; then
+    EXPORT_ARGS+=("$flag" "$value")
+  fi
+}
+
+resolve_benchmark_type() {
+  local scenario=$1
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    env SCENARIO_NAME="$scenario" \
+    "$CURRENT_RUNTIME_PYTHON" -c \
+    "import os; from vllm_hust_benchmark.registry import get_scenario; print(get_scenario(os.environ['SCENARIO_NAME']).benchmark_type)"
+}
+
+resolve_spec() {
+  local spec_file=$1
+  local output_file=$2
+  local runtime_model=$3
+  local port=$4
+  local resolve_args=(
+    "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.same_spec resolve
+    --spec-file "$spec_file"
+    --output-file "$output_file"
+    --runtime-model "$runtime_model"
+    --server-port "$port"
+    --client-port "$port"
+  )
+
+  if [[ -n "$CURRENT_SERVER_HOST" ]]; then
+    resolve_args+=(--server-host "$CURRENT_SERVER_HOST")
+  fi
+  if [[ -n "$CURRENT_CLIENT_HOST" ]]; then
+    resolve_args+=(--client-host "$CURRENT_CLIENT_HOST")
+  fi
+  if [[ -n "$CURRENT_DTYPE" ]]; then
+    resolve_args+=(--dtype "$CURRENT_DTYPE")
+  fi
+  if [[ -n "$CURRENT_MODEL_NAME" ]]; then
+    resolve_args+=(--model "$CURRENT_MODEL_NAME")
+  fi
+  if [[ -n "$CURRENT_MODEL_PARAMETERS" ]]; then
+    resolve_args+=(--model-parameters "$CURRENT_MODEL_PARAMETERS")
+  fi
+  if [[ -n "$CURRENT_MODEL_PRECISION" ]]; then
+    resolve_args+=(--model-precision "$CURRENT_MODEL_PRECISION")
+  fi
+  if [[ -n "$CURRENT_MODEL_QUANTIZATION" ]]; then
+    resolve_args+=(--model-quantization "$CURRENT_MODEL_QUANTIZATION")
+  fi
+  if [[ -n "$CURRENT_HARDWARE_CHIP_MODEL" ]]; then
+    resolve_args+=(--hardware-chip-model "$CURRENT_HARDWARE_CHIP_MODEL")
+  fi
+
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" "${resolve_args[@]}"
+}
+
+normalized_client_parameters_json() {
+  local same_spec_file=$1
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    env SAME_SPEC_FILE="$same_spec_file" \
+    BENCHMARK_TYPE=serve \
+    CLIENT_READY_CHECK_TIMEOUT_SECONDS="$CLIENT_READY_CHECK_TIMEOUT_SECONDS" \
+    CURRENT_CLIENT_TEMPERATURE="$CURRENT_CLIENT_TEMPERATURE" \
+    CURRENT_VLLM_WORKTREE="$CURRENT_VLLM_HUST_REPO" \
+    "$CURRENT_RUNTIME_PYTHON" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from vllm_hust_benchmark.official_runtime_inputs import normalize_client_parameters
+
+payload = json.loads(Path(os.environ["SAME_SPEC_FILE"]).read_text(encoding="utf-8"))
+client_temperature = os.environ.get("CURRENT_CLIENT_TEMPERATURE", "").strip()
+parameters = normalize_client_parameters(
+    payload["resolved_client_parameters"],
+    benchmark_type=os.environ["BENCHMARK_TYPE"],
+    ready_check_timeout_sec=int(os.environ.get("CLIENT_READY_CHECK_TIMEOUT_SECONDS") or 0),
+    vllm_worktree=os.environ.get("CURRENT_VLLM_WORKTREE"),
+)
+if os.environ["BENCHMARK_TYPE"] == "serve" and client_temperature:
+    parameters["temperature"] = client_temperature
+print(
+    json.dumps(
+        parameters,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+)
+PY
+}
+
+client_json_with_seed() {
+  local client_json=$1
+  local seed=$2
+
+  if [[ -z "$seed" ]]; then
+    printf '%s' "$client_json"
+    return 0
+  fi
+
+  echo "$client_json" | jq -c --arg seed "$seed" '. + {seed: ($seed | tonumber)}'
+}
+
+warmup_client_json() {
+  local client_json=$1
+
+  echo "$client_json" | jq -c \
+    --arg seed "$SIMLLM_WARMCACHE_SEED" \
+    --arg num_prompts "$SIMLLM_WARMCACHE_NUM_PROMPTS" \
+    --arg request_rate "$SIMLLM_WARMCACHE_REQUEST_RATE" '
+      def maybe_number($value): try ($value | tonumber) catch $value;
+      . + {seed: ($seed | tonumber)}
+      | if $num_prompts == "" then . else . + {num_prompts: maybe_number($num_prompts)} end
+      | if $request_rate == "" then . else . + {request_rate: maybe_number($request_rate)} end
+    '
+}
+
+list_port_listener_pids() {
+  local port=$1
+
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>/dev/null | grep -E ":${port}[[:space:]]" | grep -o 'pid=[0-9]*' | cut -d= -f2 | sort -u || true
+    return 0
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti tcp:"$port" -sTCP:LISTEN 2>/dev/null | sort -u || true
+    return 0
+  fi
+  if command -v fuser >/dev/null 2>&1; then
+    fuser "${port}/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u || true
+  fi
+}
+
+port_has_listener() {
+  [[ -n "$(list_port_listener_pids "$1")" ]]
+}
+
+assert_port_available() {
+  local port=$1
+
+  if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+    echo "Target port ${port} already has a healthy service; refusing to reuse it." >&2
+    return 1
+  fi
+  if port_has_listener "$port"; then
+    echo "Target port ${port} already has a listener; choose another port or stop it first." >&2
+    return 1
+  fi
+}
+
+list_child_pids() {
+  local parent_pid=$1
+  ps -eo pid=,ppid= | awk -v target="$parent_pid" '$2 == target {print $1}'
+}
+
+collect_process_tree_pids() {
+  local root_pid=$1
+  local child_pid
+
+  if ! kill -0 "$root_pid" 2>/dev/null; then
+    return 0
+  fi
+  echo "$root_pid"
+  while IFS= read -r child_pid; do
+    [[ -z "$child_pid" ]] && continue
+    collect_process_tree_pids "$child_pid"
+  done < <(list_child_pids "$root_pid")
+}
+
+terminate_pid_tree() {
+  local pid=$1
+  local description=$2
+  local tree_pids
+  local tree_list
+  local tree_pid
+  local still_running
+
+  tree_pids=$(collect_process_tree_pids "$pid" | sort -u)
+  [[ -z "$tree_pids" ]] && return 0
+  tree_list=$(echo "$tree_pids" | tr '\n' ' ')
+
+  echo "[simllm-warm-cache] stopping ${description}: ${tree_list}"
+  kill $tree_list 2>/dev/null || true
+
+  for _ in $(seq 1 10); do
+    still_running=0
+    while IFS= read -r tree_pid; do
+      [[ -z "$tree_pid" ]] && continue
+      if kill -0 "$tree_pid" 2>/dev/null; then
+        still_running=1
+        break
+      fi
+    done <<< "$tree_pids"
+    [[ "$still_running" == "0" ]] && return 0
+    sleep 1
+  done
+
+  kill -9 $tree_list 2>/dev/null || true
+}
+
+cleanup_active_server() {
+  if [[ -n "${ACTIVE_SERVER_PID:-}" ]]; then
+    terminate_pid_tree "$ACTIVE_SERVER_PID" "active SimLLM benchmark server" || true
+    ACTIVE_SERVER_PID=""
+  fi
+}
+
+trap cleanup_active_server EXIT
+
+probe_server_ready() {
+  local host=$1
+  local port=$2
+
+  curl -fsS "http://${host}:${port}/health" >/dev/null 2>&1 \
+    || curl -fsS "http://${host}:${port}/v1/models" >/dev/null 2>&1
+}
+
+wait_for_server() {
+  local host=$1
+  local port=$2
+  local log_file=$3
+  local waited=0
+  local next_status_at=0
+
+  while (( waited < READY_TIMEOUT_SECONDS )); do
+    if [[ -n "$ACTIVE_SERVER_PID" ]] && ! kill -0 "$ACTIVE_SERVER_PID" 2>/dev/null; then
+      echo "Server exited before becoming ready." >&2
+      tail -n 60 "$log_file" >&2 || true
+      return 1
+    fi
+
+    if probe_server_ready "$host" "$port"; then
+      echo "[simllm-warm-cache] server ready after ${waited}s"
+      return 0
+    fi
+
+    if (( waited >= next_status_at )); then
+      echo "[simllm-warm-cache] waiting for server at ${host}:${port} (${waited}s/${READY_TIMEOUT_SECONDS}s)" >&2
+      next_status_at=$((waited + READY_STATUS_INTERVAL_SECONDS))
+    fi
+    sleep 1
+    ((waited += 1))
+  done
+
+  echo "Timed out waiting for server at ${host}:${port}" >&2
+  tail -n 60 "$log_file" >&2 || true
+  return 1
+}
+
+start_server() {
+  local simllm_enabled=$1
+  local server_args=$2
+  local log_file=$3
+
+  : >"$log_file"
+  (
+    cd "$CURRENT_RUNTIME_CWD"
+    disable_proxy_env
+    export ZSH_VERSION=""
+    if [[ -f "$ASCEND_TOOLKIT_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_TOOLKIT_SET_ENV"
+      set -u
+    fi
+    if [[ -f "$ASCEND_ATB_SET_ENV" ]]; then
+      set +u
+      # shellcheck disable=SC1090
+      source "$ASCEND_ATB_SET_ENV" --cxx_abi="$ASCEND_ATB_CXX_ABI"
+      set -u
+    fi
+    export VLLM_CACHE_ROOT="$CURRENT_VLLM_CACHE_ROOT"
+    export VLLM_ASCEND_SIMLLM_ENABLED="$simllm_enabled"
+    export VLLM_ASCEND_SIMLLM_COSINE_THRESHOLD="$SIMLLM_COSINE_THRESHOLD"
+    export VLLM_ASCEND_SIMLLM_LSH_NUM_BITS="$SIMLLM_LSH_NUM_BITS"
+    export VLLM_ASCEND_SIMLLM_LSH_BATCH_THRESHOLD="$SIMLLM_LSH_BATCH_THRESHOLD"
+    export VLLM_ASCEND_SIMLLM_KV_CACHE_SIZE="$SIMLLM_KV_CACHE_SIZE"
+    export VLLM_ASCEND_SIMLLM_SANDWICH_BOTTOM="$SIMLLM_SANDWICH_BOTTOM"
+    export VLLM_ASCEND_SIMLLM_SANDWICH_TOP="$SIMLLM_SANDWICH_TOP"
+    export VLLM_ASCEND_SIMLLM_UNMATCHED_STORE_MODE="$SIMLLM_UNMATCHED_STORE_MODE"
+    export VLLM_ASCEND_SIMLLM_PROFILE="$SIMLLM_PROFILE"
+    export VLLM_ASCEND_SIMLLM_PROFILE_INTERVAL="$SIMLLM_PROFILE_INTERVAL"
+    export PYTHONUNBUFFERED=1
+    export PYTHONPATH="$CURRENT_RUNTIME_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}"
+    "$CURRENT_RUNTIME_PYTHON" -u -m vllm.entrypoints.openai.api_server $server_args
+  ) >"$log_file" 2>&1 &
+
+  ACTIVE_SERVER_PID=$!
+}
+
+collect_server_info() {
+  local result_dir=$1
+  local server_log=$2
+
+  {
+    echo "=== SimLLM patch state ==="
+    grep -i "SimLLM.*patch\|SimLLM.*state\|SimLLM.*rewrite\|SimLLM.*sandwich\|SimLLM.*enabled\|SimLLM.*cache_size" "$server_log" 2>/dev/null | head -40 || true
+    echo "=== SimLLM errors ==="
+    grep -i "SimLLM.*failed\|SimLLM.*error\|SimLLM.*OOM\|preprocess_from_scheduler\|extract_kv.*failed" "$server_log" 2>/dev/null | head -40 || true
+  } > "$result_dir/server_info.txt"
+}
+
+export_leaderboard_artifact() {
+  local label=$1
+  local result_dir=$2
+  local same_spec_file=$3
+  local raw_result_file=$4
+  local artifact_dir=$5
+  local scenario=$6
+
+  local model
+  local model_parameters
+  local model_precision
+  local model_quantization
+  local hardware_vendor
+  local hardware_chip_model
+  local chip_count
+  local node_count
+  local input_len
+  local output_len
+
+  model=${CURRENT_MODEL_NAME:-$(jq -r '.model' "$SPEC_FILE")}
+  model_parameters=${CURRENT_MODEL_PARAMETERS:-$(jq -r '.model_parameters' "$SPEC_FILE")}
+  model_precision=${CURRENT_MODEL_PRECISION:-$(jq -r '.model_precision' "$SPEC_FILE")}
+  model_quantization=${CURRENT_MODEL_QUANTIZATION:-$(jq -r '.model_quantization // empty' "$SPEC_FILE")}
+  hardware_vendor=$(jq -r '.hardware_vendor' "$SPEC_FILE")
+  hardware_chip_model=${CURRENT_HARDWARE_CHIP_MODEL:-$(jq -r '.hardware_chip_model' "$SPEC_FILE")}
+  chip_count=$(jq -r '.chip_count' "$SPEC_FILE")
+  node_count=$(jq -r '.node_count' "$SPEC_FILE")
+  input_len=$(jq -r '.client_parameters.input_len // empty' "$SPEC_FILE")
+  output_len=$(jq -r '.client_parameters.output_len // empty' "$SPEC_FILE")
+
+  EXPORT_ARGS=(
+    "$scenario"
+    --benchmark-result-file "$raw_result_file"
+    --constraints-file "$CONSTRAINTS_FILE"
+    --same-spec-file "$same_spec_file"
+    --output-dir "$artifact_dir"
+    --run-id "$label-$RUN_TIMESTAMP"
+    --engine "$CURRENT_ENGINE"
+    --engine-version "${CURRENT_ENGINE_VERSION:-$(maybe_git_describe "$CURRENT_VLLM_HUST_REPO" "$CURRENT_GIT_COMMIT")}"
+    --core-version "${CURRENT_CORE_VERSION:-${CURRENT_ENGINE_VERSION:-$(maybe_git_describe "$CURRENT_VLLM_HUST_REPO" "$CURRENT_GIT_COMMIT")}}"
+    --backend-version "${CURRENT_BACKEND_VERSION:-$(maybe_git_describe "$CURRENT_VLLM_ASCEND_HUST_REPO" "$CURRENT_PLUGIN_GIT_COMMIT")}"
+    --model-name "$model"
+    --model-parameters "$model_parameters"
+    --model-precision "$model_precision"
+    --hardware-vendor "$hardware_vendor"
+    --hardware-chip-model "$hardware_chip_model"
+    --chip-count "$chip_count"
+    --node-count "$node_count"
+    --submitter "$CURRENT_SUBMITTER"
+    --baseline-engine "$CURRENT_BASELINE_ENGINE"
+    --data-source "$CURRENT_DATA_SOURCE"
+    --git-commit "$CURRENT_GIT_COMMIT"
+    --github-repository "$CURRENT_GITHUB_REPOSITORY"
+    --github-ref "$CURRENT_GITHUB_REF"
+    --runtime-python "$CURRENT_RUNTIME_PYTHON"
+    --engine-source-repository "$CURRENT_GITHUB_REPOSITORY"
+    --engine-source-ref "$CURRENT_GITHUB_REF"
+    --engine-source-commit "$CURRENT_GIT_COMMIT"
+    --plugin-source-engine "$CURRENT_PLUGIN_ENGINE"
+    --plugin-source-repository "$CURRENT_PLUGIN_GITHUB_REPOSITORY"
+    --plugin-source-ref "$CURRENT_PLUGIN_GITHUB_REF"
+    --plugin-source-commit "$CURRENT_PLUGIN_GIT_COMMIT"
+  )
+
+  append_export_arg_if_present --quantization "$model_quantization"
+  append_export_arg_if_present --input-length "$input_len"
+  append_export_arg_if_present --output-length "$output_len"
+
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.cli export-leaderboard-artifact \
+    "${EXPORT_ARGS[@]}"
+}
+
+run_experiment() {
+  local label=$1
+  local simllm_enabled=$2
+  local do_warmup=$3
+  local result_dir=$4
+  local port=$5
+
+  local same_spec_file="$result_dir/resolved_same_spec.json"
+  local raw_result_file="$result_dir/raw_benchmark_result.json"
+  local server_log="$result_dir/server.stdout.log"
+  local artifact_dir="$result_dir/submission"
+  local scenario
+  local benchmark_type
+  local runtime_model
+  local server_host
+  local client_host
+  local client_port
+  local base_client_json
+  local measure_client_json
+  local measure_args
+  local warmup_json
+  local warmup_args
+  local server_args
+  local status
+
+  mkdir -p "$result_dir" "$artifact_dir"
+
+  scenario=$(jq -r '.scenario' "$SPEC_FILE")
+  benchmark_type=$(resolve_benchmark_type "$scenario")
+  if [[ "$benchmark_type" != "serve" ]]; then
+    echo "This warm-cache runner only supports serve benchmarks; $scenario is $benchmark_type." >&2
+    return 2
+  fi
+
+  runtime_model="${CURRENT_MODEL_PATH:-$(jq -r '.model' "$SPEC_FILE")}"
+
+  echo ""
+  echo "============================================================"
+  echo "  $label"
+  echo "  SimLLM=$simllm_enabled Warmup=$do_warmup Port=$port"
+  echo "============================================================"
+
+  resolve_spec "$SPEC_FILE" "$same_spec_file" "$runtime_model" "$port"
+  server_host=$(jq -r '.resolved_server_parameters.host' "$same_spec_file")
+  client_host=$(jq -r '.resolved_client_parameters.host' "$same_spec_file")
+  client_port=$(jq -r '.resolved_client_parameters.port' "$same_spec_file")
+  server_args=$(json2args "$(jq -c '.resolved_server_parameters | del(.disable_log_requests)' "$same_spec_file")")
+  base_client_json=$(normalized_client_parameters_json "$same_spec_file")
+  measure_client_json=$(client_json_with_seed "$base_client_json" "$SIMLLM_MEASURE_SEED")
+  measure_args=$(json2args "$measure_client_json")
+
+  assert_port_available "$client_port"
+
+  echo "[$label] resolved spec: $same_spec_file"
+  echo "[$label] runtime model: $runtime_model"
+  echo "[$label] endpoint: ${client_host}:${client_port}"
+  echo "[$label] measured seed: ${SIMLLM_MEASURE_SEED:-<benchmark-default>}"
+
+  start_server "$simllm_enabled" "$server_args" "$server_log"
+  echo "$ACTIVE_SERVER_PID" > "$result_dir/server.pid"
+
+  if ! wait_for_server "$client_host" "$client_port" "$server_log"; then
+    cleanup_active_server
+    return 1
+  fi
+
+  if [[ "$do_warmup" == "1" ]]; then
+    warmup_json=$(warmup_client_json "$base_client_json")
+    warmup_args=$(json2args "$warmup_json")
+    echo "[$label] warm-cache passes: $SIMLLM_WARMCACHE_PASSES"
+    echo "[$label] warm-cache seed: $SIMLLM_WARMCACHE_SEED"
+
+    for pass in $(seq 1 "$SIMLLM_WARMCACHE_PASSES"); do
+      echo "[$label] warm-cache pass ${pass}/${SIMLLM_WARMCACHE_PASSES}"
+      set +e
+      run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+        "$CURRENT_RUNTIME_PYTHON" "$VLLM_CLI_COMPAT" bench serve \
+        --save-result \
+        --result-dir "$result_dir" \
+        --result-filename "warmup_pass_${pass}.json" \
+        $warmup_args \
+        > "$result_dir/warmup_pass_${pass}.log" 2>&1
+      status=$?
+      set -e
+      if [[ "$status" -ne 0 ]]; then
+        echo "[$label] warm-cache pass ${pass} failed; see $result_dir/warmup_pass_${pass}.log" >&2
+        cleanup_active_server
+        return "$status"
+      fi
+    done
+
+    if (( SIMLLM_WARMCACHE_PAUSE_SECONDS > 0 )); then
+      sleep "$SIMLLM_WARMCACHE_PAUSE_SECONDS"
+    fi
+  fi
+
+  echo "[$label] measured benchmark"
+  set +e
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" "$VLLM_CLI_COMPAT" bench serve \
+    --save-result \
+    --result-dir "$result_dir" \
+    --result-filename "$(basename "$raw_result_file")" \
+    $measure_args
+  status=$?
+  set -e
+
+  collect_server_info "$result_dir" "$server_log"
+  cleanup_active_server
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "[$label] measured benchmark failed." >&2
+    return "$status"
+  fi
+
+  export_leaderboard_artifact "$label" "$result_dir" "$same_spec_file" "$raw_result_file" "$artifact_dir" "$scenario"
+  echo "[$label] done: $result_dir"
+}
+
+mkdir -p "$RESULT_DIR" "$CURRENT_VLLM_CACHE_ROOT"
+
+if [[ "$RUN_BASELINE" == "1" ]]; then
+  run_experiment "baseline" "0" "0" "$BASELINE_DIR" "$BASELINE_SERVER_PORT"
+fi
+
+if [[ "$RUN_SIMLLM" == "1" ]]; then
+  run_experiment "simllm-warm-cache" "1" "1" "$SIMLLM_DIR" "$SIMLLM_SERVER_PORT"
+fi
+
+echo ""
+echo "============================================================"
+echo "  Comparison: Baseline vs SimLLM Warm-Cache"
+echo "============================================================"
+
+BL_LEADERBOARD="$BASELINE_DIR/submission/run_leaderboard.json"
+SL_LEADERBOARD="$SIMLLM_DIR/submission/run_leaderboard.json"
+
+if [[ -f "$BL_LEADERBOARD" && -f "$SL_LEADERBOARD" ]]; then
+  run_in_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" -m vllm_hust_benchmark.perfgate compare \
+    --current "$SL_LEADERBOARD" \
+    --baseline "$BL_LEADERBOARD" \
+    --report-file "$RESULT_DIR/perfgate_report.md" \
+    --mode report || true
+  echo "Report: $RESULT_DIR/perfgate_report.md"
+else
+  echo "Skipping comparison because one leaderboard artifact is missing:"
+  echo "  Baseline: $BL_LEADERBOARD"
+  echo "  SimLLM:   $SL_LEADERBOARD"
+fi
+
+echo ""
+echo "Outputs:"
+echo "  Baseline:    $BASELINE_DIR"
+echo "  SimLLM warm: $SIMLLM_DIR"

--- a/scripts/run_simllm_saturated_throughput_warm_cache.sh
+++ b/scripts/run_simllm_saturated_throughput_warm_cache.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+set -euo pipefail
+
+# Measure SimLLM warm-cache throughput under a saturated online workload.
+#
+# Unlike the official online spec (request_rate=1), the measured pass uses
+# request_rate=inf and a bounded concurrency. This removes the client-side
+# arrival-rate ceiling while avoiding an unbounded number of in-flight requests.
+#
+# The SimLLM case keeps the existing warm-cache semantics:
+#   1. Start one SimLLM-enabled server.
+#   2. Send the same deterministic prompts once at a low request rate.
+#   3. Without restarting the server, send those prompts at request_rate=inf.
+#
+# The baseline uses the same measured workload, seed, and concurrency with
+# SimLLM disabled. At the end, a compact throughput comparison is written to
+# throughput_comparison.json and throughput_comparison.md.
+#
+# Example:
+#   cd /workspace/vllm-hust-benchmark
+#   ASCEND_RT_VISIBLE_DEVICES=6 \
+#   CURRENT_MODEL_PATH=/data/shared_models/Qwen2.5-14B-Instruct \
+#   bash scripts/run_simllm_saturated_throughput_warm_cache.sh
+#
+# Useful overrides:
+#   SIMLLM_THROUGHPUT_MAX_CONCURRENCY=32
+#   SIMLLM_THROUGHPUT_NUM_PROMPTS=128
+#   SIMLLM_THROUGHPUT_INPUT_LEN=4096
+#   SIMLLM_THROUGHPUT_OUTPUT_LEN=32
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
+WARM_CACHE_RUNNER=${WARM_CACHE_RUNNER:-"$SCRIPT_DIR/run_simllm_random_online_warm_cache.sh"}
+DEFAULT_BASE_SPEC_FILE="$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"
+
+BASE_SPEC_FILE=${1:-${BASE_SPEC_FILE:-$DEFAULT_BASE_SPEC_FILE}}
+RESULT_DIR=${RESULT_DIR:-"$REPO_ROOT/.benchmarks/simllm-saturated-throughput-warm-cache"}
+CURRENT_DATA_SOURCE=${CURRENT_DATA_SOURCE:-"vllm-ascend-hust-ci-simllm-saturated-throughput"}
+CURRENT_VLLM_ASCEND_HUST_REPO=${CURRENT_VLLM_ASCEND_HUST_REPO:-"$WORKSPACE_ROOT/vllm-ascend-hust"}
+
+SIMLLM_THROUGHPUT_NUM_PROMPTS=${SIMLLM_THROUGHPUT_NUM_PROMPTS:-32}
+SIMLLM_THROUGHPUT_INPUT_LEN=${SIMLLM_THROUGHPUT_INPUT_LEN:-4096}
+SIMLLM_THROUGHPUT_OUTPUT_LEN=${SIMLLM_THROUGHPUT_OUTPUT_LEN:-32}
+SIMLLM_THROUGHPUT_MAX_CONCURRENCY=${SIMLLM_THROUGHPUT_MAX_CONCURRENCY:-16}
+SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS=${SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS:-$SIMLLM_THROUGHPUT_INPUT_LEN}
+SIMLLM_THROUGHPUT_SCENARIO=${SIMLLM_THROUGHPUT_SCENARIO:-random-online}
+SIMLLM_THROUGHPUT_ENDPOINT=${SIMLLM_THROUGHPUT_ENDPOINT:-/v1/completions}
+SIMLLM_THROUGHPUT_DATASET_NAME=${SIMLLM_THROUGHPUT_DATASET_NAME:-random}
+SIMLLM_THROUGHPUT_BACKEND=${SIMLLM_THROUGHPUT_BACKEND:-vllm}
+SIMLLM_SATURATED_DRY_RUN=${SIMLLM_SATURATED_DRY_RUN:-0}
+
+# Warm slowly enough that entries are committed before the measured burst.
+# The measurement seed defaults to the warmup seed in the underlying runner.
+SIMLLM_WARMCACHE_REQUEST_RATE=${SIMLLM_WARMCACHE_REQUEST_RATE:-1}
+SIMLLM_WARMCACHE_NUM_PROMPTS=${SIMLLM_WARMCACHE_NUM_PROMPTS:-$SIMLLM_THROUGHPUT_NUM_PROMPTS}
+SIMLLM_WARMCACHE_SEED=${SIMLLM_WARMCACHE_SEED:-0}
+SIMLLM_MEASURE_SEED=${SIMLLM_MEASURE_SEED:-$SIMLLM_WARMCACHE_SEED}
+SIMLLM_KV_CACHE_SIZE=${VLLM_ASCEND_SIMLLM_KV_CACHE_SIZE:-${SIMLLM_KV_CACHE_SIZE:-$SIMLLM_THROUGHPUT_NUM_PROMPTS}}
+
+require_positive_integer() {
+  local name=$1
+  local value=$2
+
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "$name must be a positive integer; got: $value" >&2
+    exit 2
+  fi
+}
+
+if [[ ! -f "$BASE_SPEC_FILE" ]]; then
+  echo "Base spec file not found: $BASE_SPEC_FILE" >&2
+  exit 2
+fi
+if [[ ! -x "$WARM_CACHE_RUNNER" ]]; then
+  echo "Warm-cache runner not found or not executable: $WARM_CACHE_RUNNER" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to build the saturated workload and comparison." >&2
+  exit 2
+fi
+
+require_positive_integer SIMLLM_THROUGHPUT_NUM_PROMPTS "$SIMLLM_THROUGHPUT_NUM_PROMPTS"
+require_positive_integer SIMLLM_THROUGHPUT_INPUT_LEN "$SIMLLM_THROUGHPUT_INPUT_LEN"
+require_positive_integer SIMLLM_THROUGHPUT_OUTPUT_LEN "$SIMLLM_THROUGHPUT_OUTPUT_LEN"
+require_positive_integer SIMLLM_THROUGHPUT_MAX_CONCURRENCY "$SIMLLM_THROUGHPUT_MAX_CONCURRENCY"
+require_positive_integer SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS "$SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS"
+require_positive_integer SIMLLM_KV_CACHE_SIZE "$SIMLLM_KV_CACHE_SIZE"
+
+if (( SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS < SIMLLM_THROUGHPUT_INPUT_LEN )); then
+  echo "SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS must be at least SIMLLM_THROUGHPUT_INPUT_LEN" >&2
+  echo "A smaller token budget would split warmup prompts and prevent exact cache reuse." >&2
+  exit 2
+fi
+
+BASE_SPEC_FILE=$(cd "$(dirname "$BASE_SPEC_FILE")" && pwd)/$(basename "$BASE_SPEC_FILE")
+mkdir -p "$RESULT_DIR"
+
+SATURATED_SPEC_FILE="$RESULT_DIR/saturated-same-spec.json"
+
+jq \
+  --arg scenario "$SIMLLM_THROUGHPUT_SCENARIO" \
+  --arg dataset_name "$SIMLLM_THROUGHPUT_DATASET_NAME" \
+  --arg endpoint "$SIMLLM_THROUGHPUT_ENDPOINT" \
+  --arg backend "$SIMLLM_THROUGHPUT_BACKEND" \
+  --argjson num_prompts "$SIMLLM_THROUGHPUT_NUM_PROMPTS" \
+  --argjson input_len "$SIMLLM_THROUGHPUT_INPUT_LEN" \
+  --argjson output_len "$SIMLLM_THROUGHPUT_OUTPUT_LEN" \
+  --argjson max_concurrency "$SIMLLM_THROUGHPUT_MAX_CONCURRENCY" \
+  --argjson max_num_batched_tokens "$SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS" '
+    .scenario = $scenario
+    | .id = ("simllm-" + $scenario + "-saturated-throughput-warm-cache")
+    | .label = "SimLLM saturated throughput warm-cache"
+    | .client_parameters = ((.client_parameters // {})
+        + {
+            backend: $backend,
+            endpoint: $endpoint,
+            dataset_name: $dataset_name,
+            num_prompts: $num_prompts,
+            input_len: $input_len,
+            output_len: $output_len,
+            temperature: 0,
+            request_rate: "inf",
+            max_concurrency: $max_concurrency
+          }
+      )
+    | .client_parameters |= del(.dataset_path, .num_warmups)
+    | .server_parameters = ((.server_parameters // {})
+        + {max_num_batched_tokens: $max_num_batched_tokens})
+  ' "$BASE_SPEC_FILE" > "$SATURATED_SPEC_FILE"
+
+echo "[simllm-throughput] base spec: $BASE_SPEC_FILE"
+echo "[simllm-throughput] saturated spec: $SATURATED_SPEC_FILE"
+echo "[simllm-throughput] result dir: $RESULT_DIR"
+echo "[simllm-throughput] warmup: rate=$SIMLLM_WARMCACHE_REQUEST_RATE seed=$SIMLLM_WARMCACHE_SEED"
+echo "[simllm-throughput] measure: rate=inf concurrency=$SIMLLM_THROUGHPUT_MAX_CONCURRENCY seed=$SIMLLM_MEASURE_SEED"
+echo "[simllm-throughput] workload: prompts=$SIMLLM_THROUGHPUT_NUM_PROMPTS input=$SIMLLM_THROUGHPUT_INPUT_LEN output=$SIMLLM_THROUGHPUT_OUTPUT_LEN"
+echo "[simllm-throughput] server token budget: $SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS"
+echo "[simllm-throughput] SimLLM cache entries: $SIMLLM_KV_CACHE_SIZE"
+
+if [[ "$SIMLLM_SATURATED_DRY_RUN" == "1" ]]; then
+  echo "[simllm-throughput] dry run: generated spec only"
+  exit 0
+fi
+
+export RESULT_DIR
+export CURRENT_DATA_SOURCE
+export CURRENT_VLLM_ASCEND_HUST_REPO
+export SIMLLM_WARMCACHE_REQUEST_RATE
+export SIMLLM_WARMCACHE_NUM_PROMPTS
+export SIMLLM_WARMCACHE_SEED
+export SIMLLM_MEASURE_SEED
+export SIMLLM_KV_CACHE_SIZE
+
+"$WARM_CACHE_RUNNER" "$SATURATED_SPEC_FILE"
+
+BASELINE_RESULT="$RESULT_DIR/baseline-disabled/raw_benchmark_result.json"
+SIMLLM_RESULT="$RESULT_DIR/enabled-warm-cache/raw_benchmark_result.json"
+COMPARISON_JSON="$RESULT_DIR/throughput_comparison.json"
+COMPARISON_MD="$RESULT_DIR/throughput_comparison.md"
+
+if [[ ! -f "$BASELINE_RESULT" || ! -f "$SIMLLM_RESULT" ]]; then
+  echo "[simllm-throughput] raw result missing; skipping throughput summary" >&2
+  exit 1
+fi
+
+for result_file in "$BASELINE_RESULT" "$SIMLLM_RESULT"; do
+  completed=$(jq -r '.completed // 0' "$result_file")
+  if [[ "$completed" != "$SIMLLM_THROUGHPUT_NUM_PROMPTS" ]]; then
+    echo "[simllm-throughput] invalid result: $result_file completed $completed/$SIMLLM_THROUGHPUT_NUM_PROMPTS requests" >&2
+    exit 1
+  fi
+done
+
+jq -n \
+  --slurpfile baseline "$BASELINE_RESULT" \
+  --slurpfile simllm "$SIMLLM_RESULT" '
+    def pct($before; $after):
+      if $before == null or $after == null or $before == 0 then null
+      else (($after - $before) / $before * 100)
+      end;
+    {
+      workload: {
+        request_rate: $simllm[0].request_rate,
+        max_concurrency: $simllm[0].max_concurrency,
+        completed: $simllm[0].completed
+      },
+      baseline: {
+        request_throughput: $baseline[0].request_throughput,
+        output_token_throughput: $baseline[0].output_throughput,
+        total_token_throughput: $baseline[0].total_token_throughput
+      },
+      simllm_warm_cache: {
+        request_throughput: $simllm[0].request_throughput,
+        output_token_throughput: $simllm[0].output_throughput,
+        total_token_throughput: $simllm[0].total_token_throughput
+      },
+      improvement_percent: {
+        request_throughput: pct($baseline[0].request_throughput; $simllm[0].request_throughput),
+        output_token_throughput: pct($baseline[0].output_throughput; $simllm[0].output_throughput),
+        total_token_throughput: pct($baseline[0].total_token_throughput; $simllm[0].total_token_throughput)
+      }
+    }
+  ' > "$COMPARISON_JSON"
+
+jq -r '
+  def value($number): if $number == null then "n/a" else ($number | tostring) end;
+  def percent($number):
+    if $number == null then "n/a" else (($number * 100 | round) / 100 | tostring) + "%" end;
+  "# SimLLM saturated warm-cache throughput\n\n" +
+  "| Metric | Baseline | SimLLM warm cache | Improvement |\n" +
+  "| --- | ---: | ---: | ---: |\n" +
+  "| Requests/s | \(value(.baseline.request_throughput)) | \(value(.simllm_warm_cache.request_throughput)) | \(percent(.improvement_percent.request_throughput)) |\n" +
+  "| Output tokens/s | \(value(.baseline.output_token_throughput)) | \(value(.simllm_warm_cache.output_token_throughput)) | \(percent(.improvement_percent.output_token_throughput)) |\n" +
+  "| Total tokens/s | \(value(.baseline.total_token_throughput)) | \(value(.simllm_warm_cache.total_token_throughput)) | \(percent(.improvement_percent.total_token_throughput)) |\n\n" +
+  "Measured with request_rate=\(.workload.request_rate), max_concurrency=\(.workload.max_concurrency), completed=\(.workload.completed)."
+  ' "$COMPARISON_JSON" > "$COMPARISON_MD"
+
+echo ""
+cat "$COMPARISON_MD"
+echo ""
+echo "[simllm-throughput] comparison JSON: $COMPARISON_JSON"
+echo "[simllm-throughput] comparison report: $COMPARISON_MD"

--- a/tests/test_simllm_saturated_runner.py
+++ b/tests/test_simllm_saturated_runner.py
@@ -60,5 +60,5 @@ def test_token_budget_smaller_than_prompt_fails(tmp_path: Path) -> None:
 def test_runner_enforces_complete_ab_results_and_shared_seed() -> None:
     text = RUNNER.read_text(encoding="utf-8")
     assert "SIMLLM_MEASURE_SEED=${SIMLLM_MEASURE_SEED:-$SIMLLM_WARMCACHE_SEED}" in text
-    assert 'completed $completed/$SIMLLM_THROUGHPUT_NUM_PROMPTS' in text
+    assert "completed $completed/$SIMLLM_THROUGHPUT_NUM_PROMPTS" in text
     assert '"$WARM_CACHE_RUNNER" "$SATURATED_SPEC_FILE"' in text

--- a/tests/test_simllm_saturated_runner.py
+++ b/tests/test_simllm_saturated_runner.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run_simllm_saturated_throughput_warm_cache.sh"
+
+
+def run_dry(tmp_path: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "RESULT_DIR": str(tmp_path),
+            "SIMLLM_SATURATED_DRY_RUN": "1",
+            **overrides,
+        }
+    )
+    return subprocess.run(
+        ["bash", str(RUNNER)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_dry_run_generates_fixed_saturated_contract(tmp_path: Path) -> None:
+    result = run_dry(tmp_path)
+    assert result.returncode == 0, result.stderr
+    spec = json.loads((tmp_path / "saturated-same-spec.json").read_text())
+    client = spec["client_parameters"]
+    server = spec["server_parameters"]
+    assert spec["scenario"] == "random-online"
+    assert client["request_rate"] == "inf"
+    assert client["max_concurrency"] == 16
+    assert client["num_prompts"] == 32
+    assert client["input_len"] == 4096
+    assert client["output_len"] == 32
+    assert client["temperature"] == 0
+    assert server["gpu_memory_utilization"] == 0.6
+    assert server["max_model_len"] == 32768
+    assert server["max_num_batched_tokens"] == 4096
+
+
+def test_token_budget_smaller_than_prompt_fails(tmp_path: Path) -> None:
+    result = run_dry(
+        tmp_path,
+        SIMLLM_THROUGHPUT_INPUT_LEN="4096",
+        SIMLLM_THROUGHPUT_MAX_NUM_BATCHED_TOKENS="2048",
+    )
+    assert result.returncode == 2
+    assert "must be at least SIMLLM_THROUGHPUT_INPUT_LEN" in result.stderr
+
+
+def test_runner_enforces_complete_ab_results_and_shared_seed() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    assert "SIMLLM_MEASURE_SEED=${SIMLLM_MEASURE_SEED:-$SIMLLM_WARMCACHE_SEED}" in text
+    assert 'completed $completed/$SIMLLM_THROUGHPUT_NUM_PROMPTS' in text
+    assert '"$WARM_CACHE_RUNNER" "$SATURATED_SPEC_FILE"' in text


### PR DESCRIPTION
## Summary

- extract the SimLLM warm-cache implementation from `GuMorming/simllm-throughput-benchmark-20260720` without carrying the branch's unrelated historical snapshot changes or raw logs;
- add a deterministic Baseline versus SimLLM warm-cache runner;
- derive a saturated specialty profile from the official Ascend v0.18.0 random-online specification;
- fix the measured workload at 32 prompts, 4096 input tokens, 32 output tokens, `request_rate=inf`, concurrency 16, and temperature 0;
- require identical warmup/measured seeds, sufficient batched-token capacity, full request completion, and separate raw artifacts;
- generate JSON and Markdown throughput comparisons while retaining cache-hit and scheduler-rewrite log evidence.

## Validation

- `PYTHONPATH=src python3 -m pytest -q`: 529 passed
- shell syntax checks for both runners
- dry-run test verifies the resolved fixed configuration, including `gpu_memory_utilization=0.6` and `max_model_len=32768`
- negative test rejects a batched-token budget smaller than the prompt length

The local feasibility numbers remain labeled as non-official. Publishing a leaderboard result still requires repeated real-hardware runs and admitted artifacts; this PR only makes that collection reproducible.

Closes #59
