### PR TITLE
fix(export): preserve official workload spec path

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -172,56 +172,56 @@
         "filename": "tests/test_cli.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 970
+        "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "fe44eb76a1f3f388a3b8b1912e10d1e0c3dc9e63",
         "is_verified": false,
-        "line_number": 1400
+        "line_number": 1401
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "3e2a22e7386417073deb7eb9047b5fd114f49b5f",
         "is_verified": false,
-        "line_number": 1576
+        "line_number": 1577
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
-        "line_number": 1591
+        "line_number": 1592
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "0bbc88c8b93cad004f2db9c6bc3def18047c9588",
         "is_verified": false,
-        "line_number": 1684
+        "line_number": 1685
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "de7a2f38348d9976a67cab36fc694cde0f8471c7",
         "is_verified": false,
-        "line_number": 1699
+        "line_number": 1700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "7c0935db8a50da5834dbd7523e4058c944a310dd",
         "is_verified": false,
-        "line_number": 1778
+        "line_number": 1796
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_cli.py",
         "hashed_secret": "8b0a3a9592fccdfb5b7198074a8b7f6463f1f02e",
         "is_verified": false,
-        "line_number": 1784
+        "line_number": 1802
       }
     ],
     "tests/test_historical_pr_backfill.py": [
@@ -287,5 +287,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T03:29:51Z"
+  "generated_at": "2026-08-05T02:46:02Z"
 }

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -1279,6 +1279,7 @@ EXPORT_ARGS=(
   --benchmark-result-file "$RAW_RESULT_FILE"
   --constraints-file "$CONSTRAINTS_FILE"
   --same-spec-file "$SAME_SPEC_FILE"
+  --spec-path "$SPEC_FILE"
   --output-dir "$ARTIFACT_DIR"
   --run-id "$RUN_ID"
   --engine "$CURRENT_ENGINE"

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -119,6 +119,9 @@ if [[ ! -f "$CONSTRAINTS_FILE" ]]; then
   exit 2
 fi
 
+SPEC_FILE=$(realpath "$SPEC_FILE")
+CONSTRAINTS_FILE=$(realpath "$CONSTRAINTS_FILE")
+
 if [[ ! -f "$VLLM_CLI_COMPAT" ]]; then
   echo "CLI compatibility wrapper not found: $VLLM_CLI_COMPAT" >&2
   exit 2

--- a/src/vllm_hust_benchmark/cli.py
+++ b/src/vllm_hust_benchmark/cli.py
@@ -450,6 +450,7 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--benchmark-result-file")
     export_parser.add_argument("--constraints-file")
     export_parser.add_argument("--same-spec-file")
+    export_parser.add_argument("--spec-path")
     export_parser.add_argument("--output-dir", required=True)
     export_parser.add_argument("--artifact-name", default="run_leaderboard.json")
     export_parser.add_argument("--run-id", required=True)
@@ -699,6 +700,9 @@ def _build_parser() -> argparse.ArgumentParser:
     submit_parser.add_argument("--github-pr-url")
     submit_parser.add_argument(
         "--same-spec-file", help="Path to same-spec benchmark spec file."
+    )
+    submit_parser.add_argument(
+        "--spec-path", help="Path to the source official workload specification."
     )
     submit_parser.add_argument(
         "--runtime-python", help="Python interpreter used to run the engine."
@@ -1073,6 +1077,7 @@ def main(argv: list[str] | None = None) -> int:
         same_spec_file = (
             Path(args.same_spec_file).resolve() if args.same_spec_file else None
         )
+        spec_path = Path(args.spec_path).resolve() if args.spec_path else None
         try:
             artifact_path, manifest_path = export_leaderboard_artifacts(
                 scenario=scenario,
@@ -1124,6 +1129,7 @@ def main(argv: list[str] | None = None) -> int:
                 plugin_source_repository=args.plugin_source_repository,
                 plugin_source_ref=args.plugin_source_ref,
                 plugin_source_commit=args.plugin_source_commit,
+                spec_path=spec_path,
             )
         except (OSError, ValueError) as error:
             print(str(error), file=sys.stderr)
@@ -1318,6 +1324,9 @@ def main(argv: list[str] | None = None) -> int:
             if getattr(args, "same_spec_file", None)
             else None
         )
+        spec_path = (
+            Path(args.spec_path).resolve() if getattr(args, "spec_path", None) else None
+        )
         try:
             artifact_path, manifest_path = export_leaderboard_artifacts(
                 scenario=scenario,
@@ -1371,6 +1380,7 @@ def main(argv: list[str] | None = None) -> int:
                 ),
                 plugin_source_ref=getattr(args, "plugin_source_ref", None),
                 plugin_source_commit=getattr(args, "plugin_source_commit", None),
+                spec_path=spec_path,
             )
         except (OSError, ValueError) as error:
             print(str(error), file=sys.stderr)

--- a/src/vllm_hust_benchmark/trend_producer.py
+++ b/src/vllm_hust_benchmark/trend_producer.py
@@ -207,6 +207,7 @@ def produce_trend_entry(
     plugin_source_repository: str | None = None,
     plugin_source_ref: str | None = None,
     plugin_source_commit: str | None = None,
+    spec_path: Path | None = None,
     # --- trend coverage parameters (explicit, never inferred) ---------------
     coverage_class: str | None = None,
     campaign_id: str | None = None,
@@ -321,6 +322,7 @@ def produce_trend_entry(
         plugin_source_repository=plugin_source_repository,
         plugin_source_ref=plugin_source_ref,
         plugin_source_commit=plugin_source_commit,
+        spec_path=spec_path,
     )
 
     # -- 3. Read back the written entry --------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1783,7 +1783,7 @@ def test_export_leaderboard_artifact_keeps_official_upstream_stack_out_of_hust_c
             "--model-name",
             "Qwen/Qwen2.5-14B-Instruct",
             "--hardware-chip-model",
-            "910B3",
+            "910B2",
             "--submitter",
             "official-ascend-baseline",
             "--data-source",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from vllm_hust_benchmark.leaderboard_export import export_leaderboard_artifacts
 from vllm_hust_benchmark.integration import RepoLayout
 from vllm_hust_benchmark.integration import DEFAULT_RUNTIME_ENGINE
 from vllm_hust_benchmark.integration import build_vllm_bench_command
+from vllm_hust_benchmark.same_spec import build_same_spec_payload
 
 
 def test_build_command_prints_upstream_equivalent(capsys) -> None:
@@ -1743,6 +1744,19 @@ def test_export_leaderboard_artifact_keeps_official_upstream_stack_out_of_hust_c
         ),
         encoding="utf-8",
     )
