### PR TITLE
fix(admission): allow CI submissions under .benchmarks/ with valid STATUS

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,14 +260,14 @@
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "16a7b930da66e3f7a813e0a603cd038b251b1146",
         "is_verified": false,
-        "line_number": 373
+        "line_number": 434
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "f9e0f15edf5848ba4cb8b87e44c54017571635bb",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 435
       }
     ],
     "tests/test_trend_validator.py": [
@@ -287,5 +287,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T13:17:40Z"
+  "generated_at": "2026-08-04T01:57:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,14 +260,14 @@
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "16a7b930da66e3f7a813e0a603cd038b251b1146",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 582
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "f9e0f15edf5848ba4cb8b87e44c54017571635bb",
         "is_verified": false,
-        "line_number": 529
+        "line_number": 583
       }
     ],
     "tests/test_trend_validator.py": [
@@ -287,5 +287,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T02:07:39Z"
+  "generated_at": "2026-08-04T03:29:51Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,14 +260,14 @@
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "16a7b930da66e3f7a813e0a603cd038b251b1146",
         "is_verified": false,
-        "line_number": 434
+        "line_number": 528
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_integration_aggregation_gate.py",
         "hashed_secret": "f9e0f15edf5848ba4cb8b87e44c54017571635bb",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 529
       }
     ],
     "tests/test_trend_validator.py": [
@@ -287,5 +287,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T01:57:04Z"
+  "generated_at": "2026-08-04T02:07:39Z"
 }

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1504,7 +1504,25 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
             or _TEMPORARY_DIR_SUFFIX_PATTERN.search(path_str)
         )
         is_fixture_path = "tests" in parts and "fixtures" in parts
+        # .benchmarks/ directories are rejected as cache/working directories,
+        # UNLESS the directory carries a valid STATUS file written by the CI
+        # workflow. CI submissions are intentionally placed under .benchmarks/
+        # by run_ascend_benchmark_ci.sh, and the runner writes "OK" to STATUS
+        # after a successful benchmark. This exception allows CI submissions to
+        # pass the admission gate while still rejecting actual cache/working
+        # directories that lack a STATUS file.
         is_benchmark_cache = ".benchmarks" in parts
