### PR TITLE
fix(aggregation): reject incomplete benchmark submissions

### DIFF
--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -25,7 +25,10 @@ from vllm_hust_benchmark.leaderboard_exclusions import (
     match_leaderboard_exclusion,
 )
 from vllm_hust_benchmark.registry import get_scenario
-from vllm_hust_benchmark.submission_artifacts import iter_submission_artifact_paths
+from vllm_hust_benchmark.submission_artifacts import (
+    iter_manifest_artifact_paths,
+    iter_submission_artifact_paths,
+)
 from vllm_hust_benchmark.submission_artifacts import (
     normalize_submission_artifacts_in_tree,
 )
@@ -1438,9 +1441,13 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
     - ``FAILED``: the ``STATUS`` file content starts with ``FAILED``.
     - ``NO_STATUS``: a ``STATUS`` file exists but is empty after stripping;
       a ``ci-*`` directory has no ``STATUS``; or neither a ``STATUS`` file nor
-      a ``run_leaderboard.json`` file is present. Historical backfill/baseline
-      pipelines don't write a ``STATUS`` file by design and are admitted when
-      they contain a ``run_leaderboard.json`` artifact.
+      a ``run_leaderboard.json`` file is present.
+    - ``RUN_STATUS``: a non-empty ``STATUS`` value is neither ``OK`` nor a
+      recognized ``FAILED`` result (for example ``BLOCKED`` or ``CANCELLED``).
+    - ``MISSING_ARTIFACT`` / ``MISSING_MANIFEST`` / ``INVALID_MANIFEST``:
+      the formal artifact pair is incomplete or the manifest does not reference
+      the run artifact. Historical backfills may omit ``STATUS``, but they must
+      still carry this artifact pair.
     """
     failures: list[dict] = []
     if not source_dir.is_dir():
@@ -1473,7 +1480,8 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
             # CI publication directories must carry the explicit outcome
             # written by the runner. Merely finding a JSON artifact is not
             # enough: a failed run can produce partial data before its final
-            # admission gate executes. Historical backfills remain compatible.
+            # admission gate executes. Historical backfills remain compatible
+            # only when their complete artifact pair is present.
             if (
                 child.name.startswith("ci-")
                 or not (child / "run_leaderboard.json").is_file()
@@ -1489,19 +1497,20 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
                         ),
                     }
                 )
-            continue
-
-        try:
-            status_content = status_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            failures.append(
-                {
-                    "dir": path_str,
-                    "reason": "NO_STATUS",
-                    "detail": f"STATUS file unreadable: {exc}",
-                }
-            )
-            continue
+                continue
+            status_content = "OK"
+        else:
+            try:
+                status_content = status_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                failures.append(
+                    {
+                        "dir": path_str,
+                        "reason": "NO_STATUS",
+                        "detail": f"STATUS file unreadable: {exc}",
+                    }
+                )
+                continue
 
         if status_content.startswith("FAILED"):
             failures.append(
@@ -1519,6 +1528,57 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
                     "dir": path_str,
                     "reason": "NO_STATUS",
                     "detail": "STATUS file empty",
+                }
+            )
+            continue
+
+        if status_content.strip() != "OK":
+            failures.append(
+                {
+                    "dir": path_str,
+                    "reason": "RUN_STATUS",
+                    "detail": f"STATUS is not publishable: {status_content.strip()}",
+                }
+            )
+            continue
+
+        artifact_path = child / "run_leaderboard.json"
+        manifest_path = child / "leaderboard_manifest.json"
+        if not artifact_path.is_file():
+            failures.append(
+                {
+                    "dir": path_str,
+                    "reason": "MISSING_ARTIFACT",
+                    "detail": "run_leaderboard.json is required",
+                }
+            )
+            continue
+        if not manifest_path.is_file():
+            failures.append(
+                {
+                    "dir": path_str,
+                    "reason": "MISSING_MANIFEST",
+                    "detail": "leaderboard_manifest.json is required",
+                }
+            )
+            continue
+        try:
+            manifest_artifacts = iter_manifest_artifact_paths(manifest_path)
+        except (OSError, ValueError) as exc:
+            failures.append(
+                {
+                    "dir": path_str,
+                    "reason": "INVALID_MANIFEST",
+                    "detail": str(exc),
+                }
+            )
+            continue
+        if artifact_path not in manifest_artifacts:
+            failures.append(
+                {
+                    "dir": path_str,
+                    "reason": "INVALID_MANIFEST",
+                    "detail": "leaderboard_manifest.json does not reference run_leaderboard.json",
                 }
             )
             continue

--- a/tests/test_integration_aggregation_gate.py
+++ b/tests/test_integration_aggregation_gate.py
@@ -1,15 +1,15 @@
 """Tests for the submission admission gate in ``aggregate_to_website``.
 