+    spec_path = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / "official-baselines"
+        / "official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"
+    )
+    same_spec_file = tmp_path / "same_spec.json"
+    same_spec_file.write_text(
+        json.dumps(
+            build_same_spec_payload(json.loads(spec_path.read_text(encoding="utf-8")))
+        ),
+        encoding="utf-8",
+    )
 
     exit_code = main(
         [
@@ -1750,6 +1764,10 @@ def test_export_leaderboard_artifact_keeps_official_upstream_stack_out_of_hust_c
             "random-online",
             "--metrics-file",
             str(metrics_file),
+            "--same-spec-file",
+            str(same_spec_file),
+            "--spec-path",
+            str(spec_path),
             "--output-dir",
             str(tmp_path / "official"),
             "--run-id",
@@ -1798,6 +1816,8 @@ def test_export_leaderboard_artifact_keeps_official_upstream_stack_out_of_hust_c
         (tmp_path / "official" / "run_leaderboard.json").read_text(encoding="utf-8")
     )
     assert artifact["engine"] == "vllm"
+    assert artifact["metadata"]["target_id"] == "official-ascend-jan-2026-v0.18.0"
+    assert artifact["metadata"]["target_version"] == "Official Ascend Jan 2026"
     assert artifact["versions"] == {
         "protocol": "N/A",
         "backend": "N/A",

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -341,6 +341,10 @@ def test_current_same_spec_runner_aggregates_measured_runs_after_export() -> Non
     aggregate_index = script.index("perfgate-aggregate-runs \\")
     assert aggregate_index > export_index
 
+    export_args_index = script.index("EXPORT_ARGS=(")
+    export_block = script[export_args_index:export_index]
+    assert '--spec-path "$SPEC_FILE"' in export_block
+
     aggregate_block = script[
         script.index(
             'if [[ "$PERFGATE_WARMUP_RUNS" -gt 0 || "$PERFGATE_MEASURED_RUNS" -gt 1 ]]'

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -41,6 +41,21 @@ def test_current_same_spec_runner_preserves_wait_for_server_exit_code() -> None:
     assert 'if [[ "$server_wait_status" -eq 0 ]]; then' in wait_block
 
 
+def test_current_same_spec_runner_resolves_source_inputs_before_switching_cwd() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    spec_check = script.index('if [[ ! -f "$SPEC_FILE" ]]; then')
+    constraints_check = script.index('if [[ ! -f "$CONSTRAINTS_FILE" ]]; then')
+    spec_realpath = script.index('SPEC_FILE=$(realpath "$SPEC_FILE")')
+    constraints_realpath = script.index(
+        'CONSTRAINTS_FILE=$(realpath "$CONSTRAINTS_FILE")'
+    )
+
+    assert spec_realpath > spec_check
+    assert constraints_realpath > constraints_check
+    assert constraints_realpath < script.index("run_in_current_runtime()")
+
+
 def test_current_same_spec_runner_does_not_retry_generic_engine_startup_wrapper() -> (
     None
 ):


### PR DESCRIPTION
## Summary

  Fix official workload artifact export after `spec_path` became required for
  recording `target_id` and `target_version`.

  The Ascend same-spec runner previously passed only `resolved_same_spec.json`,
  which is a runtime-resolved payload and not the original official workload
  specification. As a result, the hardware dry-run completed 200/200 benchmark
  requests successfully but failed during artifact export.

  This change passes the original `SPEC_FILE` as `--spec-path`, then forwards it
  through the CLI to the exporter. The `submit` and trend-producer paths preserve
  the same optional parameter.

  ## Repository Scope

  - [x] `vllm-hust-benchmark`

  ## Validation

  - `PYTHONPATH=src python3 -m pytest -q tests/
  test_cli.py::test_export_leaderboard_artifact_keeps_official_upstream_stack_out_of_hust_component_slots tests/
  test_current_same_spec_script.py tests/test_leaderboard_export.py tests/test_trend_producer.py`
    - `54 passed`
  - `ruff check src/vllm_hust_benchmark/cli.py src/vllm_hust_benchmark/trend_producer.py tests/
  test_current_same_spec_script.py tests/test_cli.py`
  - `ruff format --check src/vllm_hust_benchmark/cli.py src/vllm_hust_benchmark/trend_producer.py tests/
  test_current_same_spec_script.py tests/test_cli.py`
  - `bash -n scripts/run-current-ascend-same-spec.sh`
  - `git diff --check`

  The full local suite reached `953 passed, 11 skipped`. The remaining 29 failures
  are unrelated local macOS/platform dependencies, including missing `mdformat`
  and Linux runtime-script prerequisites.

  ## Risks

  - This changes only metadata propagation for official workload exports.
  - The exporter remains fail-closed when an official workload does not provide
    `spec_path`.
  - Hardware validation still requires rerunning core PR #222 with publication
    disabled after this PR merges to benchmark `main`.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [ ] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.