### PR TITLE
bench: emit strict comparison rerun queue

### DIFF
--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -77,7 +77,7 @@ jobs:
       - self-hosted
       - ARM64
       - docker
-      - debug
+      - ascend-benchmark
     timeout-minutes: 360
     env:
       BENCHMARK_CHECKOUT_USE_SSH: ${{ secrets.VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY != '' && '1' || '0' }}

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -116,16 +116,18 @@ jobs:
           mkdir -p "$HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
           mkdir -p "$GITHUB_WORKSPACE/artifacts/official-baseline"
 
-      - name: Require GitHub SSH checkout key
+      - name: Select GitHub checkout transport
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" != "1" ]]; then
-            echo "VLLM_ASCEND_HUST_BENCHMARK_SSH_KEY is required because this workflow checks out repositories over SSH." >&2
-            exit 1
+          if [[ "$BENCHMARK_CHECKOUT_USE_SSH" == "1" ]]; then
+            echo "Using the configured SSH key for GitHub checkouts."
+          else
+            echo "SSH key is not configured; using HTTPS for read-only public checkouts."
           fi
 
       - name: Configure GitHub SSH
+        if: ${{ env.BENCHMARK_CHECKOUT_USE_SSH == '1' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/containers/strict-current-main/Dockerfile
+++ b/containers/strict-current-main/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/ascend/vllm-ascend:v0.21.0rc1-openeuler
+
+RUN /usr/local/python3.12.13/bin/python -m pip install --no-cache-dir xxhash==3.6.0

--- a/reports/leaderboard_comparison_gap_audit_20260803.json
+++ b/reports/leaderboard_comparison_gap_audit_20260803.json
@@ -1,0 +1,564 @@
+{
+  "schema_version": "leaderboard-comparison-gap-audit/v1",
+  "generated_at": "2026-08-02T23:53:21.577194Z",
+  "registry": {
+    "version": "1.0.0",
+    "sha256": "2073283467797cbe4a74682249b4e40c7c5ded4ebd393392161e038dd9bdb94c"
+  },
+  "policy": {
+    "excluded_workloads": [
+      "burstgpt-production-replay",
+      "tracelab-coding-agent-replay"
+    ],
+    "minimum_successful_repeats": 3,
+    "require_verified": true,
+    "require_exact_resolved_spec_hash": true,
+    "require_current_heads": true,
+    "require_runtime_environment": [
+      "cann_version",
+      "driver_version",
+      "pytorch_version"
+    ],
+    "require_measured_peak_memory": true
+  },
+  "current_heads": {
+    "vllm_hust": "f229ba7cad21a4dba58681af6738a9fd947388e2",
+    "vllm_ascend_hust": "cafad89a5e103f31ea517c1edb56130578c3cd56"
+  },
+  "summary": {
+    "target_count": 9,
+    "ready_pair_count": 0,
+    "rerun_target_count": 9,
+    "rerun_job_count": 18
+  },
+  "records": [
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "agent-research-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": null,
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "instructcoder-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "b6bfc226-4d0c-4305-a840-9d2724d78c09",
+        "submitted_at": "2026-07-26T16:01:55Z",
+        "git_commit": "6f612fbedff718af2dabb93692f00044e66a9b4b",
+        "resolved_spec_hash": "651db3189c7fa28ed648ae1865aa8007713e3efd1289543a0bd99273bffb917c",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "prefix-repetition-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "6cfaf763-7c0a-4309-bf9b-06056b99366e",
+        "submitted_at": "2026-07-26T08:01:54Z",
+        "git_commit": "e4ce33646f2ef1781289e6dc651fad0d00177c55",
+        "resolved_spec_hash": "cc71667b7c3de8614f22a4296a9b7bc1ca67a398550289150a8d15ec01507415",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "client_parameters.port:mismatch:8020!=8000",
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "reproducible-command-missing",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "server_parameters.port:mismatch:8020!=8000",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "random-latency",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "cae79867-3a2c-4a9d-9b90-7aae937454d1",
+        "submitted_at": "2026-07-26T23:33:41Z",
+        "git_commit": "f273f9c5e2669b6e8aeee61823c895e2399cf609",
+        "resolved_spec_hash": "4372b8fbe4a69db9e6fc5461aba0345133fc2d9c21fb33be0576d729ce9eca7d",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "random-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "c40f5805-bf3c-46d9-ab5f-b86ffca786b5",
+        "submitted_at": "2026-07-26T22:04:03Z",
+        "git_commit": "e0c0ce8e37e0fcd0f7a133c5c8eee68110295445",
+        "resolved_spec_hash": "806e24f4413cbfdeb06ebcce643ce31e645fe74bffbcbb48f77736ec4fcd0152",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "sharegpt-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "1cdeb182-fa80-481a-9de6-ff33fe883a3a",
+        "submitted_at": "2026-07-26T22:26:42Z",
+        "git_commit": "e0c0ce8e37e0fcd0f7a133c5c8eee68110295445",
+        "resolved_spec_hash": "1d37c9d71656c4164da97087fa6db74fa806f25bd84a916192239769f0d8dbd1",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "sharegpt-throughput",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "a1f75382-967f-4f77-b80e-86ddce8c4808",
+        "submitted_at": "2026-07-26T23:51:42Z",
+        "git_commit": "f273f9c5e2669b6e8aeee61823c895e2399cf609",
+        "resolved_spec_hash": "27d3c9c28d82f391744cd893644defd2dd0491b7b51b7b506561dc7fd7a81476",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
+      "target_version": "1.0.0",
+      "workload": "sonnet-throughput",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": {
+        "entry_id": "45a1ad9a-c335-41b5-a1e0-a1f20f64467b",
+        "submitted_at": "2026-07-27T00:06:32Z",
+        "git_commit": "f273f9c5e2669b6e8aeee61823c895e2399cf609",
+        "resolved_spec_hash": "0c6403549e077ff38864c362b898b0ea500938bc4f7fda4d0076ad3b1320af87",
+        "successful_repeats": 0,
+        "eligible": false,
+        "reasons": [
+          "current-core-head-stale",
+          "current-plugin-head-stale",
+          "peak-memory-unmeasured",
+          "runtime-environment.cann_version:missing",
+          "runtime-environment.driver_version:missing",
+          "runtime-environment.pytorch_version:missing",
+          "target-binding-missing-or-mismatched",
+          "target-version-missing-or-mismatched",
+          "three-successful-repeats-missing",
+          "verified-attestation-missing"
+        ]
+      },
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
+      "target_version": "1.0.0",
+      "workload": "visionarena-online",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json",
+      "status": "rerun-required",
+      "hash_match": false,
+      "baseline": null,
+      "current": null,
+      "required_sides": [
+        "vllm",
+        "vllm-hust"
+      ]
+    }
+  ],
+  "rerun_queue": [
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
+      "workload": "agent-research-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
+      "workload": "agent-research-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
+      "workload": "instructcoder-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
+      "workload": "instructcoder-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-instructcoder-online-qwen25-coder-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
+      "workload": "prefix-repetition-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
+      "workload": "prefix-repetition-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "client_parameters.port:mismatch:8020!=8000",
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "reproducible-command-missing",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "server_parameters.port:mismatch:8020!=8000",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
+      "workload": "random-latency",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
+      "workload": "random-latency",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-latency-qwen25-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+      "workload": "random-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
+      "workload": "random-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
+      "workload": "sharegpt-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
+      "workload": "sharegpt-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
+      "workload": "sharegpt-throughput",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
+      "workload": "sharegpt-throughput",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-throughput-qwen25-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
+      "workload": "sonnet-throughput",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
+      "workload": "sonnet-throughput",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sonnet-throughput-qwen25-14b-910b2.json",
+      "reasons": [
+        "current-core-head-stale",
+        "current-plugin-head-stale",
+        "peak-memory-unmeasured",
+        "runtime-environment.cann_version:missing",
+        "runtime-environment.driver_version:missing",
+        "runtime-environment.pytorch_version:missing",
+        "target-binding-missing-or-mismatched",
+        "target-version-missing-or-mismatched",
+        "three-successful-repeats-missing",
+        "verified-attestation-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
+      "workload": "visionarena-online",
+      "engine": "vllm",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    },
+    {
+      "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
+      "workload": "visionarena-online",
+      "engine": "vllm-hust",
+      "source_spec": "docs/official-baselines/official-ascend-jan-2026-v0180-visionarena-online-qwen25-vl-7b-910b2.json",
+      "reasons": [
+        "entry-missing"
+      ],
+      "repeat_count": 3,
+      "min_successful_repeats": 3
+    }
+  ]
+}

--- a/schemas/leaderboard_comparison_gap_audit_v1.schema.json
+++ b/schemas/leaderboard_comparison_gap_audit_v1.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vllm-hust.sage.org.ai/schemas/leaderboard_comparison_gap_audit_v1.schema.json",
+  "title": "Leaderboard strict comparison gap audit",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "registry",
+    "policy",
+    "current_heads",
+    "summary",
+    "records",
+    "rerun_queue"
+  ],
+  "properties": {
+    "schema_version": {"const": "leaderboard-comparison-gap-audit/v1"},
+    "generated_at": {"type": "string"},
+    "registry": {
+      "type": "object",
+      "required": ["version", "sha256"]
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "excluded_workloads",
+        "minimum_successful_repeats",
+        "require_verified",
+        "require_exact_resolved_spec_hash",
+        "require_current_heads",
+        "require_runtime_environment",
+        "require_measured_peak_memory"
+      ],
+      "properties": {
+        "excluded_workloads": {
+          "type": "array",
+          "const": [
+            "burstgpt-production-replay",
+            "tracelab-coding-agent-replay"
+          ]
+        },
+        "minimum_successful_repeats": {"const": 3},
+        "require_verified": {"const": true},
+        "require_exact_resolved_spec_hash": {"const": true},
+        "require_current_heads": {"type": "boolean"},
+        "require_runtime_environment": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "require_measured_peak_memory": {"const": true}
+      }
+    },
+    "current_heads": {
+      "type": "object",
+      "required": ["vllm_hust", "vllm_ascend_hust"]
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "target_count",
+        "ready_pair_count",
+        "rerun_target_count",
+        "rerun_job_count"
+      ]
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "target_id",
+          "target_version",
+          "workload",
+          "source_spec",
+          "status",
+          "hash_match",
+          "baseline",
+          "current",
+          "required_sides"
+        ],
+        "properties": {
+          "status": {"enum": ["ready", "rerun-required"]},
+          "required_sides": {
+            "type": "array",
+            "items": {"enum": ["vllm", "vllm-hust"]},
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "rerun_queue": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "target_id",
+          "workload",
+          "engine",
+          "source_spec",
+          "reasons",
+          "repeat_count",
+          "min_successful_repeats"
+        ],
+        "properties": {
+          "engine": {"enum": ["vllm", "vllm-hust"]},
+          "repeat_count": {"const": 3},
+          "min_successful_repeats": {"const": 3}
+        }
+      }
+    }
+  }
+}

