### PR TITLE
feat(campaign): fail closed on unfrozen Ascend evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,11 @@ Notes:
 - Set `PUBLISH_WEBSITE=1` only after you are ready to regenerate `vllm-hust-website/data` from the
   full batch output.
 
+For formal current-main multi-card campaigns, follow `docs/issue-136-ascend-evidence-execution.md`.
+Its strict launch mode requires frozen source, image, model, runtime, and topology identity; uses a
+fresh service for every repetition; and writes a machine-readable campaign summary without treating
+readiness evidence as a performance result.
+
 ## Contributing
 
 The benchmark repo uses the same pre-commit toolchain as `vllm-hust-website` so commits land on

--- a/docs/issue-136-ascend-evidence-execution.md
+++ b/docs/issue-136-ascend-evidence-execution.md
@@ -1,0 +1,128 @@
+# Ascend current-main multi-card evidence campaign
+
+This is the execution contract for
+[issue #136](https://github.com/vLLM-HUST/vllm-hust-benchmark/issues/136). It prepares the campaign;
+it is not a performance result and does not make the issue ready by itself.
+
+## Evidence boundary
+
+Do not calculate or publish a performance percentage until all cells being compared use the same
+frozen inputs:
+
+- immutable model revision;
+- full vLLM-HUST and vLLM-Ascend-HUST commits;
+- image ID, CANN version, torch-npu version, node type, and HCCS/network topology;
+- model precision, graph/eager mode, TP/DP/PP/EP, server arguments, and workload arguments.
+
+Readiness logs, historical artifacts, and results from an integration branch remain useful
+correctness evidence, but they are not current-main performance points. If a comparable baseline is
+missing, mark the cell blocked and publish no delta.
+
+## Required matrix
+
+The dense track is complete only when the following cells have at least three independent service
+processes each:
+
+| Workload                 | 1 chip   | 2 chips  | 4 chips  | Load profiles                           |
+| ------------------------ | -------- | -------- | -------- | --------------------------------------- |
+| random-online            | required | required | required | fixed 1 RPS, matched-load               |
+| sharegpt-online          | required | required | required | fixed 1 RPS, matched-load               |
+| prefix-repetition-online | required | required | required | fixed 1 RPS, matched-load               |
+| agent-research-online    | required | required | required | fixed 1 RPS, matched-load               |
+| communication-sensitive  | required | required | required | one explicitly named saturation profile |
+
+Determine each matched-load point with a capacity pilot on the frozen stack. Record the pilot; do
+not silently substitute equal low QPS for the matched-load cells.
+
+After the dense anchors are complete, run the MoE specialty track on the same frozen stack:
+
+1. MoE baseline;
+1. EPLB disabled and enabled as one matched comparison;
+1. LatchMoE disabled and enabled, or a retained blocker;
+1. current/latest only when both sides can be reproduced without crossing a commit pair.
+
+Keep eager and graph results in separate comparison scopes. Every targeted pair needs one stable
+`CAMPAIGN_COMPARISON_ID`, a `baseline` or `head` role, and three independent services per role.
+
+## Strict repetition launch
+
+`run-campaign-repetitions.sh` launches `run-single-repetition.sh` once per repetition, which in turn
+starts and stops one service. Strict mode rejects the same-server `PERFGATE_MEASURED_RUNS=3`
+pattern; three client measurements against one live service are not three independent services.
+
+Freeze and verify the inputs before running a cell:
+
+```bash
+export CAMPAIGN_REQUIRE_FROZEN_INPUTS=1
+export CAMPAIGN_ID=issue-136-current-main/v1
+export CAMPAIGN_COVERAGE_CLASS=full-matrix
+export CAMPAIGN_POINT_ROLE=checkpoint
+export CAMPAIGN_LOAD_PROFILE=fixed-1-rps
+
+export CURRENT_VLLM_HUST_REPO=/workspace/vllm-hust
+export CURRENT_VLLM_ASCEND_HUST_REPO=/workspace/vllm-ascend-hust
+export CURRENT_GIT_COMMIT=<full-40-character-core-commit>
+export CURRENT_PLUGIN_GIT_COMMIT=<full-40-character-backend-commit>
+export CURRENT_IMAGE_ID=<full-64-character-image-id-or-sha256-digest>
+export CURRENT_MODEL_REVISION=<immutable-40-to-64-character-model-revision>
+export CURRENT_CANN_VERSION=<exact-version>
+export CURRENT_TORCH_NPU_VERSION=<exact-version>
+export CURRENT_TOPOLOGY=<node-and-link-topology-description>
+
+export ASCEND_RT_VISIBLE_DEVICES=<explicit-runtime-visible-device-list>
+export ASCEND_VISIBLE_DEVICES="$ASCEND_RT_VISIBLE_DEVICES"
+export PERFGATE_WARMUP_RUNS=0
+export PERFGATE_MEASURED_RUNS=1
+
+export CAMPAIGN_SUMMARY_FILE=.benchmarks/issue-136/random-fixed-tp2-summary.json
+bash scripts/run-campaign-repetitions.sh <frozen-spec.json> \
+  --campaign-prefix issue-136-random-fixed-tp2 \
+  --repetitions 3
+```
+
+For EPLB or LatchMoE pairs, additionally set:
+
+```bash
+export CAMPAIGN_COVERAGE_CLASS=targeted-pair
+export CAMPAIGN_COMPARISON_ID=<stable-matched-comparison-id>
+export CAMPAIGN_POINT_ROLE=baseline  # use head for the enabled side
+```
+
+Strict mode fails before model startup when a commit is not full length, a checked-out repository
+does not match its declared commit, immutable model/image identity is missing, the formal role is
+invalid, fewer than three repetitions are requested, or same-server measurements are configured.
+
+Each repetition's `env-manifest.json` records both declared and observed source commits, image and
+model identity, declared and detected runtime versions, topology, visible devices, campaign role,
+load profile, and zero-based repeat index. `CAMPAIGN_SUMMARY_FILE` records every attempted artifact
+directory and exit code without replacing the raw repetitions. Artifact validation rejects missing
+or mismatched detected CANN/torch-npu versions and declared/observed source commits in strict mode.
+
+## Profiler collection
+
+Collect an unprofiled three-service series first. Then run a separately identified profiler cell
+with `run-current-ascend-same-spec-msprof.sh`; never mix profiler-affected latency or throughput
+into the unprofiled aggregate.
+
+At minimum retain:
+
+- per-rank AI Core/Vector, copy, communication, and visible-idle time;
+- HCCL collective type, count, bytes, wait, and compute overlap;
+- scheduler/admission/prefill wait, rank batch/token imbalance, and PP bubble when applicable;
+- HBM/KV capacity, preemption, and profiler overhead;
+- for MoE, per-expert load, all-to-all, placement/rebalance, and graph capture/replay coverage.
+
+Analyze the raw profile outside the runner, preserve the raw `msprof` directory, and link both the
+summary and raw profile from the issue.
+
+## Publication gate
+
+Before publishing:
+
+1. validate every artifact with `scripts/validate-run-artifact.sh`;
+1. confirm three contiguous independent-service repeat indices for every required series;
+1. compute median and IQR while retaining all raw repetitions;
+1. confirm every comparison has matching model, hardware, topology, workload, and frozen stack;
+1. publish `leaderboard_multi.json` only after the required matrix is complete;
+1. link the artifacts, profiler summaries, implementation issues, and any explicit blockers back to
+   issue #136.

--- a/docs/issue-136-ascend-evidence-execution.md
+++ b/docs/issue-136-ascend-evidence-execution.md
@@ -88,6 +88,16 @@ export CAMPAIGN_COMPARISON_ID=<stable-matched-comparison-id>
 export CAMPAIGN_POINT_ROLE=baseline  # use head for the enabled side
 ```
 
+An integration branch may use the same frozen-input checks for explicitly non-publishable pilots:
+
+```bash
+export CAMPAIGN_COVERAGE_CLASS=experimental
+unset CAMPAIGN_COMPARISON_ID CAMPAIGN_POINT_ROLE
+```
+
+Those artifacts remain experimental even when their three repetitions are complete. Re-run the
+required cells after the implementation commits merge and a unique current-main stack is frozen.
+
 Strict mode fails before model startup when a commit is not full length, a checked-out repository
 does not match its declared commit, either source tree is dirty, immutable model/image identity is
 missing, the formal role is invalid, fewer than three repetitions are requested, or same-server

--- a/docs/issue-136-ascend-evidence-execution.md
+++ b/docs/issue-136-ascend-evidence-execution.md
@@ -89,8 +89,9 @@ export CAMPAIGN_POINT_ROLE=baseline  # use head for the enabled side
 ```
 
 Strict mode fails before model startup when a commit is not full length, a checked-out repository
-does not match its declared commit, immutable model/image identity is missing, the formal role is
-invalid, fewer than three repetitions are requested, or same-server measurements are configured.
+does not match its declared commit, either source tree is dirty, immutable model/image identity is
+missing, the formal role is invalid, fewer than three repetitions are requested, or same-server
+measurements are configured.
 
 Each repetition's `env-manifest.json` records both declared and observed source commits, image and
 model identity, declared and detected runtime versions, topology, visible devices, campaign role,

--- a/docs/run-collection-template.md
+++ b/docs/run-collection-template.md
@@ -124,7 +124,7 @@ Producer 在消费 artifact 前必须检查 `STATUS` 内容。只有 `OK` 的 ar
 
 | 字段               | 来源                          | 用途                                                                    |
 | ------------------ | ----------------------------- | ----------------------------------------------------------------------- |
-| `manifest_version` | 固定值 `run-env-manifest/v1`  | schema 版本标识                                                         |
+| `manifest_version` | 固定值 `run-env-manifest/v2`  | schema 版本标识                                                         |
 | `collected_at`     | `date -u +%Y-%m-%dT%H:%M:%SZ` | 采集时间戳                                                              |
 | `os`               | `uname -a`                    | 内核版本、架构                                                          |
 | `python_version`   | `python3 --version`           | Python 版本                                                             |
@@ -133,7 +133,9 @@ Producer 在消费 artifact 前必须检查 `STATUS` 内容。只有 `OK` 的 ar
 | `ascend_toolkit`   | 文件检测                      | CANN 安装路径                                                           |
 | `npu_smi`          | `npu-smi info -t board`       | NPU 硬件信息                                                            |
 | `env_vars`         | 关键环境变量                  | PATH, LD_LIBRARY_PATH, PYTHONPATH, HF_HOME, VLLM_CACHE_ROOT, ASCEND\_\* |
-| `git_info`         | git rev-parse                 | 三个仓库的 commit SHA                                                   |
+| `git_info`         | git rev-parse + 显式环境变量  | core/backend 的 declared/observed SHA 与 benchmark SHA                  |
+| `frozen_inputs`    | 显式环境变量 + runtime 探测   | image、model revision、CANN、torch-npu 与拓扑                           |
+| `campaign`         | campaign runner               | campaign/comparison/role/load profile 与独立服务 repetition 序号        |
 | `pip_packages`     | pip list（引用外部文件）      | 详见 pip-packages.json                                                  |
 
 ### 3.3 `checksums.sha256` — 文件校验和

--- a/scripts/collect-run-artifact.sh
+++ b/scripts/collect-run-artifact.sh
@@ -42,34 +42,106 @@ if [[ ! -d "$ARTIFACT_DIR" ]]; then
   exit 2
 fi
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BENCHMARK_REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 cd "$ARTIFACT_DIR"
-BENCHMARK_REPO_ROOT=$(cd "$(dirname "$ARTIFACT_DIR")/.." && pwd)
 export BENCHMARK_REPO_ROOT
 
 # ─── 1. Environment Manifest ────────────────────────────────────────────────
 
 # Build env-manifest.json via Python for robust JSON encoding (handles
 # special characters in env var values, git output, etc.).
-python3 -c '
-import json, os, platform, subprocess, sys
+python3 - <<'PY' > env-manifest.json
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
 from pathlib import Path
+
 
 def _run(cmd, timeout=5):
     """Run a command and return stripped stdout, or empty string on error."""
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         return r.stdout.strip() if r.returncode == 0 else ""
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return ""
 
+
 def _git_commit(repo):
-    if not repo or not Path(repo).joinpath(".git").is_dir():
+    if not repo:
         return "not available"
-    return _run(["git", "-C", repo, "rev-parse", "HEAD"])
+    commit = _run(["git", "-C", repo, "rev-parse", "HEAD"])
+    return commit or "not available"
+
+
+def _runtime_package_versions():
+    runtime_python = os.environ.get("CURRENT_RUNTIME_PYTHON") or sys.executable
+    script = """
+import importlib.metadata
+import json
+
+packages = {}
+for distribution in ("torch", "torch-npu", "vllm", "vllm-ascend", "vllm-ascend-hust"):
+    try:
+        packages[distribution] = importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        continue
+print(json.dumps(packages, sort_keys=True))
+"""
+    raw = _run([runtime_python, "-c", script], timeout=20)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return result if isinstance(result, dict) else {}
+
+
+def _detect_cann_version():
+    declared = os.environ.get("CURRENT_CANN_VERSION", "")
+    ascend_home = os.environ.get("ASCEND_HOME_PATH") or os.environ.get(
+        "ASCEND_TOOLKIT_HOME", ""
+    )
+    candidates = (
+        Path(ascend_home) / "version.cfg" if ascend_home else None,
+        Path(ascend_home) / "version.info" if ascend_home else None,
+        Path(ascend_home) / "opp/version.info" if ascend_home else None,
+        Path("/usr/local/Ascend/ascend-toolkit/latest/version.cfg"),
+        Path("/usr/local/Ascend/latest/version.cfg"),
+        Path("/opt/hust-ascend-cann/Ascend/ascend-toolkit/latest/version.cfg"),
+    )
+    detected = ""
+    source = ""
+    for candidate in candidates:
+        if candidate is not None and candidate.is_file():
+            raw = candidate.read_text(encoding="utf-8", errors="replace").strip()
+            match = re.search(r'^Version\s*=\s*["\']?([^"\'\n]+)', raw, re.MULTILINE)
+            detected = match.group(1).strip() if match else raw
+            source = str(candidate)
+            break
+    return {"declared": declared, "detected": detected, "source": source}
+
+
+def _env(name):
+    return os.environ.get(name, "")
+
+
+def _int_env(name):
+    try:
+        return int(_env(name) or 0)
+    except ValueError:
+        return 0
+
+
+observed_core_commit = _git_commit(_env("CURRENT_VLLM_HUST_REPO"))
+observed_backend_commit = _git_commit(_env("CURRENT_VLLM_ASCEND_HUST_REPO"))
+package_versions = _runtime_package_versions()
 
 manifest = {
-    "manifest_version": "run-env-manifest/v1",
-    "collected_at": os.popen("date -u +%Y-%m-%dT%H:%M:%SZ").read().strip(),
+    "manifest_version": "run-env-manifest/v2",
+    "collected_at": _run(["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"]),
     "os": _run(["uname", "-a"]),
     "python_version": _run([sys.executable, "--version"]),
     "hostname": platform.node(),
@@ -82,15 +154,42 @@ manifest = {
         else "not detected"
     ),
     "npu_smi": _run(["npu-smi", "info", "-t", "board", "-i", "0"]) or "npu-smi not available",
+    "frozen_inputs_required": _env("CAMPAIGN_REQUIRE_FROZEN_INPUTS") == "1",
+    "frozen_inputs": {
+        "image_id": _env("CURRENT_IMAGE_ID"),
+        "model_revision": _env("CURRENT_MODEL_REVISION"),
+        "cann": _detect_cann_version(),
+        "torch_npu_version": {
+            "declared": _env("CURRENT_TORCH_NPU_VERSION"),
+            "detected": package_versions.get("torch-npu", ""),
+        },
+        "topology": _env("CURRENT_TOPOLOGY"),
+    },
+    "campaign": {
+        "campaign_id": _env("CAMPAIGN_ID"),
+        "coverage_class": _env("CAMPAIGN_COVERAGE_CLASS"),
+        "comparison_id": _env("CAMPAIGN_COMPARISON_ID"),
+        "point_role": _env("CAMPAIGN_POINT_ROLE"),
+        "load_profile": _env("CAMPAIGN_LOAD_PROFILE"),
+        "repeat_index": _int_env("CAMPAIGN_REPEAT_INDEX"),
+        "repetitions": _int_env("CAMPAIGN_REPETITIONS"),
+    },
+    "runtime_packages": package_versions,
     "env_vars": {
-        k: os.environ.get(k, "")
+        k: _env(k)
         for k in ["PATH", "LD_LIBRARY_PATH", "PYTHONPATH", "HF_HOME",
                    "VLLM_CACHE_ROOT", "ASCEND_RT_VISIBLE_DEVICES", "ASCEND_VISIBLE_DEVICES"]
     },
     "git_info": {
-        "vllm_hust": _git_commit(os.environ.get("CURRENT_VLLM_HUST_REPO")),
-        "vllm_ascend_hust": _git_commit(os.environ.get("CURRENT_VLLM_ASCEND_HUST_REPO")),
-        "benchmark": _run(["git", "-C", os.environ.get("BENCHMARK_REPO_ROOT", ""), "rev-parse", "HEAD"]),
+        "vllm_hust": {
+            "declared": _env("CURRENT_GIT_COMMIT"),
+            "observed": observed_core_commit,
+        },
+        "vllm_ascend_hust": {
+            "declared": _env("CURRENT_PLUGIN_GIT_COMMIT"),
+            "observed": observed_backend_commit,
+        },
+        "benchmark": _git_commit(_env("BENCHMARK_REPO_ROOT")),
     },
 }
 
@@ -98,7 +197,7 @@ manifest = {
 manifest["pip_packages"] = "see pip-packages.json"
 
 json.dump(manifest, sys.stdout, indent=2, ensure_ascii=False)
-' > env-manifest.json
+PY
 echo "[collect] env-manifest.json written"
 
 # ─── 1b. Pip packages (separate file for parsing convenience) ──────────────

--- a/scripts/run-campaign-repetitions.sh
+++ b/scripts/run-campaign-repetitions.sh
@@ -30,12 +30,15 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SINGLE_REPETITION_RUNNER=${SINGLE_REPETITION_RUNNER:-"$SCRIPT_DIR/run-single-repetition.sh"}
 
 SPEC_FILE=""
 CAMPAIGN_PREFIX=""
 REPETITIONS=3
 COOLDOWN_SECONDS=60
 MAX_PORT_WAIT_SECONDS=120
+CAMPAIGN_REQUIRE_FROZEN_INPUTS=${CAMPAIGN_REQUIRE_FROZEN_INPUTS:-0}
+CAMPAIGN_SUMMARY_FILE=${CAMPAIGN_SUMMARY_FILE:-}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -71,6 +74,137 @@ fi
 if [[ ! -f "$SPEC_FILE" ]]; then
   echo "Error: spec file not found: $SPEC_FILE" >&2
   exit 2
+fi
+
+if [[ ! -x "$SINGLE_REPETITION_RUNNER" ]]; then
+  echo "Error: single-repetition runner is not executable: $SINGLE_REPETITION_RUNNER" >&2
+  exit 2
+fi
+
+if ! [[ "$REPETITIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: repetitions must be a positive integer: $REPETITIONS" >&2
+  exit 2
+fi
+
+if ! [[ "$COOLDOWN_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Error: cooldown must be a non-negative integer: $COOLDOWN_SECONDS" >&2
+  exit 2
+fi
+
+require_nonempty() {
+  local name=$1
+  if [[ -z "${!name:-}" ]]; then
+    echo "Error: $name is required when CAMPAIGN_REQUIRE_FROZEN_INPUTS=1" >&2
+    exit 2
+  fi
+}
+
+require_git_commit() {
+  local name=$1
+  require_nonempty "$name"
+  if ! [[ "${!name}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Error: $name must be a full 40-character Git commit: ${!name}" >&2
+    exit 2
+  fi
+}
+
+assert_repo_commit() {
+  local repo_name=$1
+  local repo_path=$2
+  local expected=$3
+  local observed
+
+  if [[ ! -d "$repo_path" ]]; then
+    echo "Error: $repo_name repository not found: $repo_path" >&2
+    exit 2
+  fi
+  observed=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
+  if [[ "$observed" != "$expected" ]]; then
+    echo "Error: $repo_name HEAD $observed does not match frozen commit $expected" >&2
+    exit 2
+  fi
+}
+
+if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then
+  if ((REPETITIONS < 3)); then
+    echo "Error: formal campaigns require at least 3 independent service repetitions" >&2
+    exit 2
+  fi
+
+  require_git_commit CURRENT_GIT_COMMIT
+  require_git_commit CURRENT_PLUGIN_GIT_COMMIT
+  require_nonempty CURRENT_IMAGE_ID
+  require_nonempty CURRENT_MODEL_REVISION
+  require_nonempty CURRENT_CANN_VERSION
+  require_nonempty CURRENT_TORCH_NPU_VERSION
+  require_nonempty CURRENT_TOPOLOGY
+  require_nonempty CAMPAIGN_ID
+  require_nonempty CAMPAIGN_COVERAGE_CLASS
+  require_nonempty CAMPAIGN_POINT_ROLE
+  require_nonempty CAMPAIGN_LOAD_PROFILE
+  require_nonempty ASCEND_RT_VISIBLE_DEVICES
+  require_nonempty ASCEND_VISIBLE_DEVICES
+
+  if ! [[ "$CURRENT_IMAGE_ID" =~ ^(sha256:)?[0-9a-fA-F]{64}$ ]]; then
+    echo "Error: CURRENT_IMAGE_ID must be a full image digest or ID: $CURRENT_IMAGE_ID" >&2
+    exit 2
+  fi
+  if ! [[ "$CURRENT_MODEL_REVISION" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+    echo "Error: CURRENT_MODEL_REVISION must be an immutable 40-64 character revision: $CURRENT_MODEL_REVISION" >&2
+    exit 2
+  fi
+  if [[ "$ASCEND_RT_VISIBLE_DEVICES" != "$ASCEND_VISIBLE_DEVICES" ]]; then
+    echo "Error: ASCEND_RT_VISIBLE_DEVICES and ASCEND_VISIBLE_DEVICES must select the same devices" >&2
+    exit 2
+  fi
+  if ! [[ "$ASCEND_RT_VISIBLE_DEVICES" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+    echo "Error: visible devices must be an explicit comma-separated numeric list: $ASCEND_RT_VISIBLE_DEVICES" >&2
+    exit 2
+  fi
+  EXPECTED_CHIP_COUNT=$(jq -r '.chip_count // 1' "$SPEC_FILE")
+  if ! [[ "$EXPECTED_CHIP_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: spec chip_count must be a positive integer: $EXPECTED_CHIP_COUNT" >&2
+    exit 2
+  fi
+  IFS=',' read -r -a SELECTED_DEVICES <<< "$ASCEND_RT_VISIBLE_DEVICES"
+  if [[ "${#SELECTED_DEVICES[@]}" -ne "$EXPECTED_CHIP_COUNT" ]]; then
+    echo "Error: spec requires $EXPECTED_CHIP_COUNT chip(s), but $ASCEND_RT_VISIBLE_DEVICES selects ${#SELECTED_DEVICES[@]}" >&2
+    exit 2
+  fi
+  if [[ "$(printf '%s\n' "${SELECTED_DEVICES[@]}" | sort -u | wc -l)" -ne "${#SELECTED_DEVICES[@]}" ]]; then
+    echo "Error: visible device list contains a duplicate: $ASCEND_RT_VISIBLE_DEVICES" >&2
+    exit 2
+  fi
+
+  case "$CAMPAIGN_COVERAGE_CLASS" in
+    full-matrix)
+      if [[ "$CAMPAIGN_POINT_ROLE" != "checkpoint" ]]; then
+        echo "Error: full-matrix campaigns require CAMPAIGN_POINT_ROLE=checkpoint" >&2
+        exit 2
+      fi
+      ;;
+    targeted-pair)
+      require_nonempty CAMPAIGN_COMPARISON_ID
+      if [[ "$CAMPAIGN_POINT_ROLE" != "baseline" && "$CAMPAIGN_POINT_ROLE" != "head" ]]; then
+        echo "Error: targeted-pair campaigns require CAMPAIGN_POINT_ROLE=baseline or head" >&2
+        exit 2
+      fi
+      ;;
+    *)
+      echo "Error: unsupported formal CAMPAIGN_COVERAGE_CLASS: $CAMPAIGN_COVERAGE_CLASS" >&2
+      exit 2
+      ;;
+  esac
+
+  if [[ "${PERFGATE_WARMUP_RUNS:-0}" != "0" || "${PERFGATE_MEASURED_RUNS:-1}" != "1" ]]; then
+    echo "Error: formal independent-service campaigns require PERFGATE_WARMUP_RUNS=0 and PERFGATE_MEASURED_RUNS=1" >&2
+    exit 2
+  fi
+
+  require_nonempty CURRENT_VLLM_HUST_REPO
+  require_nonempty CURRENT_VLLM_ASCEND_HUST_REPO
+  assert_repo_commit "vllm-hust" "$CURRENT_VLLM_HUST_REPO" "$CURRENT_GIT_COMMIT"
+  assert_repo_commit "vllm-ascend-hust" "$CURRENT_VLLM_ASCEND_HUST_REPO" "$CURRENT_PLUGIN_GIT_COMMIT"
 fi
 
 # Infer campaign prefix from spec filename if not provided
@@ -127,6 +261,8 @@ SUCCESS_COUNT=0
 FAIL_COUNT=0
 FIRST_FAILURE_EXIT_CODE=0
 ARTIFACT_DIRS=()
+SUMMARY_ROWS_FILE=$(mktemp)
+trap 'rm -f "$SUMMARY_ROWS_FILE"' EXIT
 
 for (( i=1; i<=REPETITIONS; i++ )); do
   echo ""
@@ -146,9 +282,11 @@ for (( i=1; i<=REPETITIONS; i++ )); do
   # value even for long-running benchmarks that cross a clock-tick boundary.
   CAMPAIGN_RUN_TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
   export CAMPAIGN_RUN_TIMESTAMP
+  export CAMPAIGN_REPEAT_INDEX=$((i - 1))
+  export CAMPAIGN_REPETITIONS="$REPETITIONS"
 
   set +e
-  bash "$SCRIPT_DIR/run-single-repetition.sh" \
+  bash "$SINGLE_REPETITION_RUNNER" \
     "$SPEC_FILE" \
     "$CAMPAIGN_PREFIX" \
     "$i"
@@ -157,12 +295,13 @@ for (( i=1; i<=REPETITIONS; i++ )); do
 
   # Artifact dir is deterministic from the pinned timestamp.
   ARTIFACT_DIR="$REPO_ROOT/submissions/${CAMPAIGN_PREFIX}-${WORKLOAD_NAME}-${CHIP_COUNT}chip-${CAMPAIGN_RUN_TIMESTAMP}"
+  printf '%s\t%s\t%s\n' "$CAMPAIGN_REPEAT_INDEX" "$EXIT_CODE" "$ARTIFACT_DIR" >> "$SUMMARY_ROWS_FILE"
 
   if [[ "$EXIT_CODE" -eq 0 ]]; then
-    (( SUCCESS_COUNT++ ))
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
     ARTIFACT_DIRS+=("$ARTIFACT_DIR")
   else
-    (( FAIL_COUNT++ ))
+    FAIL_COUNT=$((FAIL_COUNT + 1))
     if [[ "$FIRST_FAILURE_EXIT_CODE" -eq 0 ]]; then
       FIRST_FAILURE_EXIT_CODE="$EXIT_CODE"
     fi
@@ -174,6 +313,62 @@ for (( i=1; i<=REPETITIONS; i++ )); do
     echo "[campaign] repetition ${i} failed (exit ${EXIT_CODE}); continuing..." >&2
   fi
 done
+
+if [[ -n "$CAMPAIGN_SUMMARY_FILE" ]]; then
+  mkdir -p "$(dirname "$CAMPAIGN_SUMMARY_FILE")"
+  env SUMMARY_ROWS_FILE="$SUMMARY_ROWS_FILE" \
+    CAMPAIGN_SUMMARY_FILE="$CAMPAIGN_SUMMARY_FILE" \
+    CAMPAIGN_SPEC_FILE="$(realpath "$SPEC_FILE")" \
+    CAMPAIGN_PREFIX_VALUE="$CAMPAIGN_PREFIX" \
+    python3 - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+rows = []
+for line in Path(os.environ["SUMMARY_ROWS_FILE"]).read_text(encoding="utf-8").splitlines():
+    repeat_index, exit_code, artifact_dir = line.split("\t", 2)
+    rows.append(
+        {
+            "repeat_index": int(repeat_index),
+            "exit_code": int(exit_code),
+            "status": "ok" if exit_code == "0" else "failed",
+            "artifact_dir": artifact_dir,
+        }
+    )
+
+payload = {
+    "schema_version": "independent-service-campaign-summary/v1",
+    "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "campaign_id": os.environ.get("CAMPAIGN_ID", ""),
+    "campaign_prefix": os.environ["CAMPAIGN_PREFIX_VALUE"],
+    "coverage_class": os.environ.get("CAMPAIGN_COVERAGE_CLASS", ""),
+    "comparison_id": os.environ.get("CAMPAIGN_COMPARISON_ID", ""),
+    "point_role": os.environ.get("CAMPAIGN_POINT_ROLE", ""),
+    "load_profile": os.environ.get("CAMPAIGN_LOAD_PROFILE", ""),
+    "visible_devices": os.environ.get("ASCEND_RT_VISIBLE_DEVICES", ""),
+    "spec_file": os.environ["CAMPAIGN_SPEC_FILE"],
+    "frozen_inputs": {
+        "core_commit": os.environ.get("CURRENT_GIT_COMMIT", ""),
+        "backend_commit": os.environ.get("CURRENT_PLUGIN_GIT_COMMIT", ""),
+        "image_id": os.environ.get("CURRENT_IMAGE_ID", ""),
+        "model_revision": os.environ.get("CURRENT_MODEL_REVISION", ""),
+        "cann_version": os.environ.get("CURRENT_CANN_VERSION", ""),
+        "torch_npu_version": os.environ.get("CURRENT_TORCH_NPU_VERSION", ""),
+        "topology": os.environ.get("CURRENT_TOPOLOGY", ""),
+    },
+    "requested_repetitions": int(os.environ.get("CAMPAIGN_REPETITIONS", "0")),
+    "successful_repetitions": sum(row["status"] == "ok" for row in rows),
+    "runs": rows,
+}
+Path(os.environ["CAMPAIGN_SUMMARY_FILE"]).write_text(
+    json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+    encoding="utf-8",
+)
+PY
+  echo "[campaign] summary: $CAMPAIGN_SUMMARY_FILE"
+fi
 
 # ─── Summary ───────────────────────────────────────────────────────────────
 

--- a/scripts/run-campaign-repetitions.sh
+++ b/scripts/run-campaign-repetitions.sh
@@ -144,7 +144,6 @@ if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then
   require_nonempty CURRENT_TOPOLOGY
   require_nonempty CAMPAIGN_ID
   require_nonempty CAMPAIGN_COVERAGE_CLASS
-  require_nonempty CAMPAIGN_POINT_ROLE
   require_nonempty CAMPAIGN_LOAD_PROFILE
   require_nonempty ASCEND_RT_VISIBLE_DEVICES
   require_nonempty ASCEND_VISIBLE_DEVICES
@@ -182,6 +181,7 @@ if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then
 
   case "$CAMPAIGN_COVERAGE_CLASS" in
     full-matrix)
+      require_nonempty CAMPAIGN_POINT_ROLE
       if [[ "$CAMPAIGN_POINT_ROLE" != "checkpoint" ]]; then
         echo "Error: full-matrix campaigns require CAMPAIGN_POINT_ROLE=checkpoint" >&2
         exit 2
@@ -189,8 +189,15 @@ if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then
       ;;
     targeted-pair)
       require_nonempty CAMPAIGN_COMPARISON_ID
+      require_nonempty CAMPAIGN_POINT_ROLE
       if [[ "$CAMPAIGN_POINT_ROLE" != "baseline" && "$CAMPAIGN_POINT_ROLE" != "head" ]]; then
         echo "Error: targeted-pair campaigns require CAMPAIGN_POINT_ROLE=baseline or head" >&2
+        exit 2
+      fi
+      ;;
+    experimental)
+      if [[ -n "${CAMPAIGN_COMPARISON_ID:-}" || -n "${CAMPAIGN_POINT_ROLE:-}" ]]; then
+        echo "Error: experimental campaigns must not declare CAMPAIGN_COMPARISON_ID or CAMPAIGN_POINT_ROLE" >&2
         exit 2
       fi
       ;;

--- a/scripts/run-campaign-repetitions.sh
+++ b/scripts/run-campaign-repetitions.sh
@@ -36,7 +36,7 @@ SPEC_FILE=""
 CAMPAIGN_PREFIX=""
 REPETITIONS=3
 COOLDOWN_SECONDS=60
-MAX_PORT_WAIT_SECONDS=120
+MAX_PORT_WAIT_SECONDS=${MAX_PORT_WAIT_SECONDS:-120}
 CAMPAIGN_REQUIRE_FROZEN_INPUTS=${CAMPAIGN_REQUIRE_FROZEN_INPUTS:-0}
 CAMPAIGN_SUMMARY_FILE=${CAMPAIGN_SUMMARY_FILE:-}
 
@@ -76,8 +76,8 @@ if [[ ! -f "$SPEC_FILE" ]]; then
   exit 2
 fi
 
-if [[ ! -x "$SINGLE_REPETITION_RUNNER" ]]; then
-  echo "Error: single-repetition runner is not executable: $SINGLE_REPETITION_RUNNER" >&2
+if [[ ! -f "$SINGLE_REPETITION_RUNNER" || ! -r "$SINGLE_REPETITION_RUNNER" ]]; then
+  echo "Error: single-repetition runner is not a readable file: $SINGLE_REPETITION_RUNNER" >&2
   exit 2
 fi
 
@@ -88,6 +88,11 @@ fi
 
 if ! [[ "$COOLDOWN_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "Error: cooldown must be a non-negative integer: $COOLDOWN_SECONDS" >&2
+  exit 2
+fi
+
+if ! [[ "$MAX_PORT_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Error: MAX_PORT_WAIT_SECONDS must be a non-negative integer: $MAX_PORT_WAIT_SECONDS" >&2
   exit 2
 fi
 
@@ -262,7 +267,6 @@ wait_for_port_free() {
     (( waited += 5 ))
   done
 
-  echo "[campaign] WARNING: port ${port} still has listeners after ${MAX_PORT_WAIT_SECONDS}s; proceeding anyway" >&2
   return 1
 }
 
@@ -271,6 +275,8 @@ wait_for_port_free() {
 SUCCESS_COUNT=0
 FAIL_COUNT=0
 FIRST_FAILURE_EXIT_CODE=0
+CAMPAIGN_ABORT_EXIT_CODE=0
+CAMPAIGN_ABORT_REASON=""
 ARTIFACT_DIRS=()
 SUMMARY_ROWS_FILE=$(mktemp)
 trap 'rm -f "$SUMMARY_ROWS_FILE"' EXIT
@@ -281,12 +287,25 @@ for (( i=1; i<=REPETITIONS; i++ )); do
   echo "  Repetition ${i}/${REPETITIONS}"
   echo "───────────────────────────────────────────────────────────────────────"
 
-  # Wait for port to be free between repetitions (first run skips this)
+  # Enforce a cooldown between repetitions, then prove that the target port is
+  # free before every launch. The first-run check also prevents a formal
+  # campaign from accidentally attaching to a pre-existing service.
   if (( i > 1 )); then
-    # Also enforce a cooldown to let NPU memory settle
     echo "[campaign] cooldown ${COOLDOWN_SECONDS}s before next repetition..."
     sleep "$COOLDOWN_SECONDS"
-    wait_for_port_free "${CURRENT_SERVER_PORT:-8001}" || true
+  fi
+  CAMPAIGN_PORT=${CURRENT_SERVER_PORT:-8001}
+  if ! wait_for_port_free "$CAMPAIGN_PORT"; then
+    if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then
+      CAMPAIGN_ABORT_EXIT_CODE=2
+      CAMPAIGN_ABORT_REASON="target port ${CAMPAIGN_PORT} still has listeners after ${MAX_PORT_WAIT_SECONDS}s"
+      if [[ "$FIRST_FAILURE_EXIT_CODE" -eq 0 ]]; then
+        FIRST_FAILURE_EXIT_CODE=$CAMPAIGN_ABORT_EXIT_CODE
+      fi
+      echo "[campaign] ERROR: ${CAMPAIGN_ABORT_REASON}; refusing to start repetition ${i}/${REPETITIONS} in formal mode" >&2
+      break
+    fi
+    echo "[campaign] WARNING: port ${CAMPAIGN_PORT} still has listeners after ${MAX_PORT_WAIT_SECONDS}s; proceeding in diagnostic mode" >&2
   fi
 
   # Pin a single timestamp so run-single-repetition.sh uses the same
@@ -331,6 +350,8 @@ if [[ -n "$CAMPAIGN_SUMMARY_FILE" ]]; then
     CAMPAIGN_SUMMARY_FILE="$CAMPAIGN_SUMMARY_FILE" \
     CAMPAIGN_SPEC_FILE="$(realpath "$SPEC_FILE")" \
     CAMPAIGN_PREFIX_VALUE="$CAMPAIGN_PREFIX" \
+    CAMPAIGN_ABORT_EXIT_CODE_VALUE="$CAMPAIGN_ABORT_EXIT_CODE" \
+    CAMPAIGN_ABORT_REASON_VALUE="$CAMPAIGN_ABORT_REASON" \
     python3 - <<'PY'
 import json
 import os
@@ -349,6 +370,8 @@ for line in Path(os.environ["SUMMARY_ROWS_FILE"]).read_text(encoding="utf-8").sp
         }
     )
 
+abort_exit_code = int(os.environ["CAMPAIGN_ABORT_EXIT_CODE_VALUE"])
+abort_reason = os.environ["CAMPAIGN_ABORT_REASON_VALUE"]
 payload = {
     "schema_version": "independent-service-campaign-summary/v1",
     "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -370,7 +393,15 @@ payload = {
         "topology": os.environ.get("CURRENT_TOPOLOGY", ""),
     },
     "requested_repetitions": int(os.environ.get("CAMPAIGN_REPETITIONS", "0")),
+    "attempted_repetitions": len(rows),
     "successful_repetitions": sum(row["status"] == "ok" for row in rows),
+    "status": (
+        "aborted"
+        if abort_exit_code
+        else ("failed" if any(row["status"] == "failed" for row in rows) else "ok")
+    ),
+    "abort_exit_code": abort_exit_code,
+    "abort_reason": abort_reason,
     "runs": rows,
 }
 Path(os.environ["CAMPAIGN_SUMMARY_FILE"]).write_text(
@@ -399,7 +430,10 @@ for dir in "${ARTIFACT_DIRS[@]}"; do
 done
 echo ""
 
-if (( FAIL_COUNT > 0 )); then
+if (( CAMPAIGN_ABORT_EXIT_CODE > 0 )); then
+  echo "[campaign] ❌ campaign aborted: ${CAMPAIGN_ABORT_REASON}" >&2
+  exit "$FIRST_FAILURE_EXIT_CODE"
+elif (( FAIL_COUNT > 0 )); then
   echo "[campaign] ❌ ${FAIL_COUNT}/${REPETITIONS} repetitions failed" >&2
   exit "$FIRST_FAILURE_EXIT_CODE"
 else

--- a/scripts/run-campaign-repetitions.sh
+++ b/scripts/run-campaign-repetitions.sh
@@ -123,6 +123,10 @@ assert_repo_commit() {
     echo "Error: $repo_name HEAD $observed does not match frozen commit $expected" >&2
     exit 2
   fi
+  if [[ -n "$(git -C "$repo_path" status --porcelain --untracked-files=all 2>/dev/null)" ]]; then
+    echo "Error: $repo_name repository has tracked or untracked changes; formal campaigns require a clean frozen source tree" >&2
+    exit 2
+  fi
 }
 
 if [[ "$CAMPAIGN_REQUIRE_FROZEN_INPUTS" == "1" ]]; then

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -17,6 +17,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
 ARTIFACT_DIR="${1:?Usage: validate-run-artifact.sh <artifact-dir>}"
 
 if [[ ! -d "$ARTIFACT_DIR" ]]; then
@@ -196,9 +199,6 @@ else
 fi
 
 # ─── 6. Schema normalization (if Python available) ──────────────────────────
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 if [[ -f "run_leaderboard.json" ]] && [[ -d "$REPO_ROOT/src" ]]; then
   if python3 -c "

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -35,7 +35,7 @@ check() {
     echo "  ✅ $desc"
   else
     echo "  ❌ $desc" >&2
-    (( ERRORS++ ))
+    ERRORS=$((ERRORS + 1))
   fi
 }
 
@@ -105,8 +105,62 @@ missing = [k for k in required if k not in m]
 if missing:
     print(', '.join(missing))
 " 2>/dev/null || echo "parse-error")
-    if [[ -z "$MISSING" ]] || [[ "$MISSING" == "parse-error" ]]; then
-      [[ -z "$MISSING" ]] && check "env-manifest.json has required fields" 0 || check "env-manifest.json required field check" 1
+    if [[ -z "$MISSING" ]]; then
+      check "env-manifest.json has required fields" 0
+    else
+      echo "  missing env-manifest fields: $MISSING" >&2
+      check "env-manifest.json has required fields" 1
+    fi
+    FROZEN_INPUT_ERRORS=$(python3 - <<'PY'
+import json
+
+manifest = json.load(open("env-manifest.json", encoding="utf-8"))
+if not manifest.get("frozen_inputs_required"):
+    raise SystemExit(0)
+
+errors = []
+inputs = manifest.get("frozen_inputs") or {}
+for field in ("image_id", "model_revision", "topology"):
+    if not inputs.get(field):
+        errors.append(f"frozen_inputs.{field} is empty")
+
+for field in ("cann", "torch_npu_version"):
+    value = inputs.get(field) or {}
+    if not value.get("declared"):
+        errors.append(f"frozen_inputs.{field}.declared is empty")
+    if not value.get("detected"):
+        errors.append(f"frozen_inputs.{field}.detected is empty")
+    elif value.get("declared") != value.get("detected"):
+        errors.append(
+            f"frozen_inputs.{field} declared {value.get('declared')!r} "
+            f"does not match detected {value.get('detected')!r}"
+        )
+
+for repo in ("vllm_hust", "vllm_ascend_hust"):
+    value = (manifest.get("git_info") or {}).get(repo) or {}
+    if not value.get("declared"):
+        errors.append(f"git_info.{repo}.declared is empty")
+    if value.get("declared") != value.get("observed"):
+        errors.append(
+            f"git_info.{repo} declared {value.get('declared')!r} "
+            f"does not match observed {value.get('observed')!r}"
+        )
+
+campaign = manifest.get("campaign") or {}
+for field in ("campaign_id", "coverage_class", "point_role", "load_profile"):
+    if not campaign.get(field):
+        errors.append(f"campaign.{field} is empty")
+if campaign.get("repetitions", 0) < 3:
+    errors.append("campaign.repetitions is less than 3")
+
+print("; ".join(errors))
+PY
+)
+    if [[ -z "$FROZEN_INPUT_ERRORS" ]]; then
+      check "formal campaign frozen provenance is complete" 0
+    else
+      echo "  $FROZEN_INPUT_ERRORS" >&2
+      check "formal campaign frozen provenance is complete" 1
     fi
   else
     check "env-manifest.json is valid JSON" 1

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -114,7 +114,7 @@ if missing:
       echo "  missing env-manifest fields: $MISSING" >&2
       check "env-manifest.json has required fields" 1
     fi
-    FROZEN_INPUT_ERRORS=$(python3 - <<'PY'
+    FROZEN_INPUT_ERRORS=$(python3 - <<'PY' || echo "parse-error"
 import json
 
 manifest = json.load(open("env-manifest.json", encoding="utf-8"))

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -147,9 +147,22 @@ for repo in ("vllm_hust", "vllm_ascend_hust"):
         )
 
 campaign = manifest.get("campaign") or {}
-for field in ("campaign_id", "coverage_class", "point_role", "load_profile"):
+for field in ("campaign_id", "coverage_class", "load_profile"):
     if not campaign.get(field):
         errors.append(f"campaign.{field} is empty")
+coverage_class = campaign.get("coverage_class")
+if coverage_class == "full-matrix" and campaign.get("point_role") != "checkpoint":
+    errors.append("campaign.point_role must be checkpoint for full-matrix")
+elif coverage_class == "targeted-pair":
+    if campaign.get("point_role") not in ("baseline", "head"):
+        errors.append("campaign.point_role must be baseline or head for targeted-pair")
+    if not campaign.get("comparison_id"):
+        errors.append("campaign.comparison_id is empty for targeted-pair")
+elif coverage_class == "experimental":
+    if campaign.get("point_role") or campaign.get("comparison_id"):
+        errors.append("experimental campaign declares a point_role or comparison_id")
+else:
+    errors.append(f"campaign.coverage_class is unsupported: {coverage_class!r}")
 if campaign.get("repetitions", 0) < 3:
     errors.append("campaign.repetitions is less than 3")
 

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -198,6 +198,43 @@ def test_formal_campaign_accepts_matching_frozen_repositories(tmp_path: Path) ->
     assert summary["coverage_class"] == "full-matrix"
 
 
+def test_strict_campaign_accepts_explicit_experimental_series(tmp_path: Path) -> None:
+    core = tmp_path / "core"
+    backend = tmp_path / "backend"
+    core_commit = _init_git_repo(core)
+    backend_commit = _init_git_repo(backend)
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+            "CAMPAIGN_ID": "issue-136-integration/v1",
+            "CAMPAIGN_COVERAGE_CLASS": "experimental",
+            "CAMPAIGN_POINT_ROLE": "",
+            "CAMPAIGN_COMPARISON_ID": "",
+            "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+            "CURRENT_GIT_COMMIT": core_commit,
+            "CURRENT_PLUGIN_GIT_COMMIT": backend_commit,
+            "CURRENT_IMAGE_ID": "b" * 64,
+            "CURRENT_MODEL_REVISION": "c" * 40,
+            "CURRENT_CANN_VERSION": "9.0.0",
+            "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+            "CURRENT_TOPOLOGY": "single-node-hccs",
+            "ASCEND_RT_VISIBLE_DEVICES": "0,1",
+            "ASCEND_VISIBLE_DEVICES": "0,1",
+            "CURRENT_VLLM_HUST_REPO": str(core),
+            "CURRENT_VLLM_ASCEND_HUST_REPO": str(backend),
+            "PERFGATE_WARMUP_RUNS": "0",
+            "PERFGATE_MEASURED_RUNS": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["coverage_class"] == "experimental"
+    assert summary["comparison_id"] == ""
+    assert summary["point_role"] == ""
+
+
 def test_formal_campaign_rejects_dirty_frozen_repository(tmp_path: Path) -> None:
     core = tmp_path / "core"
     backend = tmp_path / "backend"

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -198,6 +198,41 @@ def test_formal_campaign_accepts_matching_frozen_repositories(tmp_path: Path) ->
     assert summary["coverage_class"] == "full-matrix"
 
 
+def test_formal_campaign_rejects_dirty_frozen_repository(tmp_path: Path) -> None:
+    core = tmp_path / "core"
+    backend = tmp_path / "backend"
+    core_commit = _init_git_repo(core)
+    backend_commit = _init_git_repo(backend)
+    (backend / "untracked.txt").write_text("not frozen\n", encoding="utf-8")
+
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+            "CAMPAIGN_ID": "issue-136/v1",
+            "CAMPAIGN_COVERAGE_CLASS": "full-matrix",
+            "CAMPAIGN_POINT_ROLE": "checkpoint",
+            "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+            "CURRENT_GIT_COMMIT": core_commit,
+            "CURRENT_PLUGIN_GIT_COMMIT": backend_commit,
+            "CURRENT_IMAGE_ID": "b" * 64,
+            "CURRENT_MODEL_REVISION": "c" * 40,
+            "CURRENT_CANN_VERSION": "9.0.0",
+            "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+            "CURRENT_TOPOLOGY": "single-node-hccs",
+            "ASCEND_RT_VISIBLE_DEVICES": "0,1",
+            "ASCEND_VISIBLE_DEVICES": "0,1",
+            "CURRENT_VLLM_HUST_REPO": str(core),
+            "CURRENT_VLLM_ASCEND_HUST_REPO": str(backend),
+            "PERFGATE_WARMUP_RUNS": "0",
+            "PERFGATE_MEASURED_RUNS": "1",
+        },
+    )
+
+    assert result.returncode == 2
+    assert "formal campaigns require a clean frozen source tree" in result.stderr
+
+
 def test_collector_records_declared_and_observed_worktree_commits(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -1,0 +1,301 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from _bash_utils import bash_executable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CAMPAIGN_RUNNER = REPO_ROOT / "scripts/run-campaign-repetitions.sh"
+COLLECTOR = REPO_ROOT / "scripts/collect-run-artifact.sh"
+VALIDATOR = REPO_ROOT / "scripts/validate-run-artifact.sh"
+
+
+def _write_spec(path: Path, *, chip_count: int = 2) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "scenario": "random-online",
+                "chip_count": chip_count,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_fake_runner(path: Path, *, fail_index: int | None = None) -> None:
+    failure = (
+        f'if [[ "$3" == "{fail_index}" ]]; then exit 19; fi'
+        if fail_index is not None
+        else ""
+    )
+    path.write_text(
+        f"""#!/bin/bash
+set -euo pipefail
+printf '%s\\t%s\\t%s\\t%s\\n' "$1" "$2" "$3" "$CAMPAIGN_REPEAT_INDEX" >> "$CALL_LOG"
+{failure}
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _run_campaign(
+    tmp_path: Path,
+    *,
+    fail_index: int | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    spec = tmp_path / "spec.json"
+    fake_runner = tmp_path / "fake-single-runner.sh"
+    call_log = tmp_path / "calls.tsv"
+    summary = tmp_path / "summary.json"
+    _write_spec(spec)
+    _write_fake_runner(fake_runner, fail_index=fail_index)
+    env = {
+        **os.environ,
+        "SINGLE_REPETITION_RUNNER": str(fake_runner),
+        "CALL_LOG": str(call_log),
+        "CAMPAIGN_SUMMARY_FILE": str(summary),
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [
+            bash_executable(),
+            str(CAMPAIGN_RUNNER),
+            str(spec),
+            "--campaign-prefix",
+            "issue-136-test",
+            "--repetitions",
+            "3",
+            "--cooldown",
+            "0",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_campaign_runner_completes_three_successful_process_repetitions(
+    tmp_path: Path,
+) -> None:
+    result = _run_campaign(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.tsv").read_text(encoding="utf-8").splitlines()
+    assert [line.split("\t")[2:] for line in calls] == [
+        ["1", "0"],
+        ["2", "1"],
+        ["3", "2"],
+    ]
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["schema_version"] == "independent-service-campaign-summary/v1"
+    assert summary["requested_repetitions"] == 3
+    assert summary["successful_repetitions"] == 3
+    assert [run["repeat_index"] for run in summary["runs"]] == [0, 1, 2]
+
+
+def test_campaign_runner_preserves_failure_after_later_success(tmp_path: Path) -> None:
+    result = _run_campaign(tmp_path, fail_index=2)
+
+    assert result.returncode == 19
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["successful_repetitions"] == 2
+    assert [run["status"] for run in summary["runs"]] == [
+        "ok",
+        "failed",
+        "ok",
+    ]
+
+
+def test_formal_campaign_rejects_same_server_measurement_repetitions(
+    tmp_path: Path,
+) -> None:
+    frozen = "a" * 40
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+            "CAMPAIGN_ID": "issue-136/v1",
+            "CAMPAIGN_COVERAGE_CLASS": "full-matrix",
+            "CAMPAIGN_POINT_ROLE": "checkpoint",
+            "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+            "CURRENT_GIT_COMMIT": frozen,
+            "CURRENT_PLUGIN_GIT_COMMIT": frozen,
+            "CURRENT_IMAGE_ID": "b" * 64,
+            "CURRENT_MODEL_REVISION": "c" * 40,
+            "CURRENT_CANN_VERSION": "9.0.0",
+            "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+            "CURRENT_TOPOLOGY": "single-node-hccs",
+            "ASCEND_RT_VISIBLE_DEVICES": "0,1",
+            "ASCEND_VISIBLE_DEVICES": "0,1",
+            "CURRENT_VLLM_HUST_REPO": str(tmp_path / "core"),
+            "CURRENT_VLLM_ASCEND_HUST_REPO": str(tmp_path / "backend"),
+            "PERFGATE_MEASURED_RUNS": "3",
+        },
+    )
+
+    assert result.returncode == 2
+    assert "require PERFGATE_WARMUP_RUNS=0 and PERFGATE_MEASURED_RUNS=1" in (
+        result.stderr
+    )
+
+
+def _init_git_repo(path: Path) -> str:
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    (path / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "initial"], check=True)
+    return subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_formal_campaign_accepts_matching_frozen_repositories(tmp_path: Path) -> None:
+    core = tmp_path / "core"
+    backend = tmp_path / "backend"
+    core_commit = _init_git_repo(core)
+    backend_commit = _init_git_repo(backend)
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+            "CAMPAIGN_ID": "issue-136/v1",
+            "CAMPAIGN_COVERAGE_CLASS": "full-matrix",
+            "CAMPAIGN_POINT_ROLE": "checkpoint",
+            "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+            "CURRENT_GIT_COMMIT": core_commit,
+            "CURRENT_PLUGIN_GIT_COMMIT": backend_commit,
+            "CURRENT_IMAGE_ID": "b" * 64,
+            "CURRENT_MODEL_REVISION": "c" * 40,
+            "CURRENT_CANN_VERSION": "9.0.0",
+            "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+            "CURRENT_TOPOLOGY": "single-node-hccs",
+            "ASCEND_RT_VISIBLE_DEVICES": "0,1",
+            "ASCEND_VISIBLE_DEVICES": "0,1",
+            "CURRENT_VLLM_HUST_REPO": str(core),
+            "CURRENT_VLLM_ASCEND_HUST_REPO": str(backend),
+            "PERFGATE_WARMUP_RUNS": "0",
+            "PERFGATE_MEASURED_RUNS": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["campaign_id"] == "issue-136/v1"
+    assert summary["coverage_class"] == "full-matrix"
+
+
+def test_collector_records_declared_and_observed_worktree_commits(
+    tmp_path: Path,
+) -> None:
+    core = tmp_path / "core"
+    backend = tmp_path / "backend"
+    core_commit = _init_git_repo(core)
+    backend_commit = _init_git_repo(backend)
+    core_worktree = tmp_path / "core-worktree"
+    backend_worktree = tmp_path / "backend-worktree"
+    subprocess.run(
+        ["git", "-C", str(core), "worktree", "add", "-q", str(core_worktree)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(backend), "worktree", "add", "-q", str(backend_worktree)],
+        check=True,
+    )
+    assert (core_worktree / ".git").is_file()
+
+    artifact = tmp_path / "submissions" / "run"
+    artifact.mkdir(parents=True)
+    env = {
+        **os.environ,
+        "CURRENT_RUNTIME_PYTHON": sys.executable,
+        "CURRENT_VLLM_HUST_REPO": str(core_worktree),
+        "CURRENT_VLLM_ASCEND_HUST_REPO": str(backend_worktree),
+        "CURRENT_GIT_COMMIT": core_commit,
+        "CURRENT_PLUGIN_GIT_COMMIT": backend_commit,
+        "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+        "CAMPAIGN_ID": "issue-136/v1",
+        "CAMPAIGN_COVERAGE_CLASS": "full-matrix",
+        "CAMPAIGN_POINT_ROLE": "checkpoint",
+        "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+        "CAMPAIGN_REPEAT_INDEX": "1",
+        "CAMPAIGN_REPETITIONS": "3",
+        "CURRENT_IMAGE_ID": "d" * 64,
+        "CURRENT_MODEL_REVISION": "e" * 40,
+        "CURRENT_CANN_VERSION": "9.0.0",
+        "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+        "CURRENT_TOPOLOGY": "single-node-hccs",
+    }
+    result = subprocess.run(
+        [bash_executable(), str(COLLECTOR), str(artifact)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    manifest = json.loads((artifact / "env-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["manifest_version"] == "run-env-manifest/v2"
+    assert manifest["git_info"]["vllm_hust"] == {
+        "declared": core_commit,
+        "observed": core_commit,
+    }
+    assert manifest["git_info"]["vllm_ascend_hust"] == {
+        "declared": backend_commit,
+        "observed": backend_commit,
+    }
+    assert manifest["campaign"]["repeat_index"] == 1
+    assert manifest["frozen_inputs"]["image_id"] == "d" * 64
+
+
+def test_validator_rejects_missing_environment_manifest_fields(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "STATUS").write_text("OK\n", encoding="utf-8")
+    (artifact / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
+    (artifact / "leaderboard_manifest.json").write_text(
+        json.dumps({"entries": [{"leaderboard_artifact": "run_leaderboard.json"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    (artifact / "env-manifest.json").write_text("{}\n", encoding="utf-8")
+    checksums = subprocess.run(
+        [
+            "sha256sum",
+            "run_leaderboard.json",
+            "leaderboard_manifest.json",
+            "env-manifest.json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=artifact,
+    ).stdout
+    (artifact / "checksums.sha256").write_text(checksums, encoding="utf-8")
+
+    result = subprocess.run(
+        [bash_executable(), str(VALIDATOR), str(artifact)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode > 0
+    assert "missing env-manifest fields: os, python_version, collected_at" in (
+        result.stderr
+    )
+    assert "validation error(s)" in result.stderr

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -371,3 +371,23 @@ def test_validator_rejects_missing_environment_manifest_fields(tmp_path: Path) -
         result.stderr
     )
     assert "validation error(s)" in result.stderr
+
+
+def test_validator_resolves_repo_before_changing_to_artifact_dir(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [bash_executable(), "scripts/validate-run-artifact.sh", str(artifact)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode > 0
+    assert "cd: scripts: No such file or directory" not in result.stderr
+    assert "artifact contract normalization passes" in result.stderr

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -24,7 +24,9 @@ def _write_spec(path: Path, *, chip_count: int = 2) -> None:
     )
 
 
-def _write_fake_runner(path: Path, *, fail_index: int | None = None) -> None:
+def _write_fake_runner(
+    path: Path, *, fail_index: int | None = None, mode: int = 0o755
+) -> None:
     failure = (
         f'if [[ "$3" == "{fail_index}" ]]; then exit 19; fi'
         if fail_index is not None
@@ -38,13 +40,14 @@ printf '%s\\t%s\\t%s\\t%s\\n' "$1" "$2" "$3" "$CAMPAIGN_REPEAT_INDEX" >> "$CALL_
 """,
         encoding="utf-8",
     )
-    path.chmod(0o755)
+    path.chmod(mode)
 
 
 def _run_campaign(
     tmp_path: Path,
     *,
     fail_index: int | None = None,
+    runner_mode: int = 0o755,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     spec = tmp_path / "spec.json"
@@ -52,7 +55,7 @@ def _run_campaign(
     call_log = tmp_path / "calls.tsv"
     summary = tmp_path / "summary.json"
     _write_spec(spec)
-    _write_fake_runner(fake_runner, fail_index=fail_index)
+    _write_fake_runner(fake_runner, fail_index=fail_index, mode=runner_mode)
     env = {
         **os.environ,
         "SINGLE_REPETITION_RUNNER": str(fake_runner),
@@ -112,6 +115,13 @@ def test_campaign_runner_preserves_failure_after_later_success(tmp_path: Path) -
     ]
 
 
+def test_campaign_runner_accepts_readable_non_executable_runner(tmp_path: Path) -> None:
+    result = _run_campaign(tmp_path, runner_mode=0o644)
+
+    assert result.returncode == 0, result.stderr
+    assert len((tmp_path / "calls.tsv").read_text(encoding="utf-8").splitlines()) == 3
+
+
 def test_formal_campaign_rejects_same_server_measurement_repetitions(
     tmp_path: Path,
 ) -> None:
@@ -161,6 +171,117 @@ def _init_git_repo(path: Path) -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
+
+
+def _formal_campaign_env(tmp_path: Path) -> dict[str, str]:
+    core = tmp_path / "core"
+    backend = tmp_path / "backend"
+    core_commit = _init_git_repo(core)
+    backend_commit = _init_git_repo(backend)
+    return {
+        "CAMPAIGN_REQUIRE_FROZEN_INPUTS": "1",
+        "CAMPAIGN_ID": "issue-136/v1",
+        "CAMPAIGN_COVERAGE_CLASS": "full-matrix",
+        "CAMPAIGN_POINT_ROLE": "checkpoint",
+        "CAMPAIGN_LOAD_PROFILE": "fixed-1-rps",
+        "CURRENT_GIT_COMMIT": core_commit,
+        "CURRENT_PLUGIN_GIT_COMMIT": backend_commit,
+        "CURRENT_IMAGE_ID": "b" * 64,
+        "CURRENT_MODEL_REVISION": "c" * 40,
+        "CURRENT_CANN_VERSION": "9.0.0",
+        "CURRENT_TORCH_NPU_VERSION": "2.10.0",
+        "CURRENT_TOPOLOGY": "single-node-hccs",
+        "ASCEND_RT_VISIBLE_DEVICES": "0,1",
+        "ASCEND_VISIBLE_DEVICES": "0,1",
+        "CURRENT_VLLM_HUST_REPO": str(core),
+        "CURRENT_VLLM_ASCEND_HUST_REPO": str(backend),
+        "PERFGATE_WARMUP_RUNS": "0",
+        "PERFGATE_MEASURED_RUNS": "1",
+    }
+
+
+def _write_port_busy_after_first_run_tools(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    (fake_bin / "ss").write_text(
+        """#!/bin/bash
+if [[ "${PORT_BUSY_FROM_START:-0}" == "1" || -s "$CALL_LOG" ]]; then
+  echo "LISTEN 0 4096 0.0.0.0:8001 0.0.0.0:*"
+fi
+""",
+        encoding="utf-8",
+    )
+    (fake_bin / "sleep").write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+    (fake_bin / "ss").chmod(0o755)
+    (fake_bin / "sleep").chmod(0o755)
+    return fake_bin
+
+
+def test_formal_campaign_aborts_when_previous_service_keeps_port(
+    tmp_path: Path,
+) -> None:
+    fake_bin = _write_port_busy_after_first_run_tools(tmp_path)
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            **_formal_campaign_env(tmp_path),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "MAX_PORT_WAIT_SECONDS": "5",
+        },
+    )
+
+    assert result.returncode == 2
+    calls = (tmp_path / "calls.tsv").read_text(encoding="utf-8").splitlines()
+    assert len(calls) == 1
+    assert "refusing to start repetition 2/3 in formal mode" in result.stderr
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "aborted"
+    assert summary["attempted_repetitions"] == 1
+    assert summary["abort_exit_code"] == 2
+    assert "still has listeners" in summary["abort_reason"]
+
+
+def test_formal_campaign_rejects_port_listener_before_first_run(
+    tmp_path: Path,
+) -> None:
+    fake_bin = _write_port_busy_after_first_run_tools(tmp_path)
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            **_formal_campaign_env(tmp_path),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "MAX_PORT_WAIT_SECONDS": "5",
+            "PORT_BUSY_FROM_START": "1",
+        },
+    )
+
+    assert result.returncode == 2
+    assert not (tmp_path / "calls.tsv").exists()
+    assert "refusing to start repetition 1/3 in formal mode" in result.stderr
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "aborted"
+    assert summary["attempted_repetitions"] == 0
+
+
+def test_diagnostic_campaign_warns_and_continues_when_port_stays_busy(
+    tmp_path: Path,
+) -> None:
+    fake_bin = _write_port_busy_after_first_run_tools(tmp_path)
+    result = _run_campaign(
+        tmp_path,
+        extra_env={
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "MAX_PORT_WAIT_SECONDS": "5",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.tsv").read_text(encoding="utf-8").splitlines()
+    assert len(calls) == 3
+    assert result.stderr.count("proceeding in diagnostic mode") == 2
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "ok"
+    assert summary["attempted_repetitions"] == 3
 
 
 def test_formal_campaign_accepts_matching_frozen_repositories(tmp_path: Path) -> None:
@@ -370,6 +491,81 @@ def test_validator_rejects_missing_environment_manifest_fields(tmp_path: Path) -
     assert "missing env-manifest fields: os, python_version, collected_at" in (
         result.stderr
     )
+    assert "validation error(s)" in result.stderr
+
+
+def test_validator_reports_frozen_input_parser_failure_and_continues(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "STATUS").write_text("OK\n", encoding="utf-8")
+    (artifact / "run_leaderboard.json").write_text("{}\n", encoding="utf-8")
+    (artifact / "leaderboard_manifest.json").write_text(
+        json.dumps({"entries": [{"leaderboard_artifact": "run_leaderboard.json"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    (artifact / "env-manifest.json").write_text(
+        json.dumps(
+            {
+                "os": "test",
+                "python_version": "test",
+                "collected_at": "2026-08-03T00:00:00Z",
+                "frozen_inputs_required": True,
+                "frozen_inputs": {
+                    "image_id": "a" * 64,
+                    "model_revision": "b" * 40,
+                    "topology": "single-node-hccs",
+                    "cann": {"declared": "9.0.0", "detected": "9.0.0"},
+                    "torch_npu_version": {
+                        "declared": "2.10.0",
+                        "detected": "2.10.0",
+                    },
+                },
+                "git_info": {
+                    "vllm_hust": {"declared": "c" * 40, "observed": "c" * 40},
+                    "vllm_ascend_hust": {
+                        "declared": "d" * 40,
+                        "observed": "d" * 40,
+                    },
+                },
+                "campaign": {
+                    "campaign_id": "issue-136/v1",
+                    "coverage_class": "full-matrix",
+                    "point_role": "checkpoint",
+                    "load_profile": "fixed-1-rps",
+                    "repetitions": "three",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    checksums = subprocess.run(
+        [
+            "sha256sum",
+            "run_leaderboard.json",
+            "leaderboard_manifest.json",
+            "env-manifest.json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=artifact,
+    ).stdout
+    (artifact / "checksums.sha256").write_text(checksums, encoding="utf-8")
+
+    result = subprocess.run(
+        [bash_executable(), str(VALIDATOR), str(artifact)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode > 0
+    assert "parse-error" in result.stderr
+    assert "checksums.sha256 all pass" in result.stdout
     assert "validation error(s)" in result.stderr
 
 


### PR DESCRIPTION
## Summary

- fix the campaign repetition loop's `set -e` arithmetic bug so a first successful or failed repetition no longer terminates the wrapper early
- add an opt-in strict formal-campaign gate for full commits, immutable image/model identity, runtime/topology metadata, explicit device cardinality, valid trend roles, and at least three independent service processes
- reject `PERFGATE_MEASURED_RUNS>1` in strict mode so repeated client measurements against one live server cannot be mislabeled as independent services
- emit a machine-readable campaign summary with every attempted repetition and preserve the first failure status
- upgrade `env-manifest.json` to v2 with declared/observed core and backend commits, CANN/torch-npu detection, frozen inputs, campaign identity, role, load profile, and repeat index
- make artifact validation fail closed on missing or mismatched formal provenance and continue reporting all validation errors
- document the Dense 1/2/4, MoE/EPLB/LatchMoE, profiler, and publication gates for #136

## Why

Issue #136 requires three independent services per cell, matched frozen stacks, explicit comparison roles, raw repetitions, environment manifests, and profiler separation. The existing wrapper reused the right lower-level service runner, but its first `SUCCESS_COUNT++`/`FAIL_COUNT++` could exit under `set -e`, and it did not prevent incomplete provenance or same-server repetitions from entering a formal campaign.

This PR prepares the evidence path only. It does not publish benchmark percentages or treat the existing readiness artifacts as current-main performance data.

Refs #136.

## Validation

- `uv run --extra test python -m pytest -q tests`: **549 passed**
- Ruff 0.15.2 check and format check: passed
- repository pre-commit hooks on all changed files: passed
- `bash -n` on the three changed shell scripts: passed
- `git diff --check`: passed

## Remaining campaign gates

- merge and freeze the selected vLLM-HUST/vLLM-Ascend-HUST commit pair
- select the final image and immutable model revision
- complete the same-stack Dense capacity pilots and 1/2/4-card fixed/scaled-load matrix
- run the EPLB disabled/enabled matched series and separate profiler cells
- retain LatchMoE as blocked until its runtime readiness gate passes, or run its matched series once ready
