### PR TITLE
[Perfgate] Persist runtime manager provenance

### DIFF
--- a/docs/central-perfgate-baselines.md
+++ b/docs/central-perfgate-baselines.md
@@ -51,7 +51,7 @@ latest-main pointer.
 - at least one warmup and three measured runs with ordered raw-result checksums;
 - selection metadata recomputed from all measured runs;
 - a published client-metric tuple that exactly matches the selected real run;
-- exact core, plugin, and benchmark runner revisions;
+- exact core, plugin, benchmark runner, and runtime manager revisions;
 - hardware, CANN, PyTorch, and torch-npu provenance.
 
 An existing baseline key is immutable. Repeating the same write is idempotent, while different

--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -51,7 +51,7 @@ class BaselineProvenance:
     cann_version: str
     torch_version: str
     torch_npu_version: str
-    runtime_manager_sha: str | None = None
+    runtime_manager_sha: str
 
 
 def _canonical_repository(value: str) -> str:
@@ -70,13 +70,6 @@ def _validate_sha(value: str, *, field: str) -> str:
     if not SHA_PATTERN.fullmatch(normalized):
         raise ValueError(f"{field} must be a full 40-character Git SHA")
     return normalized
-
-
-def _validate_optional_sha(value: str | None, *, field: str) -> str | None:
-    normalized = str(value or "").strip()
-    if not normalized:
-        return None
-    return _validate_sha(normalized, field=field)
 
 
 def _validate_component(value: str, *, field: str) -> str:
@@ -140,7 +133,7 @@ def normalize_provenance(provenance: BaselineProvenance) -> BaselineProvenance:
         torch_npu_version=_validate_metadata_value(
             provenance.torch_npu_version, field="torch_npu_version"
         ),
-        runtime_manager_sha=_validate_optional_sha(
+        runtime_manager_sha=_validate_sha(
             provenance.runtime_manager_sha, field="runtime_manager_sha"
         ),
     )
@@ -882,7 +875,7 @@ def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--vllm-hust-sha", required=True)
     parser.add_argument("--vllm-ascend-hust-sha", required=True)
     parser.add_argument("--benchmark-runner-sha", required=True)
-    parser.add_argument("--runtime-manager-sha", default="")
+    parser.add_argument("--runtime-manager-sha", required=True)
     parser.add_argument("--hardware-chip-model", required=True)
     parser.add_argument("--cann-version", required=True)
     parser.add_argument("--torch-version", required=True)

--- a/src/vllm_hust_benchmark/perfgate_baselines.py
+++ b/src/vllm_hust_benchmark/perfgate_baselines.py
@@ -51,6 +51,7 @@ class BaselineProvenance:
     cann_version: str
     torch_version: str
     torch_npu_version: str
+    runtime_manager_sha: str | None = None
 
 
 def _canonical_repository(value: str) -> str:
@@ -69,6 +70,13 @@ def _validate_sha(value: str, *, field: str) -> str:
     if not SHA_PATTERN.fullmatch(normalized):
         raise ValueError(f"{field} must be a full 40-character Git SHA")
     return normalized
+
+
+def _validate_optional_sha(value: str | None, *, field: str) -> str | None:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return None
+    return _validate_sha(normalized, field=field)
 
 
 def _validate_component(value: str, *, field: str) -> str:
@@ -131,6 +139,9 @@ def normalize_provenance(provenance: BaselineProvenance) -> BaselineProvenance:
         ),
         torch_npu_version=_validate_metadata_value(
             provenance.torch_npu_version, field="torch_npu_version"
+        ),
+        runtime_manager_sha=_validate_optional_sha(
+            provenance.runtime_manager_sha, field="runtime_manager_sha"
         ),
     )
 
@@ -871,6 +882,7 @@ def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--vllm-hust-sha", required=True)
     parser.add_argument("--vllm-ascend-hust-sha", required=True)
     parser.add_argument("--benchmark-runner-sha", required=True)
+    parser.add_argument("--runtime-manager-sha", default="")
     parser.add_argument("--hardware-chip-model", required=True)
     parser.add_argument("--cann-version", required=True)
     parser.add_argument("--torch-version", required=True)
@@ -892,6 +904,7 @@ def _provenance_from_args(args: argparse.Namespace) -> BaselineProvenance:
         vllm_hust_sha=args.vllm_hust_sha,
         vllm_ascend_hust_sha=args.vllm_ascend_hust_sha,
         benchmark_runner_sha=args.benchmark_runner_sha,
+        runtime_manager_sha=args.runtime_manager_sha,
         hardware_chip_model=args.hardware_chip_model,
         cann_version=args.cann_version,
         torch_version=args.torch_version,

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -62,6 +62,7 @@ def _provenance(
         "cann_version": "9.0.0",
         "torch_version": "2.10.0",
         "torch_npu_version": "2.10.0",
+        "runtime_manager_sha": "d" * 40,
         **overrides,
     }
     return perfgate_baselines.BaselineProvenance(**values)
