### PR TITLE
fix(runner-ownership): reject bind mounts that bypass NPU device isol…

### DIFF
--- a/docs/RUNNER_DOCKER_OWNERSHIP.md
+++ b/docs/RUNNER_DOCKER_OWNERSHIP.md
@@ -24,6 +24,20 @@ python scripts/run-watchdog-owned-npu-container.py \
 - `ASCEND_RT_VISIBLE_DEVICES`
 - `ASCEND_VISIBLE_DEVICES`
 
+### Volume / mount 约束
+
+Volume 入口若不约束，可以通过 `--volume /dev:/dev` 或 `--volume /:/host` 绕过单卡容器的设备隔离。启动脚本和
+`validate_container_inspect` 双层校验所有 volume：
+
+- **宿主机源路径黑名单**：禁止 bind-mount
+  `/`、`/dev`、`/dev/davinci*`、`/sys`、`/proc`、`/var/run/docker.sock`、`/usr/local/Ascend`、`/etc/dcmi*`
+  等路径，这些路径会暴露宿主机设备节点、NPU 驱动 sysfs 或 Docker socket，从而绕过隔离。
+- **容器目标路径白名单**：只允许挂载到 `/workspace`、`/tmp`、`/data`、`/root/.cache`、`/home`、`/opt/models` 及其子目录。
+- **禁止危险选项**：`shared`/`slave` propagation、privileged 模式、`SYS_ADMIN`/`SYS_PTRACE`/`SYS_MODULE`
+  capabilities 均被拒绝。
+- **Docker inspect 双重校验**：`validate_container_inspect` 同时检查 `Mounts` 数组和旧式 `HostConfig.Binds`
+  列表，确保运行时配置与构建时一致。
+
 `job.container` 目前无法通过该脚本完成创建前校验。在 GitHub Actions 能可靠写入 上述 label 和设备映射以前，不得把 `job.container` 作业调度到
 `linux-aarch64-a2b3-pool`。
 

--- a/src/vllm_hust_benchmark/runner_ownership.py
+++ b/src/vllm_hust_benchmark/runner_ownership.py
@@ -19,6 +19,105 @@ RESERVED_ENV_NAMES = {
     "ASCEND_VISIBLE_DEVICES",
 }
 