-The gate rejects submission directories that are FAILED (STATUS file starts
-with ``FAILED``), NO_STATUS (missing or empty STATUS file), or temporary
-(directory name matches ``tmp|temp|wip|scratch|adhoc`` patterns) before they
-enter the formal aggregation pipeline.
+The gate rejects failed, incomplete, temporary, or malformed submission
+directories before they enter the formal aggregation pipeline.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+
+import pytest
 
 from vllm_hust_benchmark.integration import (
     RepoLayout,
@@ -77,6 +77,20 @@ def _write_mock_submission(
     (target_dir / "run_leaderboard.json").write_text(
         json.dumps(payload, indent=2) + "\n", encoding="utf-8"
     )
+    _write_manifest(target_dir)
+
+
+def _write_manifest(
+    target_dir: Path, artifact_name: str = "run_leaderboard.json"
+) -> None:
+    manifest = {
+        "schema_version": "leaderboard-export-manifest/v2",
+        "generated_at": "2026-08-01T00:00:00Z",
+        "entries": [{"leaderboard_artifact": artifact_name}],
+    }
+    (target_dir / "leaderboard_manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
 
 
 def test_failed_status_rejected(tmp_path: Path) -> None:
@@ -122,6 +136,7 @@ def test_backfill_dir_without_status_passes(tmp_path: Path) -> None:
     (backfill_dir / "run_leaderboard.json").write_text(
         '{"entry_id": "test"}\n', encoding="utf-8"
     )
+    _write_manifest(backfill_dir)
 
     failures = _scan_submission_admission_failures(source_dir)
 
@@ -177,10 +192,61 @@ def test_clean_directory_passes(tmp_path: Path) -> None:
     clean_dir = source_dir / "clean-run"
     clean_dir.mkdir()
     (clean_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (clean_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(clean_dir)
 
     failures = _scan_submission_admission_failures(source_dir)
 
     assert failures == []
+
+
+@pytest.mark.parametrize("status", ["BLOCKED", "CANCELLED", "RUNNING"])
+def test_non_publishable_status_rejected(tmp_path: Path, status: str) -> None:
+    source_dir = tmp_path / "submissions"
+    source_dir.mkdir()
+    run_dir = source_dir / "incomplete-run"
+    run_dir.mkdir()
+    (run_dir / "STATUS").write_text(status + "\n", encoding="utf-8")
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "RUN_STATUS"
+    assert status in failures[0]["detail"]
+
+
+@pytest.mark.parametrize(
+    ("artifact", "manifest", "expected_reason"),
+    [
+        (False, False, "MISSING_ARTIFACT"),
+        (True, False, "MISSING_MANIFEST"),
+        (True, True, "INVALID_MANIFEST"),
+    ],
+)
+def test_incomplete_artifact_pair_rejected(
+    tmp_path: Path,
+    artifact: bool,
+    manifest: bool,
+    expected_reason: str,
+) -> None:
+    source_dir = tmp_path / "submissions"
+    source_dir.mkdir()
+    run_dir = source_dir / "candidate-run"
+    run_dir.mkdir()
+    (run_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    if artifact:
+        (run_dir / "run_leaderboard.json").write_text(
+            '{"entry_id": "test"}\n', encoding="utf-8"
+        )
+    if manifest:
+        _write_manifest(run_dir, artifact_name="different.json")
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == expected_reason
 
 
 def test_aggregate_to_website_returns_2_on_admission_failure(
@@ -555,6 +621,10 @@ def test_report_generated_on_success(tmp_path: Path) -> None:
     clean_dir = source_dir / "clean-run"
     clean_dir.mkdir()
     (clean_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (clean_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(clean_dir)
 
     output_dir = tmp_path / "out"
 


### PR DESCRIPTION
## Summary

This is a bounded part of #100. The existing aggregation gate already rejects `FAILED`, missing-status, and temporary directories, but it can still admit:

- `BLOCKED`, `CANCELLED`, or `RUNNING` status values;
- an `OK` directory without `run_leaderboard.json`;
- a directory without `leaderboard_manifest.json`;
- a manifest that does not reference the run artifact.

This change rejects those cases before website/HF aggregation. Historical backfills may still omit `STATUS`, but they must carry a complete artifact/manifest pair. The rejection reason is preserved in the existing `rejected_superseded_report.json` path.

The checked-in 227 submission directories were scanned with the stricter gate and produced zero new failures.

## Testing

```bash
PYTHONPATH=src python3 -m pytest -q \
  tests/test_integration.py \
  tests/test_cli.py \
  tests/test_integration_aggregation_gate.py

ruff check \
  src/vllm_hust_benchmark/integration.py \
  tests/test_integration_aggregation_gate.py

ruff format --check \
  src/vllm_hust_benchmark/integration.py \
  tests/test_integration_aggregation_gate.py
```

Result: 112 tests passed; Ruff passed.

## Remaining #100 work

This PR does not choose canonical representatives for repeated successful runs and does not physically relocate quarantine data. Those should remain separate, reviewable changes.