@@ -178,7 +179,7 @@ def test_store_and_exact_fetch_validate_provenance(tmp_path: Path) -> None:
     manifest = json.loads(
         (destination.parent / "baseline-metadata.json").read_text(encoding="utf-8")
     )
-    assert manifest["provenance"]["runtime_manager_sha"] is None
+    assert manifest["provenance"]["runtime_manager_sha"] == "d" * 40
     pointer = central / perfgate_baselines.latest_pointer_relative_path(_identity())
     assert json.loads(pointer.read_text(encoding="utf-8"))["identity"] == {
         "scenario": "random-online",
@@ -817,6 +818,8 @@ def test_store_cli_requires_target_sha_on_main(tmp_path: Path) -> None:
         PLUGIN_SHA,
         "--benchmark-runner-sha",
         BENCHMARK_SHA,
+        "--runtime-manager-sha",
+        "d" * 40,
         "--hardware-chip-model",
         "910B2",
         "--cann-version",

--- a/tests/test_perfgate_baselines.py
+++ b/tests/test_perfgate_baselines.py
@@ -175,6 +175,10 @@ def test_store_and_exact_fetch_validate_provenance(tmp_path: Path) -> None:
 
     assert destination.read_bytes() == artifact.read_bytes()
     assert fetched.read_bytes() == artifact.read_bytes()
+    manifest = json.loads(
+        (destination.parent / "baseline-metadata.json").read_text(encoding="utf-8")
+    )
+    assert manifest["provenance"]["runtime_manager_sha"] is None
     pointer = central / perfgate_baselines.latest_pointer_relative_path(_identity())
     assert json.loads(pointer.read_text(encoding="utf-8"))["identity"] == {
         "scenario": "random-online",
@@ -183,6 +187,36 @@ def test_store_and_exact_fetch_validate_provenance(tmp_path: Path) -> None:
         "target_repository": TARGET_REPOSITORY,
         "target_sha": TARGET_SHA,
     }
+
+
+def test_runtime_manager_sha_is_persisted_and_compared(tmp_path: Path) -> None:
+    central = tmp_path / "central"
+    central.mkdir()
+    artifact = tmp_path / "run_leaderboard.json"
+    _write_artifact(artifact)
+    provenance = _provenance(runtime_manager_sha="d" * 40)
+
+    destination = perfgate_baselines.store_baseline(
+        central, artifact, _identity(), provenance
+    )
+    manifest = json.loads(
+        (destination.parent / "baseline-metadata.json").read_text(encoding="utf-8")
+    )
+    assert manifest["provenance"]["runtime_manager_sha"] == "d" * 40
+    perfgate_baselines.fetch_baseline(
+        central,
+        tmp_path / "fetched.json",
+        _identity(),
+        expected_provenance=provenance,
+    )
+
+    with pytest.raises(ValueError, match="exact central baseline provenance mismatch"):
+        perfgate_baselines.fetch_baseline(
+            central,
+            tmp_path / "mismatched.json",
+            _identity(),
+            expected_provenance=_provenance(runtime_manager_sha="e" * 40),
+        )
 
 
 def test_runtime_versions_accept_local_version_identifiers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

  Persist the Ascend runtime-manager revision in central perfgate baseline provenance.

  Changes:
  - Add required `runtime_manager_sha` provenance validation.
  - Add `--runtime-manager-sha` to baseline store and publish CLI commands.
  - Persist and compare the runtime-manager SHA in central baseline manifests.
  - Document runtime-manager provenance requirements.
  - Add coverage for persistence, comparison, and CLI forwarding.

  ## Repository Scope

  - [x] `vllm-hust-benchmark`

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m pytest -q tests/test_perfgate_baselines.py
  python3 -m ruff check src/vllm_hust_benchmark/perfgate_baselines.py tests/test_perfgate_baselines.py
  python3 -m ruff format --check src/vllm_hust_benchmark/perfgate_baselines.py tests/test_perfgate_baselines.py
  git diff --check origin/main...HEAD
  PYTHONPATH=src python3 -m vllm_hust_benchmark.perfgate_baselines publish --help

  Results:

  - 34 passed
  - Ruff and diff checks passed.
  - Confirmed the publish CLI exposes --runtime-manager-sha.

  ## Risks

  - This intentionally fails closed for central baselines missing
    runtime_manager_sha; such baselines cannot satisfy the complete runtime
    provenance contract.

  - Downstream producers must pass a full immutable runtime-manager SHA.
  - The paired Core workflow update must pin
    VLLM_HUST_PERFGATE_BENCHMARK_RUNNER_SHA to a commit containing this change
    before it uses the new CLI argument.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.