### PR TITLE
fix(publish): isolate invalid historical HF submissions

### DIFF
--- a/src/vllm_hust_benchmark/integration.py
+++ b/src/vllm_hust_benchmark/integration.py
@@ -2786,6 +2786,59 @@ def sync_submission_to_huggingface(
             )
             shutil.rmtree(excluded_dir)
 
+        # HF may still contain legacy submissions that predate the current
+        # admission contract. They must not block a publish of valid new
+        # submissions, but newly supplied directories must fail closed.
+        current_submission_names = {path.name for path in normalized_submission_dirs}
+        strict_current_submission_names = {
+            path.name
+            for path in normalized_submission_dirs
+            if (path / "STATUS").is_file()
+        }
+        admission_failures = _scan_submission_admission_failures(merged_source_dir)
+        current_failures = [
+            failure
+            for failure in admission_failures
+            if Path(failure["dir"]).name in strict_current_submission_names
+        ]
+        if current_failures:
+            print(
+                "ERROR: newly supplied submission directories failed admission:",
+                file=sys.stderr,
+            )
+            for failure in current_failures:
+                print(
+                    f"  {failure['dir']}: {failure['reason']} ({failure['detail']})",
+                    file=sys.stderr,
+                )
+            return 2
+
+        invalid_existing_repo_paths: list[str] = []
+        for failure in admission_failures:
+            failed_dir = Path(failure["dir"])
+            if failed_dir.name in current_submission_names:
+                continue
+            try:
+                relative_dir = failed_dir.relative_to(merged_source_dir).as_posix()
+            except ValueError:
+                print(
+                    f"invalid admission failure path outside merged source: {failed_dir}",
+                    file=sys.stderr,
+                )
+                return 2
+            invalid_existing_repo_paths.extend(
+                repo_path
+                for repo_path in prefixed_repo_files
+                if repo_path == f"{repo_prefix}{relative_dir}"
+                or repo_path.startswith(f"{repo_prefix}{relative_dir}/")
+            )
+            if failed_dir.is_dir():
+                shutil.rmtree(failed_dir)
+            print(
+                "Isolating invalid historical submission from active publish: "
+                f"{relative_dir} ({failure['reason']}: {failure['detail']})"
+            )
+
         official_coverage_keys = _load_official_baseline_coverage_keys(layout)
 
         normalize_submission_artifacts_in_tree(merged_source_dir)
@@ -2823,10 +2876,12 @@ def sync_submission_to_huggingface(
         operations: list[CommitOperationAdd] = []
         planned_paths: list[str] = []
 
-        if excluded_repo_paths:
+        if excluded_repo_paths or invalid_existing_repo_paths:
             from huggingface_hub import CommitOperationDelete
 
-            for repo_path in sorted(set(excluded_repo_paths)):
+            for repo_path in sorted(
+                set(excluded_repo_paths + invalid_existing_repo_paths)
+            ):
                 operations.append(CommitOperationDelete(path_in_repo=repo_path))
                 planned_paths.append(f"DELETE {repo_path}")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,7 +44,8 @@ def _write_complete_submission(
 ) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     files = {
-        "run_leaderboard.json": artifact + ("\n" if not artifact.endswith("\n") else ""),
+        "run_leaderboard.json": artifact
+        + ("\n" if not artifact.endswith("\n") else ""),
         "leaderboard_manifest.json": (manifest or _minimal_manifest()) + "\n",
         "env-manifest.json": "{}\n",
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 import builtins
+import hashlib
 import json
 from pathlib import Path
 import types
@@ -34,6 +35,28 @@ def _minimal_manifest(artifact_name: str = "run_leaderboard.json") -> str:
 
 def _minimal_artifact(model_name: str = "Qwen/Qwen2.5-14B-Instruct") -> str:
     return json.dumps({"model": {"name": model_name}})
+
+
+def _write_complete_submission(
+    directory: Path,
+    artifact: str,
+    manifest: str | None = None,
+) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    files = {
+        "run_leaderboard.json": artifact + ("\n" if not artifact.endswith("\n") else ""),
+        "leaderboard_manifest.json": (manifest or _minimal_manifest()) + "\n",
+        "env-manifest.json": "{}\n",
+    }
+    for name, content in files.items():
+        (directory / name).write_text(content, encoding="utf-8")
+    checksums = [
+        f"{hashlib.sha256((directory / name).read_bytes()).hexdigest()}  {name}"
+        for name in files
+    ]
+    (directory / "checksums.sha256").write_text(
+        "\n".join(checksums) + "\n", encoding="utf-8"
+    )
 
 
 def _future_official_artifact() -> dict:
@@ -1118,8 +1141,22 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
         _minimal_manifest() + "\n", encoding="utf-8"
     )
 
-    downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text(_minimal_artifact() + "\n", encoding="utf-8")
+    downloaded_existing = tmp_path / "downloaded-existing"
+    downloaded_existing.mkdir()
+    downloaded_run = downloaded_existing / "run_leaderboard.json"
+    downloaded_manifest = downloaded_existing / "leaderboard_manifest.json"
+    downloaded_env = downloaded_existing / "env-manifest.json"
+    downloaded_run.write_text(_minimal_artifact() + "\n", encoding="utf-8")
+    downloaded_manifest.write_text(_minimal_manifest() + "\n", encoding="utf-8")
+    downloaded_env.write_text("{}\n", encoding="utf-8")
+    checksum_lines = []
+    for path in (downloaded_run, downloaded_manifest, downloaded_env):
+        checksum_lines.append(
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}"
+        )
+    (downloaded_existing / "checksums.sha256").write_text(
+        "\n".join(checksum_lines) + "\n", encoding="utf-8"
+    )
 
     aggregate_calls: list[tuple[Path, Path]] = []
     merged_markers: dict[str, bool] = {}