+        if is_benchmark_cache:
+            status_path_check = child / "STATUS"
+            if status_path_check.is_file():
+                try:
+                    status_content_check = status_path_check.read_text(
+                        encoding="utf-8"
+                    ).strip()
+                    if status_content_check.startswith("OK"):
+                        is_benchmark_cache = False
+                except OSError:
+                    pass  # keep is_benchmark_cache = True
         if is_temporary_name or is_fixture_path or is_benchmark_cache:
             failures.append(
                 {

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1490,8 +1490,11 @@ def _is_ci_publication_submission(child: Path) -> bool:
         .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>
 
     where ``RUN_ID`` starts with ``ci-`` (matching
-    ``_CI_PUBLICATION_RUN_ID_PATTERN``), and the directory carries a ``STATUS``
-    file whose content starts with ``OK``.
+    ``_CI_PUBLICATION_RUN_ID_PATTERN``), the same ``RUN_ID`` is used for both
+    the result root and the submission directory (producer uses one
+    ``RUN_ID`` for both ``RESULT_ROOT`` and ``SUBMISSION_DIR``), and the
+    directory carries a ``STATUS`` file whose content equals ``OK`` after
+    stripping.
 
     This strict shape check scopes the ``.benchmarks/`` exception to real CI
     submissions only. Other ``.benchmarks/`` subtrees (``.benchmarks/cache``,
@@ -1511,13 +1514,19 @@ def _is_ci_publication_submission(child: Path) -> bool:
     grandparent = parent.parent
     if not _CI_PUBLICATION_RUN_ID_PATTERN.match(grandparent.name):
         return False
+    # Producer uses the same RUN_ID for RESULT_ROOT and SUBMISSION_DIR, so
+    # the submission dir name must equal the result root name. This rejects
+    # .benchmarks/ci/ci-A/submissions/ci-B even when both segments are valid.
+    if child.name != grandparent.name:
+        return False
     # Great-grandparent must be "ci".
     if grandparent.parent.name != "ci":
         return False
     # Great-great-grandparent must be ".benchmarks".
     if grandparent.parent.parent.name != ".benchmarks":
         return False
-    # STATUS file must exist and start with "OK".
+    # STATUS file must exist and strictly equal "OK" after stripping, matching
+    # the downstream admission gate's STATUS comparison.
     status_path = child / "STATUS"
     if not status_path.is_file():
         return False
@@ -1525,7 +1534,7 @@ def _is_ci_publication_submission(child: Path) -> bool:
         status_content = status_path.read_text(encoding="utf-8").strip()
     except OSError:
         return False
-    return status_content.startswith("OK")
+    return status_content == "OK"
 
 
 def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:

--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -1470,6 +1470,63 @@ def _find_excluded_submission_dirs(
 _TEMPORARY_DIR_PREFIX_PATTERN = re.compile(r"^(tmp|temp|wip|scratch|adhoc)")
 _TEMPORARY_DIR_SUFFIX_PATTERN = re.compile(r"/(tmp|temp|wip|scratch|adhoc)$")
 
+# CI publication directory contract used by run_ascend_benchmark_ci.sh:
+#   RESULT_ROOT       = $VLLM_HUST_REPO/.benchmarks/ci/$RUN_ID
+#   SUBMISSIONS_ROOT  = $RESULT_ROOT/submissions
+#   SUBMISSION_DIR    = $SUBMISSIONS_ROOT/$RUN_ID
+# where RUN_ID = ci-<gh-run-id>-<attempt>-<sha8> (always starts with ``ci-``).
+# The runner writes ``OK`` to ``$SUBMISSION_DIR/STATUS`` only after a successful
+# benchmark. Both the result-root segment and the submission dir name follow
+# this ``ci-*`` shape.
+_CI_PUBLICATION_RUN_ID_PATTERN = re.compile(r"^ci-[A-Za-z0-9_-]+$")
+
+
+def _is_ci_publication_submission(child: Path) -> bool:
+    """Return True iff ``child`` matches the CI publication directory contract
+    used by ``run_ascend_benchmark_ci.sh``.
+
+    The contract requires the exact shape::
+
+        .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>
+
+    where ``RUN_ID`` starts with ``ci-`` (matching
+    ``_CI_PUBLICATION_RUN_ID_PATTERN``), and the directory carries a ``STATUS``
+    file whose content starts with ``OK``.
+
+    This strict shape check scopes the ``.benchmarks/`` exception to real CI
+    submissions only. Other ``.benchmarks/`` subtrees (``.benchmarks/cache``,
+    ``.benchmarks/raw``, working directories, or paths that happen to contain
+    ``.benchmarks``) remain rejected as cache/working directories even if they
+    carry a ``STATUS=OK`` file, preserving the fail-closed boundary around the
+    temporary/quarantine rejection.
+    """
+    # Directory name must match the ci-* RUN_ID pattern.
+    if not _CI_PUBLICATION_RUN_ID_PATTERN.match(child.name):
+        return False
+    # Parent must be named "submissions".
+    parent = child.parent
+    if parent.name != "submissions":
+        return False
+    # Grandparent (the result root) must also match the ci-* RUN_ID pattern.
+    grandparent = parent.parent
+    if not _CI_PUBLICATION_RUN_ID_PATTERN.match(grandparent.name):
+        return False
+    # Great-grandparent must be "ci".
+    if grandparent.parent.name != "ci":
+        return False
+    # Great-great-grandparent must be ".benchmarks".
+    if grandparent.parent.parent.name != ".benchmarks":
+        return False
+    # STATUS file must exist and start with "OK".
+    status_path = child / "STATUS"
+    if not status_path.is_file():
+        return False
+    try:
+        status_content = status_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    return status_content.startswith("OK")
+
 
 def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
     """Scan immediate subdirectories of ``source_dir`` for admission failures.
@@ -1477,7 +1534,10 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
     Returns a list of failure dicts, each with keys ``dir``, ``reason``, and
     ``detail``. A directory is a failure if it matches ANY of:
     - ``temporary``: directory name matches a temporary naming pattern, or the
-      directory lives under ``tests/fixtures/`` or ``.benchmarks/``.
+      directory lives under ``tests/fixtures/`` or ``.benchmarks/``. The only
+      ``.benchmarks/`` exception is the CI publication contract
+      ``.benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>`` with a valid ``OK``
+      STATUS file (see ``_is_ci_publication_submission``).
     - ``FAILED``: the ``STATUS`` file content starts with ``FAILED``.
     - ``NO_STATUS``: a ``STATUS`` file exists but is empty after stripping;
       a ``ci-*`` directory has no ``STATUS``; or neither a ``STATUS`` file nor
@@ -1505,24 +1565,15 @@ def _scan_submission_admission_failures(source_dir: Path) -> list[dict]:
         )
         is_fixture_path = "tests" in parts and "fixtures" in parts
         # .benchmarks/ directories are rejected as cache/working directories,
-        # UNLESS the directory carries a valid STATUS file written by the CI
-        # workflow. CI submissions are intentionally placed under .benchmarks/
-        # by run_ascend_benchmark_ci.sh, and the runner writes "OK" to STATUS
-        # after a successful benchmark. This exception allows CI submissions to
-        # pass the admission gate while still rejecting actual cache/working
-        # directories that lack a STATUS file.
+        # UNLESS the directory matches the strict CI publication contract used
+        # by run_ascend_benchmark_ci.sh:
+        #   .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>  with STATUS=OK.
+        # The strict shape check (see _is_ci_publication_submission) ensures
+        # other .benchmarks/ subtrees (cache, raw, working dirs) remain rejected
+        # even if they carry a STATUS=OK file, preserving fail-closed behavior.
         is_benchmark_cache = ".benchmarks" in parts
-        if is_benchmark_cache:
-            status_path_check = child / "STATUS"
-            if status_path_check.is_file():
-                try:
-                    status_content_check = status_path_check.read_text(
-                        encoding="utf-8"
-                    ).strip()
-                    if status_content_check.startswith("OK"):
-                        is_benchmark_cache = False
-                except OSError:
-                    pass  # keep is_benchmark_cache = True
+        if is_benchmark_cache and _is_ci_publication_submission(child):
+            is_benchmark_cache = False
         if is_temporary_name or is_fixture_path or is_benchmark_cache:
             failures.append(
                 {

--- a/tests/test_integration_aggregation_gate.py
+++ b/tests/test_integration_aggregation_gate.py
@@ -285,6 +285,100 @@ def test_benchmarks_dir_with_failed_status_rejected(tmp_path: Path) -> None:
     assert failures[0]["reason"] == "temporary"
 
 
+def test_benchmarks_cache_path_with_ok_status_rejected(tmp_path: Path) -> None:
+    """Directories under .benchmarks/cache/ (or any non-ci subtree) must be
+    rejected even with STATUS=OK. The CI publication exception is scoped to
+    .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID> only, so a path that looks
+    superficially similar but lives under .benchmarks/cache/ must still be
+    rejected as a cache/working directory.
+    """
+    source_dir = tmp_path / ".benchmarks" / "cache" / "ci-run-1" / "submissions"
+    source_dir.mkdir(parents=True)
+    cache_dir = source_dir / "ci-30554037879-1-7363d82b"
+    cache_dir.mkdir()
+    (cache_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (cache_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(cache_dir)
+    _write_admission_required_files(cache_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+    assert "directory name matches temporary pattern" in failures[0]["detail"]
+
+
+def test_benchmarks_ci_submissions_non_ci_name_rejected(tmp_path: Path) -> None:
+    """Under .benchmarks/ci/<RUN_ID>/submissions/, a directory whose name does
+    NOT start with ci- must be rejected even with STATUS=OK. The CI contract
+    requires the submission dir name to be the ci-* RUN_ID produced by
+    run_ascend_benchmark_ci.sh.
+    """
+    source_dir = tmp_path / ".benchmarks" / "ci" / "ci-run-1" / "submissions"
+    source_dir.mkdir(parents=True)
+    other_dir = source_dir / "manual-submission"
+    other_dir.mkdir()
+    (other_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (other_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(other_dir)
+    _write_admission_required_files(other_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
+def test_benchmarks_ci_non_submissions_parent_rejected(tmp_path: Path) -> None:
+    """A ci-* directory under .benchmarks/ci/<RUN_ID>/ but NOT inside a
+    submissions/ parent must be rejected even with STATUS=OK. The CI contract
+    requires .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>.
+    """
+    source_dir = tmp_path / ".benchmarks" / "ci" / "ci-run-1"
+    source_dir.mkdir(parents=True)
+    # Direct child of ci-run-1, not under submissions/
+    stray_dir = source_dir / "ci-30554037879-1-7363d82b"
+    stray_dir.mkdir()
+    (stray_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (stray_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(stray_dir)
+    _write_admission_required_files(stray_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
+def test_benchmarks_non_ci_grandparent_rejected(tmp_path: Path) -> None:
+    """A ci-* directory under submissions/ whose great-grandparent is not
+    named "ci" must be rejected even with STATUS=OK. The CI contract requires
+    .benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>; .benchmarks/raw/ or
+    .benchmarks/working/ subtrees do not qualify.
+    """
+    source_dir = tmp_path / ".benchmarks" / "raw" / "ci-run-1" / "submissions"
+    source_dir.mkdir(parents=True)
+    ci_dir = source_dir / "ci-30554037879-1-7363d82b"
+    ci_dir.mkdir()
+    (ci_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (ci_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(ci_dir)
+    _write_admission_required_files(ci_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
 def test_clean_directory_passes(tmp_path: Path) -> None:
     source_dir = tmp_path / "submissions"
     source_dir.mkdir()

--- a/tests/test_integration_aggregation_gate.py
+++ b/tests/test_integration_aggregation_gate.py
@@ -224,6 +224,67 @@ def test_temporary_directory_rejected(tmp_path: Path) -> None:
     assert "tmp-prefix-recheck" in failures[0]["dir"]
 
 
+def test_benchmarks_dir_without_status_rejected(tmp_path: Path) -> None:
+    """Directories under .benchmarks/ without a STATUS file must be rejected
+    as cache/working directories."""
+    source_dir = tmp_path / ".benchmarks" / "ci" / "ci-run-1" / "submissions"
+    source_dir.mkdir(parents=True)
+    cache_dir = source_dir / "ci-30554037879-1-7363d82b"
+    cache_dir.mkdir()
+    (cache_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    # No STATUS file — should be rejected as benchmark cache
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+    assert "directory name matches temporary pattern" in failures[0]["detail"]
+
+
+def test_benchmarks_dir_with_ok_status_passes(tmp_path: Path) -> None:
+    """CI submissions under .benchmarks/ with a valid STATUS file (written by
+    run_ascend_benchmark_ci.sh) must pass the admission gate.
+
+    The CI workflow intentionally places submissions under .benchmarks/ and
+    writes "OK" to STATUS after a successful benchmark. The admission gate
+    must accept these, not reject them as cache directories.
+    """
+    source_dir = (
+        tmp_path / ".benchmarks" / "ci" / "ci-30835313188-1-ba82f2122b" / "submissions"
+    )
+    source_dir.mkdir(parents=True)
+    ci_dir = source_dir / "ci-30835313188-1-ba82f2122b117de38542e9db09f5747a83013b71"
+    ci_dir.mkdir()
+    (ci_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (ci_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(ci_dir)
+    _write_admission_required_files(ci_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert failures == []
+
+
+def test_benchmarks_dir_with_failed_status_rejected(tmp_path: Path) -> None:
+    """Directories under .benchmarks/ with a FAILED STATUS must still be
+    rejected. Since the STATUS is not "OK", the .benchmarks exception does
+    not apply and the directory is rejected as temporary (fail-closed)."""
+    source_dir = tmp_path / ".benchmarks" / "ci" / "ci-run-failed" / "submissions"
+    source_dir.mkdir(parents=True)
+    failed_dir = source_dir / "ci-30554037879-1-failed"
+    failed_dir.mkdir()
+    (failed_dir / "STATUS").write_text("FAILED: server crashed\n", encoding="utf-8")
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
 def test_clean_directory_passes(tmp_path: Path) -> None:
     source_dir = tmp_path / "submissions"
     source_dir.mkdir()

--- a/tests/test_integration_aggregation_gate.py
+++ b/tests/test_integration_aggregation_gate.py
@@ -250,12 +250,14 @@ def test_benchmarks_dir_with_ok_status_passes(tmp_path: Path) -> None:
     The CI workflow intentionally places submissions under .benchmarks/ and
     writes "OK" to STATUS after a successful benchmark. The admission gate
     must accept these, not reject them as cache directories.
+
+    The producer uses the same RUN_ID for both RESULT_ROOT and SUBMISSION_DIR,
+    so the result-root segment and the submission dir name must be identical.
     """
-    source_dir = (
-        tmp_path / ".benchmarks" / "ci" / "ci-30835313188-1-ba82f2122b" / "submissions"
-    )
+    run_id = "ci-30835313188-1-ba82f2122b"
+    source_dir = tmp_path / ".benchmarks" / "ci" / run_id / "submissions"
     source_dir.mkdir(parents=True)
-    ci_dir = source_dir / "ci-30835313188-1-ba82f2122b117de38542e9db09f5747a83013b71"
+    ci_dir = source_dir / run_id
     ci_dir.mkdir()
     (ci_dir / "STATUS").write_text("OK\n", encoding="utf-8")
     (ci_dir / "run_leaderboard.json").write_text(
@@ -273,11 +275,63 @@ def test_benchmarks_dir_with_failed_status_rejected(tmp_path: Path) -> None:
     """Directories under .benchmarks/ with a FAILED STATUS must still be
     rejected. Since the STATUS is not "OK", the .benchmarks exception does
     not apply and the directory is rejected as temporary (fail-closed)."""
-    source_dir = tmp_path / ".benchmarks" / "ci" / "ci-run-failed" / "submissions"
+    run_id = "ci-30554037879-1-failed"
+    source_dir = tmp_path / ".benchmarks" / "ci" / run_id / "submissions"
     source_dir.mkdir(parents=True)
-    failed_dir = source_dir / "ci-30554037879-1-failed"
+    failed_dir = source_dir / run_id
     failed_dir.mkdir()
     (failed_dir / "STATUS").write_text("FAILED: server crashed\n", encoding="utf-8")
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
+def test_benchmarks_ci_mismatched_run_id_rejected(tmp_path: Path) -> None:
+    """Even when both RUN_ID segments match the ci-* pattern, the submission
+    must be rejected if the result-root RUN_ID and the submission-dir RUN_ID
+    differ. The producer (run_ascend_benchmark_ci.sh) uses the same RUN_ID for
+    both RESULT_ROOT and SUBMISSION_DIR, so ``child.name != grandparent.name``
+    indicates the path does not come from the real CI producer.
+    """
+    source_dir = (
+        tmp_path / ".benchmarks" / "ci" / "ci-30835313188-1-ba82f2122b" / "submissions"
+    )
+    source_dir.mkdir(parents=True)
+    # Different RUN_ID — both valid ci-* but not equal.
+    mismatched_dir = source_dir / "ci-30554037879-1-7363d82b"
+    mismatched_dir.mkdir()
+    (mismatched_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+    (mismatched_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(mismatched_dir)
+    _write_admission_required_files(mismatched_dir)
+
+    failures = _scan_submission_admission_failures(source_dir)
+
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "temporary"
+
+
+def test_benchmarks_status_not_strict_ok_rejected(tmp_path: Path) -> None:
+    """STATUS content must strictly equal ``OK`` after stripping. Values like
+    ``OK-ish`` or ``OKAY`` that merely start with ``OK`` must NOT qualify for
+    the .benchmarks exception, matching the downstream admission gate's strict
+    STATUS comparison.
+    """
+    run_id = "ci-30835313188-1-ba82f2122b"
+    source_dir = tmp_path / ".benchmarks" / "ci" / run_id / "submissions"
+    source_dir.mkdir(parents=True)
+    ci_dir = source_dir / run_id
+    ci_dir.mkdir()
+    (ci_dir / "STATUS").write_text("OK-ish\n", encoding="utf-8")
+    (ci_dir / "run_leaderboard.json").write_text(
+        '{"entry_id": "test"}\n', encoding="utf-8"
+    )
+    _write_manifest(ci_dir)
+    _write_admission_required_files(ci_dir)
 
     failures = _scan_submission_admission_failures(source_dir)
 


### PR DESCRIPTION
## Purpose

Fix the ascend-benchmark CI failure on vllm-hust PR #214 (and likely other PRs). The admission gate rejected all directories under `.benchmarks/` as cache directories, but the CI workflow intentionally places submissions under `.benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>` and writes "OK" to STATUS after a successful benchmark.

## Root cause

`_scan_submission_admission_failures` in `integration.py` rejects any directory whose path parts contain `.benchmarks`:

```python
is_benchmark_cache = ".benchmarks" in parts
if is_temporary_name or is_fixture_path or is_benchmark_cache:
    failures.append({"reason": "temporary", ...})
    continue
```

The CI workflow (`run_ascend_benchmark_ci.sh`) places submissions under `.benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>/` and writes `OK` to STATUS (line 1548). When `publish-website` calls `aggregate_to_website` with `source_dir` pointing to `.benchmarks/ci/.../submissions/`, the admission gate rejects the submission directory because `.benchmarks` is in its path parts.

This caused `ascend-benchmark` CI to fail with exit code 2 even when the benchmark itself succeeded (8/8 requests, 0 failures, 61.81 tok/s).

## Fix

Scope the `.benchmarks/` exception to the exact CI publication directory contract used by `run_ascend_benchmark_ci.sh`. The new helper `_is_ci_publication_submission(child)` checks the full path shape:

```
.benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>
```

where `RUN_ID` matches `^ci-[A-Za-z0-9_-]+$`, and the directory carries a `STATUS` file starting with `OK`.

```python
is_benchmark_cache = ".benchmarks" in parts
if is_benchmark_cache and _is_ci_publication_submission(child):
    is_benchmark_cache = False
```

Other `.benchmarks/` subtrees (`.benchmarks/cache`, `.benchmarks/raw`, working dirs) remain rejected even with `STATUS=OK`, preserving fail-closed behavior.

## Test Plan

```bash
PYTHONPATH=src python -m pytest tests/test_integration_aggregation_gate.py -v
```

## Test Result

All 46 admission gate tests pass, including 3 original `.benchmarks` tests and 4 new reverse tests:

- `test_benchmarks_dir_without_status_rejected`: `.benchmarks/ci/<run>/submissions/ci-*` without STATUS → rejected as temporary
- `test_benchmarks_dir_with_ok_status_passes`: `.benchmarks/ci/<RUN_ID>/submissions/<RUN_ID>` with OK STATUS → passes
- `test_benchmarks_dir_with_failed_status_rejected`: FAILED STATUS → rejected as temporary (fail-closed)
- `test_benchmarks_cache_path_with_ok_status_rejected`: `.benchmarks/cache/.../submissions/ci-*` with OK STATUS → rejected (non-ci subtree)
- `test_benchmarks_ci_submissions_non_ci_name_rejected`: `manual-submission` (non `ci-*`) with OK STATUS → rejected
- `test_benchmarks_ci_non_submissions_parent_rejected`: `ci-*` dir without `submissions/` parent, OK STATUS → rejected
- `test_benchmarks_non_ci_grandparent_rejected`: `.benchmarks/raw/.../submissions/ci-*` with OK STATUS → rejected (great-grandparent not `ci`)

```
46 passed in 0.20s
```

Full suite: 665 passed, 1 pre-existing Python 3.9 `int | None` collection error (unrelated).

## Not duplicating

No existing PR targets this fix.


Refs vLLM-HUST/vllm-hust#214 https://github.com/vLLM-HUST/vllm-hust-benchmark/issues/144