### PR TITLE
[CI] Retain same-spec server attempt logs

### DIFF
--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -904,6 +904,34 @@ print_server_log_tail() {
   tail -n "$lines" "$log_file" >&2
 }
 
+print_server_attempt_log_tails() {
+  local log_file
+  local found=0
+
+  for log_file in "$SERVER_ATTEMPT_LOG_DIR"/server-attempt-*.stdout.log; do
+    [[ -f "$log_file" ]] || continue
+    found=1
+    echo "---- same-spec server attempt log: $log_file (last ${SERVER_LOG_TAIL_LINES} lines) ----" >&2
+    print_server_log_tail "$log_file"
+    echo "---- end same-spec server attempt log ----" >&2
+  done
+
+  if [[ "$found" == "0" ]]; then
+    echo "No same-spec server attempt logs were captured." >&2
+  fi
+}
+
+prepare_server_attempt_log() {
+  local start_attempt=$1
+  local attempt_log="$SERVER_ATTEMPT_LOG_DIR/server-attempt-${start_attempt}.stdout.log"
+
+  : >"$attempt_log"
+  # Keep the legacy result path pointing at the active attempt while
+  # retaining prior attempts for post-failure diagnosis.
+  ln -f "$attempt_log" "$SERVER_CANONICAL_STDOUT_LOG"
+  printf '%s\n' "$attempt_log"
+}
+
 wait_for_server() {
   local host=$1
   local port=$2
@@ -1113,7 +1141,10 @@ CLIENT_ARGS=$(json2args "$(normalized_client_parameters_json)")
 RAW_RESULT_FILE="$RESULT_DIR/raw_benchmark_result.json"
 ARTIFACT_DIR="$RESULT_DIR/submission"
 SERVER_STDOUT_LOG="$RESULT_DIR/server.stdout.log"
+SERVER_CANONICAL_STDOUT_LOG="$SERVER_STDOUT_LOG"
+SERVER_ATTEMPT_LOG_DIR="$RESULT_DIR/server-attempt-logs"
 OFFLINE_GRAPH_PROOF_FILE="$RESULT_DIR/offline_graph_proof.json"
+mkdir -p "$SERVER_ATTEMPT_LOG_DIR"
 
 if [[ "$BENCHMARK_TYPE" == "serve" ]]; then
   SERVER_HOST=$(jq -r '.resolved_server_parameters.host' "$SAME_SPEC_FILE")
@@ -1140,7 +1171,7 @@ if [[ "$BENCHMARK_TYPE" == "serve" ]]; then
   else
     server_ready=0
     for start_attempt in $(seq 1 "$SERVER_START_RETRIES"); do
-      : >"$SERVER_STDOUT_LOG"
+      SERVER_STDOUT_LOG=$(prepare_server_attempt_log "$start_attempt")
       run_server_command >"$SERVER_STDOUT_LOG" 2>&1 &
       SERVER_PID=$!
       persist_managed_server_state
@@ -1163,6 +1194,7 @@ if [[ "$BENCHMARK_TYPE" == "serve" ]]; then
         continue
       fi
 
+      print_server_attempt_log_tails
       exit "$server_wait_status"
     done
 

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -213,6 +213,54 @@ def test_current_same_spec_runner_prints_enough_server_log_context() -> None:
     assert "tail -n 40" not in script
 
 
+def test_current_same_spec_runner_retains_each_server_start_attempt_log() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    retry_block = script[script.index("for start_attempt in") :]
+    retry_block = retry_block[: retry_block.index("run_client_command")]
+
+    assert 'SERVER_ATTEMPT_LOG_DIR="$RESULT_DIR/server-attempt-logs"' in script
+    assert 'SERVER_CANONICAL_STDOUT_LOG="$SERVER_STDOUT_LOG"' in script
+    assert 'mkdir -p "$SERVER_ATTEMPT_LOG_DIR"' in script
+    assert "prepare_server_attempt_log()" in script
+    assert (
+        'SERVER_STDOUT_LOG=$(prepare_server_attempt_log "$start_attempt")'
+        in retry_block
+    )
+    assert "print_server_attempt_log_tails" in retry_block
+
+
+def test_current_same_spec_runner_preserves_previous_attempt_log_contents(
+    tmp_path: Path,
+) -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    prepare_attempt_log = _function_text(script, "prepare_server_attempt_log")
+    attempt_dir = tmp_path / "server-attempt-logs"
+    canonical_log = tmp_path / "server.stdout.log"
+    harness = f"""#!/bin/bash
+set -euo pipefail
+{prepare_attempt_log}
+SERVER_ATTEMPT_LOG_DIR="$1"
+SERVER_CANONICAL_STDOUT_LOG="$2"
+mkdir -p "$SERVER_ATTEMPT_LOG_DIR"
+first_log=$(prepare_server_attempt_log 1)
+printf 'first failure\\n' > "$first_log"
+second_log=$(prepare_server_attempt_log 2)
+printf 'second failure\\n' > "$second_log"
+[[ "$(cat "$first_log")" == "first failure" ]]
+[[ "$(cat "$second_log")" == "second failure" ]]
+[[ "$(cat "$SERVER_CANONICAL_STDOUT_LOG")" == "second failure" ]]
+"""
+
+    result = subprocess.run(
+        ["bash", "-c", harness, "bash", str(attempt_dir), str(canonical_log)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_current_same_spec_runner_prints_server_log_progress_while_waiting() -> None:
     script = RUNNER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

  Fixes same-spec Ascend benchmark startup diagnostics.

  The runner previously reused `server.stdout.log` for every server-start retry, so a retry overwrote the first
  EngineCore failure log. This made failures such as Core workflow run `30802914760` end with only the secondary
  `generator didn't yield` symptom.

  This PR now:

  - writes each start attempt to `server-attempt-logs/server-attempt-N.stdout.log`;
  - retains `server.stdout.log` as the current/final attempt log for compatibility;
  - prints all attempt log tails before a terminal startup failure;
  - preserves all attempt logs under the existing result directory for artifact upload.

  ## Repository Scope

  - [x] `vllm-hust-benchmark`

  ## Validation

  ```bash
  python3 -m pytest tests/test_current_same_spec_script.py -q
  # 18 passed

  python3 -m ruff check tests/test_current_same_spec_script.py
  python3 -m ruff format --check tests/test_current_same_spec_script.py
  bash -n scripts/run-current-ascend-same-spec.sh
  git diff --check

  The new behavior test verifies that a second attempt does not overwrite the first attempt log and that the
  compatibility server.stdout.log points to the latest attempt.

  ## Risks

  This changes diagnostic artifact layout only. Existing consumers of server.stdout.log remain supported. The new attempt
  logs will be verified on the next real Ascend producer run; this PR does not change model, benchmark, or NPU execution
  settings.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.