@@ -1147,7 +1184,12 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
             self.token = token
 
         def list_repo_files(self, repo_id, repo_type, revision):
-            return ["submissions-auto/existing-run/run_leaderboard.json"]
+            return [
+                "submissions-auto/existing-run/run_leaderboard.json",
+                "submissions-auto/existing-run/leaderboard_manifest.json",
+                "submissions-auto/existing-run/env-manifest.json",
+                "submissions-auto/existing-run/checksums.sha256",
+            ]
 
         def repo_info(self, repo_id, repo_type):
             return {"repo_id": repo_id, "repo_type": repo_type}
@@ -1172,7 +1214,7 @@ def test_sync_submission_to_huggingface_merges_existing_submission_and_uploads(
             }
 
     def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
-        return str(downloaded_submission)
+        return str(downloaded_existing / Path(filename).name)
 
     monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
     fake_hf_module = types.SimpleNamespace(
@@ -1298,10 +1340,12 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
         ),
         encoding="utf-8",
     )
-    included_run = tmp_path / "included-run.json"
-    included_run.write_text(_minimal_artifact(), encoding="utf-8")
-    manifest = tmp_path / "manifest.json"
-    manifest.write_text(_minimal_manifest(), encoding="utf-8")
+    included_dir = tmp_path / "included-files"
+    _write_complete_submission(included_dir, _minimal_artifact())
+    included_run = included_dir / "run_leaderboard.json"
+    manifest = included_dir / "leaderboard_manifest.json"
+    legacy_run = tmp_path / "legacy-run.json"
+    legacy_run.write_text(_minimal_artifact("Qwen2.5-7B-Instruct"), encoding="utf-8")
     seeded_snapshot = tmp_path / "leaderboard_single.json"
     seeded_snapshot.write_text(
         json.dumps(
@@ -1325,6 +1369,7 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
     def fake_aggregate_to_website(*, layout, source_dir, output_dir, execute):
         source_markers["excluded"] = (source_dir / "excluded-run").exists()
         source_markers["included"] = (source_dir / "included-run").exists()
+        source_markers["legacy"] = (source_dir / "legacy-run").exists()
         seeded_rows = json.loads(
             (output_dir / "leaderboard_single.json").read_text(encoding="utf-8")
         )
@@ -1351,6 +1396,9 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
                 "submissions-auto/excluded-run/run_leaderboard.json",
                 "submissions-auto/included-run/leaderboard_manifest.json",
                 "submissions-auto/included-run/run_leaderboard.json",
+                "submissions-auto/included-run/env-manifest.json",
+                "submissions-auto/included-run/checksums.sha256",
+                "submissions-auto/legacy-run/run_leaderboard.json",
             ]
 
         def repo_info(self, repo_id, repo_type):
@@ -1364,6 +1412,12 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
             return str(seeded_snapshot)
         if filename.endswith("leaderboard_manifest.json"):
             return str(manifest)
+        if filename.endswith("env-manifest.json"):
+            return str(included_dir / "env-manifest.json")
+        if filename.endswith("checksums.sha256"):
+            return str(included_dir / "checksums.sha256")
+        if "/legacy-run/" in filename:
+            return str(legacy_run)
         if "/excluded-run/" in filename:
             return str(excluded_run)
         return str(included_run)
@@ -1397,11 +1451,14 @@ def test_sync_submission_to_huggingface_deletes_excluded_remote_submission(
     assert source_markers == {
         "excluded": False,
         "included": True,
+        "legacy": False,
         "seed_filtered": True,
     }
+    assert "submissions-auto/legacy-run/run_leaderboard.json" in deleted_paths
     assert deleted_paths == [
         "submissions-auto/excluded-run/leaderboard_manifest.json",
         "submissions-auto/excluded-run/run_leaderboard.json",
+        "submissions-auto/legacy-run/run_leaderboard.json",
     ]
     assert "submissions-auto/included-run/run_leaderboard.json" in uploaded_paths
 
@@ -1440,8 +1497,8 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
         _minimal_manifest() + "\n", encoding="utf-8"
     )
 
-    downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text(_minimal_artifact() + "\n", encoding="utf-8")
+    downloaded_existing = tmp_path / "downloaded-existing"
+    _write_complete_submission(downloaded_existing, _minimal_artifact())
 
     merged_markers: dict[str, bool] = {}
     uploaded_paths: list[str] = []
@@ -1470,7 +1527,12 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
             self.token = token
 
         def list_repo_files(self, repo_id, repo_type, revision):
-            return ["submissions-auto/existing-run/run_leaderboard.json"]
+            return [
+                "submissions-auto/existing-run/run_leaderboard.json",
+                "submissions-auto/existing-run/leaderboard_manifest.json",
+                "submissions-auto/existing-run/env-manifest.json",
+                "submissions-auto/existing-run/checksums.sha256",
+            ]
 
         def repo_info(self, repo_id, repo_type):
             return {"repo_id": repo_id, "repo_type": repo_type}
@@ -1495,11 +1557,12 @@ def test_sync_submission_to_huggingface_merges_multiple_submissions_and_uploads(
             }
 
     def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
-        return str(downloaded_submission)
+        return str(downloaded_existing / Path(filename).name)
 
     monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
     fake_hf_module = types.SimpleNamespace(
         CommitOperationAdd=FakeCommitOperationAdd,
+        CommitOperationDelete=lambda **kwargs: None,
         HfApi=FakeHfApi,
         hf_hub_download=fake_hf_hub_download,
     )
@@ -1714,27 +1777,23 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
         _minimal_manifest() + "\n", encoding="utf-8"
     )
 