--- a/scripts/audit_leaderboard_comparison_gaps.py
+++ b/scripts/audit_leaderboard_comparison_gaps.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from vllm_hust_benchmark.comparison_gap_audit import build_comparison_gap_audit
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--current-core-head")
+    parser.add_argument("--current-plugin-head")
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help="Return 2 unless every in-scope target has a strict matched pair.",
+    )
+    args = parser.parse_args()
+    report = build_comparison_gap_audit(
+        args.repo_root.resolve(),
+        current_core_head=args.current_core_head,
+        current_plugin_head=args.current_plugin_head,
+    )
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    summary = report["summary"]
+    print(
+        "comparison gap audit: "
+        f"targets={summary['target_count']} "
+        f"ready={summary['ready_pair_count']} "
+        f"rerun_targets={summary['rerun_target_count']} "
+        f"rerun_jobs={summary['rerun_job_count']}",
+        file=sys.stderr,
+    )
+    if args.require_complete and summary["ready_pair_count"] != summary["target_count"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -44,7 +44,7 @@ TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE:-"$HF_HOME/transformers"}
 export HF_HOME HF_HUB_CACHE TRANSFORMERS_CACHE
 CURRENT_MODEL_PATH=${CURRENT_MODEL_PATH:-}
 CURRENT_SERVER_HOST=${CURRENT_SERVER_HOST:-}
-CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-"8001"}
+CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-}
 CURRENT_CLIENT_HOST=${CURRENT_CLIENT_HOST:-}
 CURRENT_CLIENT_PORT=${CURRENT_CLIENT_PORT:-$CURRENT_SERVER_PORT}
 CURRENT_USE_MANAGED_SERVER=${CURRENT_USE_MANAGED_SERVER:-0}