+# Host paths that must never be bind-mounted into a container, because doing
+# so would bypass single-card NPU device isolation or expose host resources.
+FORBIDDEN_HOST_PATH_PATTERNS = (
+    re.compile(r"^/+$"),  # root filesystem
+    re.compile(r"^/dev/?$"),  # /dev exposes all device nodes
+    re.compile(r"^/dev/davinci\d+$"),  # NPU device nodes
+    re.compile(r"^/dev/davinci_manager$"),  # NPU management device
+    re.compile(r"^/dev/devmm_svm$"),  # NPU memory management device
+    re.compile(r"^/dev/hisi_hdc$"),  # NPU debug device
+    re.compile(r"^/sys/?$"),  # sysfs (NPU driver sysfs)
+    re.compile(r"^/sys/class/devdrv.*"),  # NPU driver sysfs entries
+    re.compile(r"^/proc/?$"),  # procfs
+    re.compile(r"^/(var/)?run/docker\.sock$"),  # Docker socket (container escape)
+    re.compile(r"^/usr/local/Ascend/?$"),  # CANN installation
+    re.compile(r"^/usr/local/slog/?$"),  # NPU log directory
+    re.compile(r"^/etc/dcmi.*"),  # NPU DCMI configuration
+)
+
+# Container destinations allowed for bind mounts. Keeps the attack surface
+# small by only permitting work-related paths inside the container.
+ALLOWED_CONTAINER_DESTINATIONS = (
+    "/workspace",
+    "/tmp",
+    "/data",
+    "/root/.cache",
+    "/home",
+    "/opt/models",
+)
+
+# Mount options that weaken isolation.
+FORBIDDEN_MOUNT_OPTIONS = {"shared", "slave"}
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize a POSIX path for comparison (strip trailing slash)."""
+    if path == "/":
+        return "/"
+    return path.rstrip("/")
+
+
+def _is_forbidden_host_path(host_path: str) -> bool:
+    """Return True if bind-mounting host_path would bypass isolation."""
+    normalized = _normalize_path(host_path)
+    return any(pattern.match(normalized) for pattern in FORBIDDEN_HOST_PATH_PATTERNS)
+
+
+def _is_allowed_container_destination(container_path: str) -> bool:
+    """Return True if container_path is an allowed mount destination."""
+    normalized = _normalize_path(container_path)
+    for allowed in ALLOWED_CONTAINER_DESTINATIONS:
+        allowed_norm = _normalize_path(allowed)
+        if normalized == allowed_norm or normalized.startswith(allowed_norm + "/"):
+            return True
+    return False
+
+
+def _validate_volume_spec(volume_spec: str) -> None:
+    """Validate a Docker volume spec before it reaches docker create.
+
+    Format: [HOST_PATH:]CONTAINER_PATH[:OPTIONS].
+
+    Raises ValueError when the spec would bypass single-card device isolation
+    or mount into a non-allowlisted container path.
+    """
+    parts = volume_spec.split(":")
+    if len(parts) == 1:
+        # Anonymous volume (container path only, Docker-managed) — safe.
+        return
+    if len(parts) not in (2, 3):
+        raise ValueError(
+            f"invalid volume spec (expected 1-3 colon-separated parts): {volume_spec!r}"
+        )
+    host_path, container_path = parts[0], parts[1]
+    options = parts[2] if len(parts) == 3 else ""
+
+    # A leading "/" marks a bind mount (host path). Named volumes (e.g.
+    # "my_vol:/workspace") are Docker-managed and safe.
+    if host_path.startswith("/"):
+        if _is_forbidden_host_path(host_path):
+            raise ValueError(
+                f"forbidden host path in volume spec {volume_spec!r}: "
+                f"mounting {host_path!r} would bypass device isolation or "
+                f"expose host resources; use --device for device access"
+            )
+
+    if not _is_allowed_container_destination(container_path):
+        raise ValueError(
+            f"forbidden container destination in volume spec {volume_spec!r}: "
+            f"only {ALLOWED_CONTAINER_DESTINATIONS} are allowed, "
+            f"got {container_path!r}"
+        )
+
+    if options:
+        for opt in options.split(","):
+            if opt.strip() in FORBIDDEN_MOUNT_OPTIONS:
+                raise ValueError(
+                    f"forbidden mount option in volume spec {volume_spec!r}: {opt!r}"
+                )
+
 
 @dataclass(frozen=True)
 class RunnerDeviceAssignment:
@@ -98,12 +197,45 @@ def build_docker_create_command(
         ("--env", f"ASCEND_VISIBLE_DEVICES={assignment.logical_device}")
     )
     for volume in volumes:
+        _validate_volume_spec(volume)
         docker_command.extend(("--volume", volume))
     for environment in _validate_extra_env(extra_env):
         docker_command.extend(("--env", environment))
     docker_command.append(image)
     docker_command.extend(command)
     return docker_command
+
+
+def _validate_mount_entry(mount: Mapping[str, Any]) -> None:
+    """Validate a single Mounts entry from docker inspect."""
+    mount_type = mount.get("Type", "")
+    # tmpfs mounts have no host source and are safe.
+    if mount_type == "tmpfs":
+        return
+
+    source = mount.get("Source", "")
+    destination = mount.get("Destination", "")
+    propagation = mount.get("Propagation", "")
+
+    if mount_type == "bind" and source.startswith("/"):
+        if _is_forbidden_host_path(source):
+            raise ValueError(
+                f"forbidden bind mount source {source!r} -> {destination!r}: "
+                f"this path would bypass NPU device isolation; "
+                f"use --device for device access"
+            )
+
+    if destination and not _is_allowed_container_destination(destination):
+        raise ValueError(
+            f"forbidden mount destination {destination!r}: "
+            f"only {ALLOWED_CONTAINER_DESTINATIONS} are allowed"
+        )
+
+    if propagation in FORBIDDEN_MOUNT_OPTIONS:
+        raise ValueError(
+            f"forbidden mount propagation {propagation!r} for "
+            f"{source!r} -> {destination!r}"
+        )
 
 
 def validate_container_inspect(
@@ -123,7 +255,30 @@ def validate_container_inspect(
                 f"container label {name}={actual!r}, expected {expected!r}"
             )
 
-    devices = (inspect_payload.get("HostConfig") or {}).get("Devices") or []
+    host_config = inspect_payload.get("HostConfig") or {}
+
+    # Reject bind mounts that would bypass device isolation. Docker inspect
+    # exposes both the modern Mounts array and the legacy Binds list.
+    mounts = inspect_payload.get("Mounts") or []
+    for mount in mounts:
+        _validate_mount_entry(mount)
+
+    binds = host_config.get("Binds") or []
+    for bind_spec in binds:
+        _validate_volume_spec(bind_spec)
+
+    # Privileged mode and dangerous capabilities bypass all isolation.
+    if host_config.get("Privileged"):
+        raise ValueError("container must not run in privileged mode")
+    cap_add = host_config.get("CapAdd") or []
+    dangerous_caps = {"SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE"}
+    present = dangerous_caps.intersection(cap_add)
+    if present:
+        raise ValueError(
+            f"container must not have dangerous capabilities: {sorted(present)}"
+        )
+
+    devices = host_config.get("Devices") or []
     mapped_devices = {
         (device.get("PathOnHost"), device.get("PathInContainer")) for device in devices
     }

--- a/tests/test_runner_ownership.py
+++ b/tests/test_runner_ownership.py
@@ -87,3 +87,191 @@ def test_validate_container_inspect_rejects_wrong_device() -> None:
     payload["HostConfig"]["Devices"][0]["PathOnHost"] = "/dev/davinci2"
     with pytest.raises(ValueError, match="mapping is missing or incorrect"):
         validate_container_inspect(payload, assignment)
+
+
+# --- mount constraint tests (issue #127 review feedback) ---
+
+
+@pytest.mark.parametrize(
+    "volume_spec",
+    [
+        "/dev:/dev",  # exposes all device nodes
+        "/dev/davinci1:/dev/davinci1",  # bypasses single-card isolation
+        "/:/host",  # exposes host root filesystem
+        "/sys:/sys",  # exposes NPU driver sysfs
+        "/var/run/docker.sock:/var/run/docker.sock",  # container escape
+        "/usr/local/Ascend:/usr/local/Ascend",  # exposes CANN stack
+    ],
+)
+def test_docker_command_rejects_bypass_volume(volume_spec: str) -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="forbidden host path"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=[volume_spec],
+        )
+
+
+@pytest.mark.parametrize(
+    "volume_spec",
+    [
+        "/host/data:/etc",  # non-allowlisted destination
+        "/host/data:/usr/bin",  # non-allowlisted destination
+    ],
+)
+def test_docker_command_rejects_non_allowlisted_destination(volume_spec: str) -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="forbidden container destination"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=[volume_spec],
+        )
+
+
+def test_docker_command_rejects_invalid_volume_format() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    with pytest.raises(ValueError, match="invalid volume spec"):
+        build_docker_create_command(
+            assignment=assignment,
+            container_name="benchmark-job",
+            image="example/ascend:latest",
+            command=[],
+            volumes=["a:b:c:d"],
+        )
+
+
+def test_docker_command_accepts_workspace_volume() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["/host/ws:/workspace", "/host/cache:/root/.cache"],
+    )
+    joined = " ".join(command)
+    assert "/host/ws:/workspace" in joined
+    assert "/host/cache:/root/.cache" in joined
+
+
+def test_docker_command_accepts_named_and_anonymous_volumes() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["my_vol:/workspace", "/tmp"],
+    )
+    joined = " ".join(command)
+    assert "my_vol:/workspace" in joined
+    assert "/tmp" in joined
+
+
+def test_docker_command_accepts_readonly_option() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    command = build_docker_create_command(
+        assignment=assignment,
+        container_name="benchmark-job",
+        image="example/ascend:latest",
+        command=[],
+        volumes=["/host/ws:/workspace:ro"],
+    )
+    assert "/host/ws:/workspace:ro" in " ".join(command)
+
+
+def test_inspect_rejects_dev_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/dev",
+            "Destination": "/dev",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    with pytest.raises(ValueError, match="forbidden bind mount source"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_root_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/",
+            "Destination": "/host",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    with pytest.raises(ValueError, match="forbidden"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_privileged_mode() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["Privileged"] = True
+    with pytest.raises(ValueError, match="privileged"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_dangerous_capabilities() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["CapAdd"] = ["SYS_ADMIN"]
+    with pytest.raises(ValueError, match="dangerous capabilities"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_legacy_binds() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["HostConfig"]["Binds"] = ["/dev:/dev"]
+    with pytest.raises(ValueError, match="forbidden host path"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_rejects_shared_propagation() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/host/data",
+            "Destination": "/workspace",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "shared",
+        }
+    ]
+    with pytest.raises(ValueError, match="propagation"):
+        validate_container_inspect(payload, assignment)
+
+
+def test_inspect_accepts_workspace_bind_mount() -> None:
+    assignment = resolve_runner_device("poy-180-21rc-npu0")
+    payload = _inspect_payload(assignment.runner_name, 0)
+    payload["Mounts"] = [
+        {
+            "Type": "bind",
+            "Source": "/home/user/workspace",
+            "Destination": "/workspace",
+            "Mode": "rw",
+            "RW": True,
+            "Propagation": "rprivate",
+        }
+    ]
+    validate_container_inspect(payload, assignment)


### PR DESCRIPTION
…ation

Address PR #128 review feedback: volume entry could bypass single-card container device isolation via --volume /dev:/dev or binding other /dev/davinciN. Add host-path blacklist, container-destination allowlist, forbidden mount options, privileged mode and dangerous capability checks in both build_docker_create_command and validate_container_inspect.

Refs #127

## Summary

Describe what changed and why.

## Repository Scope

- [ ] `vllm-hust`
- [ ] `vllm-ascend-hust`
- [ ] `ascend-runtime-manager`
- [ ] `vllm-hust-dev-hub`
- [ ] `vllm-hust-benchmark`
- [ ] `vllm-hust-website`
- [ ] `vllm-hust-workstation`
- [ ] `vllm-hust-docs`
- [ ] `EvoScientist`
- [ ] other

## Validation

List the exact commands, workflows, smoke tests, or manual checks you ran.

## Risks

Call out any mergeability, hardware, deployment, CI, or compatibility risks.

## Checklist

- [ ] I removed or redacted secrets, tokens, and private endpoints.
- [ ] I updated docs if user-facing behavior changed.
- [ ] I noted the tests I ran, or clearly stated what I could not run.