-    downloaded_run = tmp_path / "downloaded-existing-run.json"
-    downloaded_manifest = tmp_path / "downloaded-existing-manifest.json"
-    downloaded_run.write_text(
-        json.dumps(
-            {
-                "model": {"name": "Qwen2.5-7B-Instruct"},
-                "hardware": {"chip_model": "910B3"},
-                "workload": {"name": "sharegpt-online"},
-                "config_type": "single_gpu",
-                "constraints": {
-                    "accountable_scope": {
-                        "baseline_engine": "vllm",
-                        "declared_baseline_engine": "vllm",
-                        "baseline_status": "pending-baseline",
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
+    downloaded_existing = tmp_path / "downloaded-existing"
+    downloaded_artifact = json.dumps(
+        {
+            "model": {"name": "Qwen2.5-7B-Instruct"},
+            "hardware": {"chip_model": "910B3"},
+            "workload": {"name": "sharegpt-online"},
+            "config_type": "single_gpu",
+            "constraints": {
+                "accountable_scope": {
+                    "baseline_engine": "vllm",
+                    "declared_baseline_engine": "vllm",
+                    "baseline_status": "pending-baseline",
+                }
+            },
+        }
     )
-    downloaded_manifest.write_text(_minimal_manifest() + "\n", encoding="utf-8")
+    _write_complete_submission(downloaded_existing, downloaded_artifact)
 
     seen_baselines: dict[str, dict[str, str]] = {}
 
@@ -1779,6 +1838,8 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
             return [
                 "submissions-auto/existing-run/leaderboard_manifest.json",
                 "submissions-auto/existing-run/run_leaderboard.json",
+                "submissions-auto/existing-run/env-manifest.json",
+                "submissions-auto/existing-run/checksums.sha256",
             ]
 
         def repo_info(self, repo_id, repo_type):
@@ -1804,9 +1865,7 @@ def test_sync_submission_to_huggingface_normalizes_unsupported_historical_baseli
             }
 
     def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
-        if filename.endswith("leaderboard_manifest.json"):
-            return str(downloaded_manifest)
-        return str(downloaded_run)
+        return str(downloaded_existing / Path(filename).name)
 
     monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
     fake_hf_module = types.SimpleNamespace(
@@ -1868,10 +1927,10 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
         website_repo=website_repo,
     )
 
-    downloaded_submission = tmp_path / "downloaded-existing.json"
-    downloaded_submission.write_text(
+    downloaded_existing = tmp_path / "downloaded-existing"
+    _write_complete_submission(
+        downloaded_existing,
         json.dumps({"model": {"name": "Qwen2.5-7B-Instruct"}}),
-        encoding="utf-8",
     )
 
     uploaded_paths: list[str] = []
@@ -1898,7 +1957,12 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
             self.token = token
 
         def list_repo_files(self, repo_id, repo_type, revision):
-            return ["submissions-auto/existing-run/run_leaderboard.json"]
+            return [
+                "submissions-auto/existing-run/run_leaderboard.json",
+                "submissions-auto/existing-run/leaderboard_manifest.json",
+                "submissions-auto/existing-run/env-manifest.json",
+                "submissions-auto/existing-run/checksums.sha256",
+            ]
 
         def repo_info(self, repo_id, repo_type):
             return {"repo_id": repo_id, "repo_type": repo_type}
@@ -1923,7 +1987,7 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
             }
 
     def fake_hf_hub_download(repo_id, repo_type, filename, revision, token):
-        return str(downloaded_submission)
+        return str(downloaded_existing / Path(filename).name)
 
     monkeypatch.setattr(integration, "aggregate_to_website", fake_aggregate_to_website)
     monkeypatch.setattr(
@@ -1933,6 +1997,7 @@ def test_sync_submission_to_huggingface_existing_only_backfills_historical_artif
     )
     fake_hf_module = types.SimpleNamespace(
         CommitOperationAdd=FakeCommitOperationAdd,
+        CommitOperationDelete=lambda **kwargs: None,
         HfApi=FakeHfApi,
         hf_hub_download=fake_hf_hub_download,
     )


### PR DESCRIPTION
## Summary

Fix the publish path that caused PR #159's HF sync to fail before snapshot regeneration.

The sync job downloaded every historical submission under `submissions-auto/` and passed them into the current admission gate. Legacy directories missing `env-manifest.json`, `checksums.sha256`, or other required evidence therefore blocked valid new submissions.

This change:

- scans the merged HF submission tree before aggregation;
- keeps fail-closed behavior for newly supplied formal submissions;
- removes invalid historical directories from the active aggregation source;
- schedules their remote files for deletion from the active HF prefix;
- preserves valid historical submissions and valid new submissions.

Closes #160.

## Validation

- `PYTHONPATH=.:src pytest -q tests/test_integration.py tests/test_integration_aggregation_gate.py tests/test_push_to_hf_workflow.py` -> 95 passed
- `PYTHONPATH=.:src pytest -q` -> 1046 passed, 4 skipped; 2 unrelated environment failures due missing `mdformat` and an old `jsonschema` without `Draft202012Validator`
- `PYTHONPATH=src python3 scripts/validate_public_leaderboard_snapshots.py --snapshot-dir leaderboard-data/snapshots` -> passed
- `python3 scripts/validate_snapshot_consistency.py --hf-repo-id none --skip-website` -> passed
- `git diff --check` -> passed