@@ -759,10 +759,12 @@ resolve_same_spec() {
   fi
 
   if [[ "$BENCHMARK_TYPE" == "serve" ]]; then
-    resolve_args+=(
-      --server-port "$CURRENT_SERVER_PORT"
-      --client-port "$CURRENT_CLIENT_PORT"
-    )
+    if [[ -n "$CURRENT_SERVER_PORT" ]]; then
+      resolve_args+=(--server-port "$CURRENT_SERVER_PORT")
+    fi
+    if [[ -n "$CURRENT_CLIENT_PORT" ]]; then
+      resolve_args+=(--client-port "$CURRENT_CLIENT_PORT")
+    fi
 
     if [[ -n "$CURRENT_SERVER_HOST" ]]; then
       resolve_args+=(--server-host "$CURRENT_SERVER_HOST")

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -775,6 +775,26 @@ resolve_same_spec() {
   run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" "${resolve_args[@]}"
 }
 
+verify_current_runtime_requirements() {
+  run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" - <<'PY'
+import importlib
+
+required_modules = ("xxhash",)
+missing = []
+for module_name in required_modules:
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        missing.append(module_name)
+
+if missing:
+    raise SystemExit(
+        "current runtime is missing required module(s): " + ", ".join(missing)
+    )
+PY
+}
+
 resolve_scenario_benchmark_type() {
   run_in_current_runtime "$REPO_ROOT/src${CURRENT_RUNTIME_PYTHONPATH:+:$CURRENT_RUNTIME_PYTHONPATH}" \
     env SCENARIO_NAME="$SCENARIO" \
@@ -1036,9 +1056,9 @@ stop_peak_hbm_sampler() {
 }
 
 start_peak_hbm_sampler() {
-  local device_scope=${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}
+  local device_scope=${ASCEND_HBM_PHYSICAL_DEVICES:-${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}}
   if [[ -z "$device_scope" ]]; then
-    echo "Explicit ASCEND_RT_VISIBLE_DEVICES or ASCEND_VISIBLE_DEVICES is required for peak HBM evidence" >&2
+    echo "Explicit ASCEND_HBM_PHYSICAL_DEVICES, ASCEND_RT_VISIBLE_DEVICES, or ASCEND_VISIBLE_DEVICES is required for peak HBM evidence" >&2
     exit 2
   fi
   PEAK_HBM_EVIDENCE_FILE="$RESULT_DIR/peak_hbm_evidence.json"
@@ -1121,6 +1141,7 @@ if cached_model_path=$(resolve_runtime_model); then
 fi
 
 SAME_SPEC_FILE="$RESULT_DIR/resolved_same_spec.json"
+verify_current_runtime_requirements
 resolve_same_spec
 start_peak_hbm_sampler
 

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -92,6 +92,8 @@ READY_PROBE_TIMEOUT_SECONDS=${READY_PROBE_TIMEOUT_SECONDS:-5}
 NPU_OOM_EXIT_CODE=87
 SERVER_PID=""
 RUNNER_LOCK_FD=""
+PEAK_HBM_SAMPLER_PID=""
+PEAK_HBM_EVIDENCE_FILE=""
 
 if [[ "$CURRENT_USE_MANAGED_SERVER" == "1" ]]; then
   CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_HUST_REPO"
@@ -1025,7 +1027,28 @@ run_client_command_with_server_monitor() {
   return "$client_status"
 }
 
+stop_peak_hbm_sampler() {
+  if [[ -n "${PEAK_HBM_SAMPLER_PID:-}" ]]; then
+    kill -TERM "$PEAK_HBM_SAMPLER_PID" >/dev/null 2>&1 || true
+    wait "$PEAK_HBM_SAMPLER_PID" >/dev/null 2>&1 || true
+    PEAK_HBM_SAMPLER_PID=""
+  fi
+}
+
+start_peak_hbm_sampler() {
+  local device_scope=${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}
+  if [[ -z "$device_scope" ]]; then
+    echo "Explicit ASCEND_RT_VISIBLE_DEVICES or ASCEND_VISIBLE_DEVICES is required for peak HBM evidence" >&2
+    exit 2
+  fi
+  PEAK_HBM_EVIDENCE_FILE="$RESULT_DIR/peak_hbm_evidence.json"
+  python3 "$REPO_ROOT/scripts/sample_ascend_peak_hbm.py" \
+    --devices "$device_scope" --output "$PEAK_HBM_EVIDENCE_FILE" &
+  PEAK_HBM_SAMPLER_PID=$!
+}
+
 kill_server() {
+  stop_peak_hbm_sampler
   cleanup_managed_server || true
 }
 
@@ -1099,6 +1122,7 @@ fi
 
 SAME_SPEC_FILE="$RESULT_DIR/resolved_same_spec.json"
 resolve_same_spec
+start_peak_hbm_sampler
 
 resolved_dataset_path=$(jq -r '.resolved_client_parameters.dataset_path // empty' "$SAME_SPEC_FILE")
 ensure_runtime_dataset_available "$resolved_dataset_path"
@@ -1242,6 +1266,16 @@ if [[ "$BENCHMARK_TYPE" != "serve" ]]; then
   fi
 fi
 
+stop_peak_hbm_sampler
+if [[ ! -f "$PEAK_HBM_EVIDENCE_FILE" ]] || ! jq -e \
+  '.sample_count > 0 and .peak_hbm_mb > 0' "$PEAK_HBM_EVIDENCE_FILE" >/dev/null; then
+  echo "Peak HBM sampling did not produce valid evidence" >&2
+  exit 2
+fi
+PEAK_HBM_MB=$(jq -r '.peak_hbm_mb' "$PEAK_HBM_EVIDENCE_FILE")
+SPEC_REPRO_PATH=$(realpath --relative-to="$REPO_ROOT" "$SPEC_FILE")
+printf -v REPRODUCIBLE_CMD 'bash scripts/run-current-ascend-same-spec.sh %q' "$SPEC_REPRO_PATH"
+
 EXPORT_ARGS=(
   "$SCENARIO"
   --benchmark-result-file "$RAW_RESULT_FILE"
@@ -1267,6 +1301,8 @@ EXPORT_ARGS=(
   --git-commit "$CURRENT_GIT_COMMIT"
   --github-repository "$CURRENT_GITHUB_REPOSITORY"
   --github-ref "$CURRENT_GITHUB_REF"
+  --peak-mem-mb "$PEAK_HBM_MB"
+  --reproducible-cmd "$REPRODUCIBLE_CMD"
   --runtime-python "$CURRENT_RUNTIME_PYTHON"
   --engine-source-repository "$CURRENT_GITHUB_REPOSITORY"
   --engine-source-ref "$CURRENT_GITHUB_REF"

--- a/scripts/run-official-ascend-goal-baseline-matrix.sh
+++ b/scripts/run-official-ascend-goal-baseline-matrix.sh
@@ -22,6 +22,7 @@ FORCE_RUN_EXISTING=${FORCE_RUN_EXISTING:-0}
 REPEAT_COUNT=${REPEAT_COUNT:-3}
 MIN_SUCCESSFUL_REPEATS=${MIN_SUCCESSFUL_REPEATS:-}
 MAX_REPEAT_ATTEMPTS=${MAX_REPEAT_ATTEMPTS:-}
+STRICT_CANONICAL_ATTESTATION=${STRICT_CANONICAL_ATTESTATION:-1}
 PREPARE_OFFICIAL_ENV=${PREPARE_OFFICIAL_ENV:-1}
 READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-900}
 SUMMARY_FILE=${MATRIX_SUMMARY_FILE:-"$MATRIX_RESULT_ROOT/summary.md"}
@@ -49,6 +50,8 @@ Behavior:
   - Repeats missing-canonical specs REPEAT_COUNT times (default: 3)
   - Allows bounded repeat failures and still selects a canonical candidate when enough successful repeats exist
   - Chooses the repeat whose primary metric is closest to the median run and promotes only that candidate into canonical submissions/<spec-id>/
+  - Requires three machine-attested repeats before canonical promotion by default
+  - Set STRICT_CANONICAL_ATTESTATION=0 only for non-public legacy/test workflows
   - Set FORCE_RUN_EXISTING=1 to run specs even when a canonical submission already exists
     Existing canonical submissions are preserved and the new run is left in .benchmarks/ for manual review
   - Set PUBLISH_WEBSITE=1 to rebuild website data from the full submissions/ tree after the batch
@@ -202,6 +205,35 @@ promote_submission_to_canonical() {
   mkdir -p "$(dirname "$canonical_dir")"
   cp -a "$submission_dir" "$canonical_dir"
   echo "[official-baseline-matrix] promoted canonical submission: $spec_id -> $canonical_dir"
+}
+
+attest_promoted_submission() {
+  local canonical_dir=$1
+  local spec_file=$2
+  local selected_result_dir=$3
+  local primary_metric_name=$4
+  shift 4
+  PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' \
+    "$canonical_dir" "$spec_file" "$selected_result_dir" "$primary_metric_name" "$@"
+from pathlib import Path
+import sys
+
+from vllm_hust_benchmark.official_baselines import attest_canonical_submission
+from vllm_hust_benchmark.official_baselines import load_official_baseline_spec
+
+canonical_dir = Path(sys.argv[1])
+spec_file = Path(sys.argv[2])
+selected_result_dir = Path(sys.argv[3])
+primary_metric_name = sys.argv[4]
+result_dirs = [Path(item) for item in sys.argv[5:]]
+attest_canonical_submission(
+    canonical_dir,
+    spec=load_official_baseline_spec(spec_file),
+    result_dirs=result_dirs,
+    selected_result_dir=selected_result_dir,
+    primary_metric_name=primary_metric_name,
+)
+PY
 }
 
 append_summary() {
@@ -528,6 +560,13 @@ for spec_file in "${SPEC_FILES[@]}"; do
     append_summary "  - Proceeding with degraded sample count for $spec_id: ${successful_repeat_count}/${target_successful_repeats} successful repeat(s), failures=${repeat_failure_count}"
   fi
 
+  if [[ "$should_promote" == "1" ]] \
+    && [[ "$STRICT_CANONICAL_ATTESTATION" == "1" ]] \
+    && (( successful_repeat_count < 3 )); then
+    record_failed_spec "$spec_id" "strict canonical attestation requires three successful repeats"
+    continue
+  fi
+
   selection_error_log="$MATRIX_RESULT_ROOT/$spec_slug/candidate-selection.stderr.log"
   set +e
   selection_json=$(select_canonical_candidate "$benchmark_type" "${repeat_result_dirs[@]}" 2>"$selection_error_log")
@@ -549,6 +588,14 @@ for spec_file in "${SPEC_FILES[@]}"; do
 
   if [[ "$should_promote" == "1" ]]; then
     promote_submission_to_canonical "$selected_result_dir" "$canonical_dir" "$spec_id"
+    if [[ "$STRICT_CANONICAL_ATTESTATION" == "1" ]]; then
+      attest_promoted_submission \
+        "$canonical_dir" \
+        "$spec_file" \
+        "$selected_result_dir" \
+        "$primary_metric_name" \
+        "${repeat_result_dirs[@]}"
+    fi
     append_summary "  - Selected canonical candidate: $selected_result_dir"
     ((PROMOTED_COUNT+=1))
 

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -1518,7 +1518,7 @@ stop_peak_hbm_sampler() {
 }
 
 start_peak_hbm_sampler() {
-  local device_scope=${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}
+  local device_scope=${ASCEND_HBM_PHYSICAL_DEVICES:-${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}}
   stop_peak_hbm_sampler
   if [[ -z "$device_scope" ]]; then
     echo "Explicit Ascend device scope is required for peak HBM evidence" >&2

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -49,6 +49,8 @@ NPU_SMI_TIMEOUT_SECONDS=${NPU_SMI_TIMEOUT_SECONDS:-20}
 GOAL_BASELINE_DEVICE_PREFERENCE_FILE=${GOAL_BASELINE_DEVICE_PREFERENCE_FILE:-}
 SERVER_PID=""
 RUNNER_LOCK_FD=""
+PEAK_HBM_SAMPLER_PID=""
+PEAK_HBM_EVIDENCE_FILE=""
 
 if [[ -z "$GOAL_BASELINE_ENV_PREFIX" ]]; then
   echo "GOAL_BASELINE_ENV_PREFIX is required" >&2
@@ -1507,7 +1509,29 @@ wait_for_single_card_ascend_device() {
   return "$selection_status"
 }
 
+stop_peak_hbm_sampler() {
+  if [[ -n "${PEAK_HBM_SAMPLER_PID:-}" ]]; then
+    kill -TERM "$PEAK_HBM_SAMPLER_PID" >/dev/null 2>&1 || true
+    wait "$PEAK_HBM_SAMPLER_PID" >/dev/null 2>&1 || true
+    PEAK_HBM_SAMPLER_PID=""
+  fi
+}
+
+start_peak_hbm_sampler() {
+  local device_scope=${ASCEND_RT_VISIBLE_DEVICES:-${ASCEND_VISIBLE_DEVICES:-}}
+  stop_peak_hbm_sampler
+  if [[ -z "$device_scope" ]]; then
+    echo "Explicit Ascend device scope is required for peak HBM evidence" >&2
+    exit 2
+  fi
+  PEAK_HBM_EVIDENCE_FILE="$RESULT_DIR/peak_hbm_evidence.json"
+  "$HOST_PYTHON_BIN" "$REPO_ROOT/scripts/sample_ascend_peak_hbm.py" \
+    --devices "$device_scope" --output "$PEAK_HBM_EVIDENCE_FILE" &
+  PEAK_HBM_SAMPLER_PID=$!
+}
+
 kill_server() {
+  stop_peak_hbm_sampler
   cleanup_managed_server || true
 }
 
@@ -1679,6 +1703,7 @@ case "$BENCHMARK_TYPE" in
       fi
 
       echo "[goal-baseline] Ascend visible devices: ${ASCEND_VISIBLE_DEVICES:-<unset>} (rt=${ASCEND_RT_VISIBLE_DEVICES:-<unset>})"
+      start_peak_hbm_sampler
 
       if wait_for_ascend_runtime_ready; then
         runtime_ready_status=0
@@ -1724,6 +1749,9 @@ case "$BENCHMARK_TYPE" in
     fi
     ;;
   throughput|latency)
+    wait_for_single_card_ascend_device
+    echo "[goal-baseline] Ascend visible devices: ${ASCEND_VISIBLE_DEVICES:-<unset>} (rt=${ASCEND_RT_VISIBLE_DEVICES:-<unset>})"
+    start_peak_hbm_sampler
     CLIENT_COMMAND="VLLM_VERSION=$OFFICIAL_CORE_VERSION PYTHONPATH=$OFFICIAL_RUNTIME_PYTHONPATH\${PYTHONPATH:+:\$PYTHONPATH} $OFFICIAL_RUNTIME_PYTHON $VLLM_CLI_COMPAT bench $BENCHMARK_TYPE --output-json $RAW_RESULT_FILE $CLIENT_ARGS"
     ;;
   *)
@@ -1734,6 +1762,15 @@ esac
 
 echo "[goal-baseline] client command: $CLIENT_COMMAND"
 run_client_command
+stop_peak_hbm_sampler
+if [[ ! -f "$PEAK_HBM_EVIDENCE_FILE" ]] || ! jq -e \
+  '.sample_count > 0 and .peak_hbm_mb > 0' "$PEAK_HBM_EVIDENCE_FILE" >/dev/null; then
+  echo "Peak HBM sampling did not produce valid evidence" >&2
+  exit 2
+fi
+PEAK_HBM_MB=$(jq -r '.peak_hbm_mb' "$PEAK_HBM_EVIDENCE_FILE")
+SPEC_REPRO_PATH=$(realpath --relative-to="$REPO_ROOT" "$SPEC_FILE")
+printf -v REPRODUCIBLE_CMD 'GOAL_BASELINE_ENV_PREFIX=<env-prefix> bash scripts/run-official-ascend-goal-baseline.sh %q' "$SPEC_REPRO_PATH"
 
 EXPORT_ARGS=(
   python -m vllm_hust_benchmark.cli export-leaderboard-artifact
@@ -1761,6 +1798,9 @@ EXPORT_ARGS=(
   --git-commit "$GIT_COMMIT"
   --github-repository "$GITHUB_REPOSITORY"
   --github-ref "$GITHUB_REF"
+  --peak-mem-mb "$PEAK_HBM_MB"
+  --reproducible-cmd "$REPRODUCIBLE_CMD"
+  --runtime-python "$OFFICIAL_RUNTIME_PYTHON"
   --engine-source-repository "$OFFICIAL_CORE_SOURCE_REPOSITORY"
   --engine-source-ref "$OFFICIAL_CORE_SOURCE_REF"
   --engine-source-commit "$OFFICIAL_CORE_SOURCE_COMMIT"

--- a/scripts/sample_ascend_peak_hbm.py
+++ b/scripts/sample_ascend_peak_hbm.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Sample peak HBM usage for an explicitly scoped set of Ascend devices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEVICE_ROW = re.compile(r"^\|\s*(\d+)\s+\S+\s+\|")
+HBM_CELL = re.compile(r"(\d+)\s*/\s*(\d+)")
+
+
+def parse_hbm_usage(output: str) -> dict[int, tuple[int, int]]:
+    """Return physical NPU id -> (used MiB, capacity MiB)."""
+    lines = output.splitlines()
+    parsed: dict[int, tuple[int, int]] = {}
+    for index, line in enumerate(lines[:-1]):
+        match = DEVICE_ROW.match(line)
+        if not match:
+            continue
+        cells = lines[index + 1].split("|")
+        if len(cells) < 3:
+            continue
+        hbm_matches = HBM_CELL.findall(cells[-2])
+        if hbm_matches:
+            used, capacity = hbm_matches[-1]
+            parsed[int(match.group(1))] = (
+                int(used),
+                int(capacity),
+            )
+    return parsed
+
+
+def _device_scope(value: str | None) -> list[int]:
+    raw = value or os.environ.get("ASCEND_RT_VISIBLE_DEVICES") or os.environ.get(
+        "ASCEND_VISIBLE_DEVICES"
+    )
+    if not raw:
+        raise ValueError(
+            "an explicit --devices, ASCEND_RT_VISIBLE_DEVICES, or "
+            "ASCEND_VISIBLE_DEVICES scope is required"
+        )
+    devices = [int(item.strip()) for item in raw.split(",") if item.strip()]
+    if not devices or len(devices) != len(set(devices)):
+        raise ValueError(f"invalid Ascend device scope: {raw}")
+    return devices
+
+
+def _write_summary(
+    output_path: Path,
+    *,
+    devices: list[int],
+    per_device_peak: dict[int, int],
+    capacities: dict[int, int],
+    samples: int,
+    failures: int,
+) -> None:
+    payload = {
+        "schema_version": "ascend-peak-hbm-evidence/v1",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": "npu-smi info",
+        "devices": devices,
+        "sample_count": samples,
+        "sample_failure_count": failures,
+        "peak_hbm_mb": sum(per_device_peak.values()),
+        "per_device_peak_hbm_mb": {
+            str(device): per_device_peak.get(device, 0) for device in devices
+        },
+        "per_device_capacity_mb": {
+            str(device): capacities.get(device) for device in devices
+        },
+    }
+    temporary = output_path.with_suffix(output_path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(output_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--devices")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--interval-seconds", type=float, default=1.0)
+    parser.add_argument("--npu-smi", default="npu-smi")
+    args = parser.parse_args()
+    if args.interval_seconds <= 0:
+        parser.error("--interval-seconds must be positive")
+    try:
+        devices = _device_scope(args.devices)
+    except ValueError as error:
+        parser.error(str(error))
+
+    stop = False
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    per_device_peak = {device: 0 for device in devices}
+    capacities: dict[int, int] = {}
+    samples = 0
+    failures = 0
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    while not stop:
+        try:
+            result = subprocess.run(
+                [args.npu_smi, "info"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            usage = parse_hbm_usage(result.stdout)
+            if any(device not in usage for device in devices):
+                raise RuntimeError("npu-smi output omitted a scoped device")
+            for device in devices:
+                used, capacity = usage[device]
+                per_device_peak[device] = max(per_device_peak[device], used)
+                capacities[device] = capacity
+            samples += 1
+        except (OSError, subprocess.SubprocessError, RuntimeError):
+            failures += 1
+        _write_summary(
+            args.output,
+            devices=devices,
+            per_device_peak=per_device_peak,
+            capacities=capacities,
+            samples=samples,
+            failures=failures,
+        )
+        if not stop:
+            time.sleep(args.interval_seconds)
+    return 0 if samples else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_public_leaderboard_snapshots.py
+++ b/scripts/validate_public_leaderboard_snapshots.py
@@ -57,6 +57,7 @@ REJECTED_SUPERSEDED_REPORT_REQUIRED_FIELDS = (
     "excluded_plugin_commits",
 )
 REJECTED_SUPERSEDED_REPORT_SCHEMA_VERSION = "rejected-superseded-report/v1"
+COMPARE_SNAPSHOT_FILE = "leaderboard_compare.json"
 
 
 def parse_args() -> argparse.Namespace:
@@ -294,10 +295,87 @@ def validate_rejected_superseded_report(snapshot_dir: Path) -> list[str]:
     return errors
 
 
+def validate_compare_snapshot(
+    snapshot_dir: Path,
+    entries_by_id: dict[str, dict[str, Any]],
+) -> list[str]:
+    errors: list[str] = []
+    path = snapshot_dir / COMPARE_SNAPSHOT_FILE
+    if not path.is_file():
+        return [f"missing compare snapshot: {path}"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"invalid JSON in {path}: {exc}"]
+    if not isinstance(payload, dict):
+        return [f"{path}: compare snapshot payload must be a JSON object"]
+
+    pairs = payload.get("preferred_pairs")
+    if not isinstance(pairs, list):
+        return [f"{path.name}: preferred_pairs must be an array"]
+    declared_count = payload.get("preferred_pair_count")
+    if declared_count != len(pairs):
+        errors.append(
+            f"{path.name}: preferred_pair_count={declared_count!r} does not match "
+            f"preferred_pairs length={len(pairs)}"
+        )
+
+    for index, item in enumerate(pairs):
+        pair = item.get("preferred_pair") if isinstance(item, dict) else None
+        if not isinstance(pair, dict):
+            errors.append(f"{path.name}: preferred_pairs[{index}] missing preferred_pair")
+            continue
+        summaries: dict[str, dict[str, Any]] = {}
+        for side in ("left", "right"):
+            summary = pair.get(side)
+            if not isinstance(summary, dict):
+                errors.append(
+                    f"{path.name}: preferred_pairs[{index}].preferred_pair.{side} "
+                    "must be an object"
+                )
+                continue
+            summaries[side] = summary
+            entry_id = str(summary.get("entry_id") or "")
+            source_entry = entries_by_id.get(entry_id)
+            if source_entry is None:
+                errors.append(
+                    f"{path.name}: preferred_pairs[{index}] {side} references "
+                    f"unknown entry_id {entry_id!r}"
+                )
+                continue
+            summary_hash = str(
+                ((summary.get("same_spec") or {}).get("resolved_spec_hash") or "")
+            )
+            source_hash = str(
+                ((source_entry.get("same_spec") or {}).get("resolved_spec_hash") or "")
+            )
+            if not summary_hash or summary_hash != source_hash:
+                errors.append(
+                    f"{path.name}: preferred_pairs[{index}] {side} hash "
+                    f"{summary_hash!r} does not match source entry {entry_id!r} "
+                    f"hash {source_hash!r}"
+                )
+        if set(summaries) != {"left", "right"}:
+            continue
+        left_hash = str(
+            ((summaries["left"].get("same_spec") or {}).get("resolved_spec_hash") or "")
+        )
+        right_hash = str(
+            ((summaries["right"].get("same_spec") or {}).get("resolved_spec_hash") or "")
+        )
+        if not left_hash or left_hash != right_hash:
+            errors.append(
+                f"{path.name}: preferred_pairs[{index}] resolved_spec_hash mismatch: "
+                f"left={left_hash!r} right={right_hash!r}"
+            )
+    return errors
+
+
 def main() -> int:
     args = parse_args()
     snapshot_dir = Path(args.snapshot_dir)
     errors: list[str] = []
+    entries_by_id: dict[str, dict[str, Any]] = {}
 
     hash_fingerprints: dict[str, tuple[str, str]] = {}
     for file_name in SNAPSHOT_FILES:
@@ -306,6 +384,9 @@ def main() -> int:
             errors.append(f"missing snapshot file: {path}")
             continue
         for entry in load_entries(path):
+            entry_id = str(entry.get("entry_id") or "")
+            if entry_id:
+                entries_by_id[entry_id] = entry
             errors.extend(validate_entry(entry, source=path))
             same_spec = (
                 entry.get("same_spec")
@@ -333,6 +414,7 @@ def main() -> int:
             else:
                 hash_fingerprints[spec_hash] = (fingerprint, source_label)
 
+    errors.extend(validate_compare_snapshot(snapshot_dir, entries_by_id))
     errors.extend(validate_rejected_superseded_report(snapshot_dir))
 
     if errors:

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -491,6 +491,10 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--github-pr-number", type=int)
     export_parser.add_argument("--github-pr-url")
     export_parser.add_argument("--runtime-python")
+    export_parser.add_argument("--reproducible-cmd")
+    export_parser.add_argument("--pytorch-version")
+    export_parser.add_argument("--cann-version")
+    export_parser.add_argument("--driver-version")
     export_parser.add_argument("--engine-source-repository")
     export_parser.add_argument("--engine-source-ref")
     export_parser.add_argument("--engine-source-commit")
@@ -1030,6 +1034,10 @@ def main(argv: list[str] | None = None) -> int:
                 plugin_source_repository=args.plugin_source_repository,
                 plugin_source_ref=args.plugin_source_ref,
                 plugin_source_commit=args.plugin_source_commit,
+                reproducible_cmd=args.reproducible_cmd,
+                pytorch_version=args.pytorch_version,
+                cann_version=args.cann_version,
+                driver_version=args.driver_version,
             )
         except (OSError, ValueError) as error:
             print(str(error), file=sys.stderr)
@@ -1277,6 +1285,10 @@ def main(argv: list[str] | None = None) -> int:
                 ),
                 plugin_source_ref=getattr(args, "plugin_source_ref", None),
                 plugin_source_commit=getattr(args, "plugin_source_commit", None),
+                reproducible_cmd=getattr(args, "reproducible_cmd", None),
+                pytorch_version=getattr(args, "pytorch_version", None),
+                cann_version=getattr(args, "cann_version", None),
+                driver_version=getattr(args, "driver_version", None),
             )
         except (OSError, ValueError) as error:
             print(str(error), file=sys.stderr)

--- a/src/vllm_hust_benchmark/comparison_gap_audit.py
+++ b/src/vllm_hust_benchmark/comparison_gap_audit.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "leaderboard-comparison-gap-audit/v1"
+EXCLUDED_WORKLOADS = frozenset(
+    {"burstgpt-production-replay", "tracelab-coding-agent-replay"}
+)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _submitted_at(entry: Mapping[str, Any]) -> str:
+    return str(_mapping(entry.get("metadata")).get("submitted_at") or "")
+
+
+def _resolved_value(
+    actual: Mapping[str, Any], key: str, *, workload: str
+) -> tuple[bool, Any]:
+    aliases: dict[str, tuple[str, ...]] = {
+        "input_len": ("random_input_len",),
+        "output_len": ("random_output_len", "prefix_repetition_output_len"),
+    }
+    if key == "input_len" and workload.startswith("prefix-repetition"):
+        prefix_len = actual.get("prefix_repetition_prefix_len")
+        suffix_len = actual.get("prefix_repetition_suffix_len")
+        if isinstance(prefix_len, int) and isinstance(suffix_len, int):
+            return True, prefix_len + suffix_len
+    if key in actual:
+        return True, actual[key]
+    for alias in aliases.get(key, ()):
+        if alias in actual:
+            return True, actual[alias]
+    return False, None
+
+
+def _parameter_reasons(
+    expected: Mapping[str, Any],
+    actual: Mapping[str, Any],
+    *,
+    prefix: str,
+    workload: str,
+) -> list[str]:
+    reasons: list[str] = []
+    for key, expected_value in sorted(expected.items()):
+        present, actual_value = _resolved_value(actual, key, workload=workload)
+        if not present:
+            reasons.append(f"{prefix}.{key}:missing")
+        elif actual_value != expected_value:
+            reasons.append(
+                f"{prefix}.{key}:mismatch:{actual_value!r}!={expected_value!r}"
+            )
+    return reasons
+
+
+def _successful_repeats(entry: Mapping[str, Any]) -> int:
+    metadata = _mapping(entry.get("metadata"))
+    attestation = _mapping(metadata.get("verification_attestation"))
+    value = attestation.get("successful_repeats")
+    if isinstance(value, int):
+        return value
+    aggregate = _mapping(entry.get("canonical_aggregate"))
+    for key in ("n", "repeat_count", "successful_repeats"):
+        value = aggregate.get(key)
+        if isinstance(value, int):
+            return value
+    return 0
+
+
+def _entry_reasons(
+    entry: Mapping[str, Any],
+    target: Mapping[str, Any],
+    *,
+    engine: str,
+    current_core_head: str | None,
+    current_plugin_head: str | None,
+) -> list[str]:
+    reasons: list[str] = []
+    metadata = _mapping(entry.get("metadata"))
+    same_spec = _mapping(entry.get("same_spec"))
+    workload = _mapping(entry.get("workload"))
+    target_workload = _mapping(target.get("workload"))
+    target_hardware = _mapping(target.get("hardware"))
+    target_model = _mapping(target.get("model"))
+
+    if metadata.get("verified") is not True:
+        reasons.append("verified-attestation-missing")
+    if metadata.get("target_id") != target.get("target_id"):
+        reasons.append("target-binding-missing-or-mismatched")
+    if metadata.get("target_version") != target.get("target_version"):
+        reasons.append("target-version-missing-or-mismatched")
+    if metadata.get("workload_config_contract") != "explicit-effective/v1":
+        reasons.append("explicit-effective-contract-missing")
+    if not metadata.get("reproducible_cmd"):
+        reasons.append("reproducible-command-missing")
+
+    expected_identity = {
+        "same_spec.spec_id": (target.get("target_id"), same_spec.get("spec_id")),
+        "workload.name": (target_workload.get("name"), workload.get("name")),
+        "hardware.chip_count": (
+            target_hardware.get("chip_count"),
+            _mapping(entry.get("hardware")).get("chip_count"),
+        ),
+        "model.id": (
+            target_model.get("id"),
+            same_spec.get("model")
+            or _mapping(entry.get("model")).get("repo_id")
+            or _mapping(entry.get("model")).get("name"),
+        ),
+        "model.precision": (
+            target_model.get("precision"),
+            same_spec.get("model_precision")
+            or _mapping(entry.get("model")).get("precision"),
+        ),
+    }
+    for field, (expected, actual) in expected_identity.items():
+        if expected != actual:
+            reasons.append(f"{field}:mismatch:{actual!r}!={expected!r}")
+
+    workload_name = str(target_workload.get("name") or "")
+    reasons.extend(
+        _parameter_reasons(
+            _mapping(target.get("server_parameters")),
+            _mapping(same_spec.get("resolved_server_parameters")),
+            prefix="server_parameters",
+            workload=workload_name,
+        )
+    )
+    reasons.extend(
+        _parameter_reasons(
+            _mapping(target_workload.get("client_parameters")),
+            _mapping(same_spec.get("resolved_client_parameters")),
+            prefix="client_parameters",
+            workload=workload_name,
+        )
+    )
+    if not same_spec.get("resolved_spec_hash"):
+        reasons.append("resolved-spec-hash-missing")
+    if _successful_repeats(entry) < 3:
+        reasons.append("three-successful-repeats-missing")
+
+    metrics = _mapping(entry.get("metrics"))
+    if metrics.get("error_rate") not in (0, 0.0):
+        reasons.append("nonzero-or-missing-error-rate")
+    peak_mem = metrics.get("peak_mem_mb")
+    if not isinstance(peak_mem, (int, float)) or peak_mem <= 0:
+        reasons.append("peak-memory-unmeasured")
+
+    environment = _mapping(entry.get("environment"))
+    for field in ("cann_version", "driver_version", "pytorch_version"):
+        if not environment.get(field):
+            reasons.append(f"runtime-environment.{field}:missing")
+
+    provenance = _mapping(metadata.get("runtime_provenance"))
+    engine_provenance = _mapping(provenance.get("engine"))
+    plugin_provenance = _mapping(provenance.get("plugin"))
+    if not engine_provenance.get("commit"):
+        reasons.append("runtime-provenance.engine-commit:missing")
+    if not plugin_provenance.get("commit"):
+        reasons.append("runtime-provenance.plugin-commit:missing")
+
+    if engine == "vllm-hust":
+        if current_core_head and engine_provenance.get("commit") != current_core_head:
+            reasons.append("current-core-head-stale")
+        if current_plugin_head and plugin_provenance.get("commit") != current_plugin_head:
+            reasons.append("current-plugin-head-stale")
+    return sorted(set(reasons))
+
+
+def _entry_summary(
+    entry: Mapping[str, Any] | None,
+    target: Mapping[str, Any],
+    *,
+    engine: str,
+    current_core_head: str | None,
+    current_plugin_head: str | None,
+) -> dict[str, Any] | None:
+    if entry is None:
+        return None
+    reasons = _entry_reasons(
+        entry,
+        target,
+        engine=engine,
+        current_core_head=current_core_head,
+        current_plugin_head=current_plugin_head,
+    )
+    same_spec = _mapping(entry.get("same_spec"))
+    metadata = _mapping(entry.get("metadata"))
+    return {
+        "entry_id": entry.get("entry_id"),
+        "submitted_at": metadata.get("submitted_at"),
+        "git_commit": metadata.get("git_commit"),
+        "resolved_spec_hash": same_spec.get("resolved_spec_hash"),
+        "successful_repeats": _successful_repeats(entry),
+        "eligible": not reasons,
+        "reasons": reasons,
+    }
+
+
+def build_comparison_gap_audit(
+    repo_root: Path,
+    *,
+    generated_at: str | None = None,
+    current_core_head: str | None = None,
+    current_plugin_head: str | None = None,
+) -> dict[str, Any]:
+    registry_path = repo_root / "leaderboard-data" / "official-targets.json"
+    registry = _load_json(registry_path)
+    snapshot_dir = repo_root / "leaderboard-data" / "snapshots"
+    entries: list[dict[str, Any]] = []
+    for name in ("leaderboard_single.json", "leaderboard_multi.json"):
+        payload = _load_json(snapshot_dir / name)
+        if not isinstance(payload, list):
+            raise ValueError(f"snapshot must be an array: {name}")
+        entries.extend(item for item in payload if isinstance(item, dict))
+
+    targets = [
+        item
+        for item in registry.get("targets", [])
+        if isinstance(item, dict)
+        and item.get("status") == "active"
+        and item.get("intended_use") == "public-leaderboard"
+        and str(_mapping(item.get("workload")).get("name") or "").lower()
+        not in EXCLUDED_WORKLOADS
+    ]
+    records: list[dict[str, Any]] = []
+    rerun_queue: list[dict[str, Any]] = []
+    for target in sorted(targets, key=lambda item: str(item.get("target_id") or "")):
+        target_id = str(target.get("target_id") or "")
+        candidates = [
+            entry
+            for entry in entries
+            if str(_mapping(entry.get("same_spec")).get("spec_id") or "")
+            == target_id
+        ]
+        by_engine = {
+            engine: sorted(
+                [entry for entry in candidates if entry.get("engine") == engine],
+                key=_submitted_at,
+                reverse=True,
+            )
+            for engine in ("vllm", "vllm-hust")
+        }
+        baseline_entry = by_engine["vllm"][0] if by_engine["vllm"] else None
+        current_entry = by_engine["vllm-hust"][0] if by_engine["vllm-hust"] else None
+        baseline = _entry_summary(
+            baseline_entry,
+            target,
+            engine="vllm",
+            current_core_head=current_core_head,
+            current_plugin_head=current_plugin_head,
+        )
+        current = _entry_summary(
+            current_entry,
+            target,
+            engine="vllm-hust",
+            current_core_head=current_core_head,
+            current_plugin_head=current_plugin_head,
+        )
+        hash_match = bool(
+            baseline
+            and current
+            and baseline.get("resolved_spec_hash")
+            and baseline.get("resolved_spec_hash") == current.get("resolved_spec_hash")
+        )
+        ready = bool(
+            baseline
+            and current
+            and baseline.get("eligible")
+            and current.get("eligible")
+            and hash_match
+        )
+        required_sides: list[str] = []
+        if not baseline or not baseline.get("eligible"):
+            required_sides.append("vllm")
+        if not current or not current.get("eligible"):
+            required_sides.append("vllm-hust")
+        if not required_sides and not hash_match:
+            required_sides.append("vllm-hust")
+        status = "ready" if ready else "rerun-required"
+        record = {
+            "target_id": target_id,
+            "target_version": target.get("target_version"),
+            "workload": _mapping(target.get("workload")).get("name"),
+            "source_spec": _mapping(target.get("source_spec")).get("path"),
+            "status": status,
+            "hash_match": hash_match,
+            "baseline": baseline,
+            "current": current,
+            "required_sides": required_sides,
+        }
+        records.append(record)
+        for side in required_sides:
+            selected = baseline if side == "vllm" else current
+            reasons = ["entry-missing"] if selected is None else list(selected["reasons"])
+            if selected and selected.get("eligible") and not hash_match:
+                reasons.append("cross-engine-resolved-spec-hash-mismatch")
+            rerun_queue.append(
+                {
+                    "target_id": target_id,
+                    "workload": record["workload"],
+                    "engine": side,
+                    "source_spec": record["source_spec"],
+                    "reasons": sorted(set(reasons)),
+                    "repeat_count": 3,
+                    "min_successful_repeats": 3,
+                }
+            )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at
+        or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "registry": {
+            "version": registry.get("registry_version"),
+            "sha256": _sha256(registry_path),
+        },
+        "policy": {
+            "excluded_workloads": sorted(EXCLUDED_WORKLOADS),
+            "minimum_successful_repeats": 3,
+            "require_verified": True,
+            "require_exact_resolved_spec_hash": True,
+            "require_current_heads": bool(current_core_head or current_plugin_head),
+            "require_runtime_environment": [
+                "cann_version",
+                "driver_version",
+                "pytorch_version",
+            ],
+            "require_measured_peak_memory": True,
+        },
+        "current_heads": {
+            "vllm_hust": current_core_head,
+            "vllm_ascend_hust": current_plugin_head,
+        },
+        "summary": {
+            "target_count": len(records),
+            "ready_pair_count": sum(item["status"] == "ready" for item in records),
+            "rerun_target_count": sum(
+                item["status"] == "rerun-required" for item in records
+            ),
+            "rerun_job_count": len(rerun_queue),
+        },
+        "records": records,
+        "rerun_queue": rerun_queue,
+    }

--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
+import os
 import platform
 import re
 import uuid
@@ -82,6 +84,57 @@ KNOWN_MEMORY_PER_CHIP_GB = {
     "ascend 910b2": 64.0,
     "ascend 910b3": 64.0,
 }
+
+
+def _read_version_value(path: Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        match = re.match(r"\s*(?:Version|version|package_version)\s*=\s*[\"']?([^\"'\s]+)", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _detect_pytorch_version() -> str | None:
+    try:
+        return importlib.metadata.version("torch")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _detect_cann_version() -> str | None:
+    candidates: list[Path] = []
+    for env_name in ("ASCEND_HOME_PATH", "ASCEND_TOOLKIT_HOME"):
+        root = os.environ.get(env_name)
+        if root:
+            candidates.extend((Path(root) / "version.info", Path(root) / "version.cfg"))
+    ascend_root = Path("/usr/local/Ascend")
+    candidates.extend(
+        (
+            ascend_root / "ascend-toolkit/latest/version.info",
+            ascend_root / "ascend-toolkit/latest/version.cfg",
+        )
+    )
+    candidates.extend(sorted(ascend_root.glob("cann-*/compiler/version.info"), reverse=True))
+    for candidate in candidates:
+        version = _read_version_value(candidate)
+        if version:
+            return version
+    return None
+
+
+def _detect_driver_version() -> str | None:
+    for candidate in (
+        Path("/usr/local/Ascend/driver/version.info"),
+        Path("/usr/local/Ascend/version.info"),
+    ):
+        version = _read_version_value(candidate)
+        if version:
+            return version
+    return None
 
 
 def _short_commit(value: Any) -> str:
@@ -560,6 +613,10 @@ def export_leaderboard_artifacts(
     plugin_source_repository: str | None,
     plugin_source_ref: str | None,
     plugin_source_commit: str | None,
+    reproducible_cmd: str | None = None,
+    pytorch_version: str | None = None,
+    cann_version: str | None = None,
+    driver_version: str | None = None,
 ) -> tuple[Path, Path]:
     engine_version = _sanitize_engine_version(engine_version, git_commit=git_commit)
     model_identity = resolve_model_identity(model_name)
@@ -689,10 +746,10 @@ def export_leaderboard_artifacts(
         "environment": {
             "os": platform.platform(),
             "python_version": platform.python_version(),
-            "pytorch_version": None,
+            "pytorch_version": pytorch_version or _detect_pytorch_version(),
             "cuda_version": None,
-            "cann_version": None,
-            "driver_version": None,
+            "cann_version": cann_version or _detect_cann_version(),
+            "driver_version": driver_version or _detect_driver_version(),
         },
         "metadata": {
             "submitted_at": submitted_at,
@@ -700,7 +757,7 @@ def export_leaderboard_artifacts(
             "data_source": data_source,
             "engine": engine,
             "engine_version": engine_version,
-            "reproducible_cmd": None,
+            "reproducible_cmd": reproducible_cmd,
             "git_commit": git_commit,
             "github_user": github_user,
             "github_commit_url": github_commit_url,

--- a/src/vllm_hust_benchmark/official_baselines.py
+++ b/src/vllm_hust_benchmark/official_baselines.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from statistics import median
 from typing import Any, Mapping
 
+from vllm_hust_benchmark.official_targets import PACKAGE_REGISTRY_PATH
 from vllm_hust_benchmark.registry import get_scenario
 
 OFFICIAL_BASELINE_SUBMITTER = "official-ascend-baseline"
@@ -164,3 +166,222 @@ def select_canonical_candidate(
         "selected_result_dir": selected["result_dir"],
         "candidates": candidates,
     }
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_target_parameters(
+    expected: Mapping[str, Any],
+    actual: Mapping[str, Any],
+    *,
+    aliases: Mapping[str, tuple[str, ...]] | None = None,
+) -> None:
+    aliases = aliases or {}
+    for key, expected_value in expected.items():
+        if (
+            key == "input_len"
+            and isinstance(actual.get("prefix_repetition_prefix_len"), int)
+            and isinstance(actual.get("prefix_repetition_suffix_len"), int)
+        ):
+            actual_value = (
+                actual["prefix_repetition_prefix_len"]
+                + actual["prefix_repetition_suffix_len"]
+            )
+            if actual_value != expected_value:
+                raise ValueError(
+                    f"resolved target parameter mismatch: {key}="
+                    f"{actual_value!r}, expected {expected_value!r}"
+                )
+            continue
+        actual_keys = (key, *aliases.get(key, ()))
+        actual_key = next((name for name in actual_keys if name in actual), None)
+        if actual_key is None:
+            raise ValueError(f"resolved target parameter is missing: {key}")
+        if actual[actual_key] != expected_value:
+            raise ValueError(
+                f"resolved target parameter mismatch: {key}="
+                f"{actual[actual_key]!r}, expected {expected_value!r}"
+            )
+
+
+def attest_canonical_submission(
+    canonical_dir: Path,
+    *,
+    spec: Mapping[str, Any],
+    result_dirs: list[Path],
+    selected_result_dir: Path,
+    primary_metric_name: str,
+    registry_path: Path = PACKAGE_REGISTRY_PATH,
+) -> dict[str, Any]:
+    """Bind a promoted candidate to its target and repeated-run evidence.
+
+    The matrix starts a fresh runner process for every result directory.  This
+    function fails closed unless at least three distinct, zero-error artifacts
+    agree on target, resolved configuration, runtime provenance, and required
+    environment evidence.
+    """
+
+    if len(result_dirs) < 3:
+        raise ValueError("canonical verification requires at least three repeats")
+
+    spec_id = get_official_baseline_spec_id(spec)
+    registry = _load_json_object(registry_path)
+    targets = registry.get("targets") if registry else None
+    if not isinstance(targets, list):
+        raise ValueError(f"official target registry is invalid: {registry_path}")
+    target = next(
+        (
+            item
+            for item in targets
+            if isinstance(item, Mapping) and item.get("target_id") == spec_id
+        ),
+        None,
+    )
+    if target is None or target.get("status") != "active":
+        raise ValueError(f"canonical verification requires an active target: {spec_id}")
+    target_version = str(target.get("target_version") or "").strip()
+    if not target_version:
+        raise ValueError(f"active target is missing target_version: {spec_id}")
+
+    selected_resolved = selected_result_dir.resolve()
+    resolved_result_dirs = [path.resolve() for path in result_dirs]
+    if selected_resolved not in resolved_result_dirs:
+        raise ValueError("selected canonical candidate is not one of the repeats")
+
+    repeat_evidence: list[dict[str, Any]] = []
+    identities: set[str] = set()
+    resolved_hashes: set[str] = set()
+    provenance_pairs: set[tuple[str, str]] = set()
+    for repeat_index, result_dir in enumerate(resolved_result_dirs, start=1):
+        artifact_path = result_dir / "submission" / "run_leaderboard.json"
+        raw_path = result_dir / "raw_benchmark_result.json"
+        payload = _load_json_object(artifact_path)
+        raw_payload = _load_json_object(raw_path)
+        if payload is None or raw_payload is None:
+            raise ValueError(f"repeat evidence is incomplete: {result_dir}")
+
+        metadata = payload.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        same_spec = payload.get("same_spec")
+        same_spec = same_spec if isinstance(same_spec, Mapping) else {}
+        metrics = payload.get("metrics")
+        metrics = metrics if isinstance(metrics, Mapping) else {}
+        environment = payload.get("environment")
+        environment = environment if isinstance(environment, Mapping) else {}
+        provenance = metadata.get("runtime_provenance")
+        provenance = provenance if isinstance(provenance, Mapping) else {}
+        engine_provenance = provenance.get("engine")
+        engine_provenance = (
+            engine_provenance if isinstance(engine_provenance, Mapping) else {}
+        )
+        plugin_provenance = provenance.get("plugin")
+        plugin_provenance = (
+            plugin_provenance if isinstance(plugin_provenance, Mapping) else {}
+        )
+
+        if same_spec.get("spec_id") != spec_id:
+            raise ValueError(f"repeat target mismatch: {result_dir}")
+        resolved_server = same_spec.get("resolved_server_parameters")
+        resolved_server = (
+            resolved_server if isinstance(resolved_server, Mapping) else {}
+        )
+        resolved_client = same_spec.get("resolved_client_parameters")
+        resolved_client = (
+            resolved_client if isinstance(resolved_client, Mapping) else {}
+        )
+        target_server = target.get("server_parameters")
+        target_server = target_server if isinstance(target_server, Mapping) else {}
+        target_workload = target.get("workload")
+        target_workload = target_workload if isinstance(target_workload, Mapping) else {}
+        target_client = target_workload.get("client_parameters")
+        target_client = target_client if isinstance(target_client, Mapping) else {}
+        _assert_target_parameters(target_server, resolved_server)
+        _assert_target_parameters(
+            target_client,
+            resolved_client,
+            aliases={
+                "input_len": ("random_input_len",),
+                "output_len": (
+                    "random_output_len",
+                    "prefix_repetition_output_len",
+                ),
+            },
+        )
+        resolved_hash = str(same_spec.get("resolved_spec_hash") or "").strip()
+        if not resolved_hash:
+            raise ValueError(f"repeat is missing resolved spec hash: {result_dir}")
+        resolved_hashes.add(resolved_hash)
+        if metrics.get("error_rate") not in (0, 0.0):
+            raise ValueError(f"repeat has nonzero or missing error rate: {result_dir}")
+        peak_mem = metrics.get("peak_mem_mb")
+        if not isinstance(peak_mem, (int, float)) or peak_mem <= 0:
+            raise ValueError(f"repeat is missing measured peak memory: {result_dir}")
+        if raw_payload.get("failed", 0) not in (0, 0.0):
+            raise ValueError(f"repeat raw result contains failures: {result_dir}")
+        if not metadata.get("reproducible_cmd"):
+            raise ValueError(f"repeat is missing reproducible command: {result_dir}")
+        if metadata.get("workload_config_contract") != "explicit-effective/v1":
+            raise ValueError(f"repeat is missing explicit config contract: {result_dir}")
+        for field in ("pytorch_version", "cann_version", "driver_version"):
+            if not environment.get(field):
+                raise ValueError(f"repeat is missing {field}: {result_dir}")
+
+        engine_commit = str(engine_provenance.get("commit") or "").strip()
+        plugin_commit = str(plugin_provenance.get("commit") or "").strip()
+        if not engine_commit or not plugin_commit:
+            raise ValueError(f"repeat is missing runtime provenance: {result_dir}")
+        provenance_pairs.add((engine_commit, plugin_commit))
+
+        identity = str(metadata.get("idempotency_key") or "").strip()
+        if not identity or identity in identities:
+            raise ValueError(f"repeat identity is missing or duplicated: {result_dir}")
+        identities.add(identity)
+        repeat_evidence.append(
+            {
+                "repeat_index": repeat_index,
+                "idempotency_key": identity,
+                "leaderboard_artifact_sha256": _sha256_file(artifact_path),
+                "raw_result_sha256": _sha256_file(raw_path),
+                "submitted_at": metadata.get("submitted_at"),
+            }
+        )
+
+    if len(resolved_hashes) != 1:
+        raise ValueError("repeats do not share one resolved spec hash")
+    if len(provenance_pairs) != 1:
+        raise ValueError("repeats do not share one runtime provenance pair")
+
+    canonical_path = canonical_dir / "run_leaderboard.json"
+    canonical_payload = _load_json_object(canonical_path)
+    if canonical_payload is None:
+        raise ValueError(f"canonical artifact is missing: {canonical_path}")
+    canonical_metadata = canonical_payload.get("metadata")
+    canonical_metadata = (
+        dict(canonical_metadata) if isinstance(canonical_metadata, Mapping) else {}
+    )
+    selected_index = resolved_result_dirs.index(selected_resolved) + 1
+    canonical_metadata.update(
+        {
+            "verified": True,
+            "target_id": spec_id,
+            "target_version": target_version,
+            "verification_attestation": {
+                "schema_version": "official-repeat-attestation/v1",
+                "successful_repeats": len(repeat_evidence),
+                "independent_service_processes": len(repeat_evidence),
+                "selection_policy": "median-primary-metric",
+                "primary_metric_name": primary_metric_name,
+                "selected_repeat_index": selected_index,
+                "resolved_spec_hash": next(iter(resolved_hashes)),
+                "repeat_evidence": repeat_evidence,
+            },
+        }
+    )
+    canonical_payload["metadata"] = canonical_metadata
+    canonical_path.write_text(
+        json.dumps(canonical_payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return canonical_payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1384,6 +1384,14 @@ def test_export_leaderboard_artifact_embeds_same_spec_payload(tmp_path: Path) ->
             "ci",
             "--runtime-python",
             "/root/miniconda3/envs/vllm-hust-dev/bin/python",
+            "--reproducible-cmd",
+            "bash scripts/run-current-ascend-same-spec.sh docs/spec.json",
+            "--pytorch-version",
+            "2.8.0",
+            "--cann-version",
+            "9.0.0",
+            "--driver-version",
+            "26.0.rc1",
             "--engine-source-repository",
             "vLLM-HUST/vllm-hust",
             "--engine-source-ref",
@@ -1416,6 +1424,10 @@ def test_export_leaderboard_artifact_embeds_same_spec_payload(tmp_path: Path) ->
     assert artifact["metadata"]["runtime_provenance"]["plugin"]["repository"] == (
         "vLLM-HUST/vllm-ascend-hust"
     )
+    assert artifact["metadata"]["reproducible_cmd"].startswith("bash scripts/")
+    assert artifact["environment"]["pytorch_version"] == "2.8.0"
+    assert artifact["environment"]["cann_version"] == "9.0.0"
+    assert artifact["environment"]["driver_version"] == "26.0.rc1"
 
 
 def test_export_leaderboard_artifact_rejects_zero_long_context_length(

--- a/tests/test_comparison_gap_audit.py
+++ b/tests/test_comparison_gap_audit.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+from vllm_hust_benchmark.comparison_gap_audit import build_comparison_gap_audit
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _target(target_id: str, workload: str) -> dict[str, object]:
+    return {
+        "target_id": target_id,
+        "target_version": "1.0.0",
+        "status": "active",
+        "intended_use": "public-leaderboard",
+        "hardware": {"chip_count": 1},
+        "model": {"id": "Qwen/model", "precision": "FP16"},
+        "server_parameters": {"gpu_memory_utilization": 0.6},
+        "workload": {
+            "name": workload,
+            "client_parameters": {"request_rate": 1},
+        },
+        "source_spec": {"path": f"docs/{target_id}.json"},
+    }
+
+
+def _entry(
+    target_id: str,
+    workload: str,
+    engine: str,
+    spec_hash: str,
+    *,
+    verified: bool = True,
+) -> dict[str, object]:
+    core_commit = "core-head" if engine == "vllm-hust" else "baseline-core"
+    plugin_commit = "plugin-head" if engine == "vllm-hust" else "baseline-plugin"
+    return {
+        "entry_id": f"{target_id}-{engine}",
+        "engine": engine,
+        "workload": {"name": workload},
+        "hardware": {"chip_count": 1},
+        "model": {"name": "Qwen/model", "precision": "FP16"},
+        "same_spec": {
+            "spec_id": target_id,
+            "model": "Qwen/model",
+            "model_precision": "FP16",
+            "resolved_server_parameters": {"gpu_memory_utilization": 0.6},
+            "resolved_client_parameters": {"request_rate": 1},
+            "resolved_spec_hash": spec_hash,
+        },
+        "metrics": {"error_rate": 0, "peak_mem_mb": 1024},
+        "environment": {
+            "cann_version": "9.0",
+            "driver_version": "26.0",
+            "pytorch_version": "2.8",
+        },
+        "metadata": {
+            "submitted_at": "2026-08-03T00:00:00Z",
+            "verified": verified,
+            "target_id": target_id,
+            "target_version": "1.0.0",
+            "workload_config_contract": "explicit-effective/v1",
+            "reproducible_cmd": "run benchmark",
+            "runtime_provenance": {
+                "engine": {"commit": core_commit},
+                "plugin": {"commit": plugin_commit},
+            },
+            "verification_attestation": {"successful_repeats": 3},
+        },
+    }
+
+
+def test_audit_excludes_new_trace_workloads_and_requires_strict_pairs(
+    tmp_path: Path,
+) -> None:
+    ready = _target("ready", "random-online")
+    missing = _target("missing", "sharegpt-online")
+    trace = _target("trace", "tracelab-coding-agent-replay")
+    burst = _target("burst", "burstgpt-production-replay")
+    _write_json(
+        tmp_path / "leaderboard-data/official-targets.json",
+        {
+            "registry_version": "1.0.0",
+            "targets": [ready, missing, trace, burst],
+        },
+    )
+    entries = [
+        _entry("ready", "random-online", "vllm", "same-hash"),
+        _entry("ready", "random-online", "vllm-hust", "same-hash"),
+        _entry("missing", "sharegpt-online", "vllm", "baseline-hash"),
+        _entry(
+            "missing",
+            "sharegpt-online",
+            "vllm-hust",
+            "current-hash",
+            verified=False,
+        ),
+    ]
+    _write_json(
+        tmp_path / "leaderboard-data/snapshots/leaderboard_single.json", entries
+    )
+    _write_json(tmp_path / "leaderboard-data/snapshots/leaderboard_multi.json", [])
+
+    report = build_comparison_gap_audit(
+        tmp_path,
+        generated_at="2026-08-03T00:00:00Z",
+        current_core_head="core-head",
+        current_plugin_head="plugin-head",
+    )
+
+    assert report["policy"]["excluded_workloads"] == [
+        "burstgpt-production-replay",
+        "tracelab-coding-agent-replay",
+    ]
+    assert report["summary"] == {
+        "target_count": 2,
+        "ready_pair_count": 1,
+        "rerun_target_count": 1,
+        "rerun_job_count": 1,
+    }
+    assert report["rerun_queue"][0]["engine"] == "vllm-hust"
+    assert "verified-attestation-missing" in report["rerun_queue"][0]["reasons"]
+
+
+def test_current_checkout_must_match_both_heads(tmp_path: Path) -> None:
+    target = _target("target", "random-online")
+    _write_json(
+        tmp_path / "leaderboard-data/official-targets.json",
+        {"registry_version": "1.0.0", "targets": [target]},
+    )
+    entries = [
+        _entry("target", "random-online", "vllm", "same-hash"),
+        _entry("target", "random-online", "vllm-hust", "same-hash"),
+    ]
+    _write_json(
+        tmp_path / "leaderboard-data/snapshots/leaderboard_single.json", entries
+    )
+    _write_json(tmp_path / "leaderboard-data/snapshots/leaderboard_multi.json", [])
+
+    report = build_comparison_gap_audit(
+        tmp_path,
+        current_core_head="new-core",
+        current_plugin_head="new-plugin",
+    )
+    reasons = report["records"][0]["current"]["reasons"]
+    assert "current-core-head-stale" in reasons
+    assert "current-plugin-head-stale" in reasons
+    assert report["summary"]["ready_pair_count"] == 0
+
+
+def test_current_workspace_report_matches_schema_and_excludes_trace_targets() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    report = build_comparison_gap_audit(repo_root)
+    schema = json.loads(
+        (repo_root / "schemas/leaderboard_comparison_gap_audit_v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    Draft7Validator(schema).validate(report)
+    workloads = {record["workload"] for record in report["records"]}
+    assert "tracelab-coding-agent-replay" not in workloads
+    assert "burstgpt-production-replay" not in workloads

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -116,6 +116,15 @@ def test_current_same_spec_runner_defaults_to_one_start_attempt() -> None:
     assert "SERVER_START_RETRIES=${SERVER_START_RETRIES:-1}" in script
 
 
+def test_current_same_spec_runner_preserves_target_port_by_default() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert "CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-}" in script
+    assert 'if [[ -n "$CURRENT_SERVER_PORT" ]]; then' in script
+    assert 'if [[ -n "$CURRENT_CLIENT_PORT" ]]; then' in script
+    assert 'CURRENT_SERVER_PORT=${CURRENT_SERVER_PORT:-"8001"}' not in script
+
+
 def test_current_same_spec_runner_requires_offline_graph_proof() -> None:
     script = RUNNER.read_text(encoding="utf-8")
 

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -313,3 +313,19 @@ def test_current_same_spec_runner_aggregates_measured_runs_after_export() -> Non
     assert (
         'AGGREGATE_ARGS+=(--run-raw-result "$measured_raw_result")' in aggregate_block
     )
+
+
+def test_current_same_spec_runner_separates_physical_hbm_scope() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert "ASCEND_HBM_PHYSICAL_DEVICES" in script
+    assert "sample_ascend_peak_hbm.py" in script
+
+
+def test_current_same_spec_runner_checks_xxhash_before_server_start() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    verify_index = script.index("verify_current_runtime_requirements")
+    resolve_index = script.index("resolve_same_spec", verify_index)
+    assert 'required_modules = ("xxhash",)' in script
+    assert verify_index < resolve_index

--- a/tests/test_official_baseline_matrix_script.py
+++ b/tests/test_official_baseline_matrix_script.py
@@ -97,6 +97,7 @@ def _run_matrix(
     spec_file: Path, env: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
     merged_env = {**os.environ, **env}
+    merged_env.setdefault("STRICT_CANONICAL_ATTESTATION", "0")
     # Forward the modern bash to the matrix script so its child ``$SINGLE_RUNNER``
     # invocation also uses bash 4+ (macOS system bash is 3.2 and chokes on
     # ``;;&`` fall-through and ``mapfile``).

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from vllm_hust_benchmark.official_baselines import get_canonical_submission_dir
 from vllm_hust_benchmark.official_baselines import (
+    attest_canonical_submission,
     get_primary_metric_name_for_benchmark_type,
 )
 from vllm_hust_benchmark.official_baselines import has_canonical_run
@@ -404,6 +405,162 @@ def test_select_canonical_candidate_prefers_lower_error_rate(tmp_path: Path) -> 
     payload = select_canonical_candidate([repeat_a, repeat_b], benchmark_type="serve")
 
     assert Path(payload["selected_result_dir"]) == repeat_b.resolve()
+
+
+def _write_attestable_repeat(
+    result_dir: Path, *, spec_id: str, identity: str, ttft_ms: float
+) -> None:
+    submission_dir = result_dir / "submission"
+    submission_dir.mkdir(parents=True)
+    payload = {
+        "metrics": {
+            "ttft_ms": ttft_ms,
+            "throughput_tps": 200.0,
+            "error_rate": 0.0,
+            "peak_mem_mb": 40960,
+        },
+        "environment": {
+            "pytorch_version": "2.10.0",
+            "cann_version": "9.0.0",
+            "driver_version": "26.0.rc1",
+        },
+        "metadata": {
+            "submitted_at": "2026-08-03T00:00:00Z",
+            "idempotency_key": identity,
+            "reproducible_cmd": "bash scripts/run-current-ascend-same-spec.sh spec.json",
+            "workload_config_contract": "explicit-effective/v1",
+            "runtime_provenance": {
+                "engine": {"commit": "a" * 40},
+                "plugin": {"commit": "b" * 40},
+            },
+        },
+        "same_spec": {
+            "spec_id": spec_id,
+            "resolved_spec_hash": "c" * 64,
+            "resolved_server_parameters": {"port": 8000},
+            "resolved_client_parameters": {
+                "port": 8000,
+                "random_input_len": 1024,
+                "random_output_len": 256,
+            },
+        },
+    }
+    (submission_dir / "run_leaderboard.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    (result_dir / "raw_benchmark_result.json").write_text(
+        json.dumps({"completed": 200, "failed": 0}), encoding="utf-8"
+    )
+
+
+def test_attest_canonical_submission_binds_three_repeat_evidence(
+    tmp_path: Path,
+) -> None:
+    spec_id = "official-test-target"
+    repeats = [tmp_path / f"repeat-{index}" for index in range(1, 4)]
+    for index, repeat in enumerate(repeats, start=1):
+        _write_attestable_repeat(
+            repeat, spec_id=spec_id, identity=f"run-{index}", ttft_ms=100 + index
+        )
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    source = repeats[1] / "submission" / "run_leaderboard.json"
+    (canonical_dir / "run_leaderboard.json").write_bytes(source.read_bytes())
+    registry_path = tmp_path / "official_targets.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "target_id": spec_id,
+                        "target_version": "1.2.3",
+                        "status": "active",
+                        "server_parameters": {"port": 8000},
+                        "workload": {
+                            "client_parameters": {
+                                "port": 8000,
+                                "input_len": 1024,
+                                "output_len": 256,
+                            }
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = attest_canonical_submission(
+        canonical_dir,
+        spec={"id": spec_id},
+        result_dirs=repeats,
+        selected_result_dir=repeats[1],
+        primary_metric_name="ttft_ms",
+        registry_path=registry_path,
+    )
+
+    metadata = payload["metadata"]
+    assert metadata["verified"] is True
+    assert metadata["target_id"] == spec_id
+    assert metadata["target_version"] == "1.2.3"
+    attestation = metadata["verification_attestation"]
+    assert attestation["successful_repeats"] == 3
+    assert attestation["independent_service_processes"] == 3
+    assert attestation["selected_repeat_index"] == 2
+    assert len(attestation["repeat_evidence"]) == 3
+    assert len({item["idempotency_key"] for item in attestation["repeat_evidence"]}) == 3
+
+
+def test_attest_canonical_submission_rejects_duplicate_repeat_identity(
+    tmp_path: Path,
+) -> None:
+    spec_id = "official-test-target"
+    repeats = [tmp_path / f"repeat-{index}" for index in range(1, 4)]
+    for repeat in repeats:
+        _write_attestable_repeat(
+            repeat, spec_id=spec_id, identity="duplicate", ttft_ms=100
+        )
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    source = repeats[0] / "submission" / "run_leaderboard.json"
+    (canonical_dir / "run_leaderboard.json").write_bytes(source.read_bytes())
+    registry_path = tmp_path / "official_targets.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "target_id": spec_id,
+                        "target_version": "1.0.0",
+                        "status": "active",
+                        "server_parameters": {"port": 8000},
+                        "workload": {
+                            "client_parameters": {
+                                "port": 8000,
+                                "input_len": 1024,
+                                "output_len": 256,
+                            }
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        attest_canonical_submission(
+            canonical_dir,
+            spec={"id": spec_id},
+            result_dirs=repeats,
+            selected_result_dir=repeats[0],
+            primary_metric_name="ttft_ms",
+            registry_path=registry_path,
+        )
+    except ValueError as exc:
+        assert "duplicated" in str(exc)
+    else:
+        raise AssertionError("duplicate repeat identities must fail closed")
 
 
 def test_public_official_baseline_specs_are_v0180_910b2_fp16() -> None:

--- a/tests/test_sample_ascend_peak_hbm.py
+++ b/tests/test_sample_ascend_peak_hbm.py
@@ -1,0 +1,22 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts/sample_ascend_peak_hbm.py"
+SPEC = spec_from_file_location("sample_ascend_peak_hbm", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_parse_hbm_usage() -> None:
+    output = """
+| 2     910B2               | OK            | 92.1                 38                      0    / 0                |
+| 0                         | 0000:81:00.0  | 0                    0    / 0                3417 / 65536          |
+| 7     910B2               | OK            | 175.0                51                      0    / 0                |
+| 0                         | 0000:42:00.0  | 100                  0    / 0                61203/ 65536          |
+"""
+    assert MODULE.parse_hbm_usage(output) == {
+        2: (3417, 65536),
+        7: (61203, 65536),
+    }

--- a/tests/test_validate_public_leaderboard_snapshots.py
+++ b/tests/test_validate_public_leaderboard_snapshots.py
@@ -111,3 +111,46 @@ def test_future_official_entry_requires_effective_config_contract() -> None:
 
     assert any("workload config contract" in error for error in errors)
     assert any("workload_config_contract" in error for error in errors)
+
+
+def test_compare_snapshot_rejects_mismatched_resolved_hashes(tmp_path: Path) -> None:
+    module = load_module()
+    left = entry("left", same_spec())
+    right_payload = same_spec()
+    right_payload["resolved_server_parameters"]["tensor_parallel_size"] = 2
+    right_payload["resolved_spec_hash"] = "different-hash"
+    right = entry("right", right_payload)
+    (tmp_path / "leaderboard_compare.json").write_text(
+        json.dumps(
+            {
+                "preferred_pair_count": 1,
+                "preferred_pairs": [
+                    {
+                        "preferred_pair": {
+                            "left": {
+                                "entry_id": "left",
+                                "same_spec": {
+                                    "resolved_spec_hash": left["same_spec"][
+                                        "resolved_spec_hash"
+                                    ]
+                                },
+                            },
+                            "right": {
+                                "entry_id": "right",
+                                "same_spec": {
+                                    "resolved_spec_hash": "different-hash"
+                                },
+                            },
+                        }
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors = module.validate_compare_snapshot(
+        tmp_path, {"left": left, "right": right}
+    )
+
+    assert any("resolved_spec_hash mismatch" in error for error in errors)


### PR DESCRIPTION
## Summary

- audit all 9 active public targets while explicitly excluding TraceLab and BurstGPT
- emit a fail-closed, machine-readable 18-job rerun queue (vLLM baseline + current vllm-hust per target)
- reject compare preferred pairs unless both entries have the exact same resolved spec hash
- capture PyTorch/CANN/driver, reproducible command, runtime provenance, and scoped peak Ascend HBM evidence in official/current runners

## Current audit

- targets: 9
- strict ready pairs: 0
- targets requiring rerun: 9
- rerun jobs: 18
- current core head: `f229ba7cad21a4dba58681af6738a9fd947388e2`
- current plugin head: `cafad89a5e103f31ea517c1edb56130578c3cd56`

The queue is in `reports/leaderboard_comparison_gap_audit_20260803.json`. Missing evidence fails closed: verified status, three successful repeats, zero errors, measured peak HBM, runtime versions, reproducible command, exact target binding/config/hash, and current source SHAs.

## Validation

- 90 targeted tests passed
- public snapshot validator passed
- full suite: 546 passed; 2 environment-only failures because the host test environment lacks `mdformat` and exposes an old `jsonschema` without `Draft202012Validator`

Tracks #79 and #105.