### PR TITLE
test(issue-127): add launcher tests for watchdog-owned NPU container

### DIFF
--- a/tests/test_run_watchdog_owned_npu_container.py
+++ b/tests/test_run_watchdog_owned_npu_container.py
@@ -1,0 +1,283 @@
+"""Tests for the watchdog-owned NPU container launcher script.
+
+These tests cover argparse, RUNNER_NAME resolution, exit-code propagation,
+preflight failures, and the cleanup branch (keep_container=False) using
+subprocess monkeypatching — no real docker daemon is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "run-watchdog-owned-npu-container.py"
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+def _load_launcher():
+    spec = importlib.util.spec_from_file_location(
+        "run_watchdog_owned_npu_container", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+@pytest.fixture
+def launcher():
+    return _load_launcher()
+
+
+def _run_args(name: str = "test", image: str = "img", **extra) -> list[str]:
+    args = ["--name", name, "--image", image]
+    for key, value in extra.items():
+        if key == "volumes":
+            for vol in value:
+                args.extend(["--volume", vol])
+        elif key == "envs":
+            for env in value:
+                args.extend(["--env", env])
+        elif key == "keep":
+            args.append("--keep-container")
+    args.extend(["python", "run.py"])
+    return args
+
+
+def test_build_parser_accepts_required_flags(launcher) -> None:
+    parser = launcher.build_parser()
+    args = parser.parse_args(
+        ["--name", "test", "--image", "img", "--keep-container", "python", "run.py"]
+    )
+    assert args.name == "test"
+    assert args.image == "img"
+    assert args.keep_container is True
+    assert args.command == ["python", "run.py"]
+
+
+def test_build_parser_accepts_repeated_volume_and_env(launcher) -> None:
+    parser = launcher.build_parser()
+    args = parser.parse_args(
+        [
+            "--name",
+            "test",
+            "--image",
+            "img",
+            "--volume",
+            "/a:/workspace",
+            "--volume",
+            "/b:/tmp",
+            "--env",
+            "A=1",
+            "python",
+            "run.py",
+        ]
+    )
+    assert args.volume == ["/a:/workspace", "/b:/tmp"]
+    assert args.env == ["A=1"]
+
+
+def test_run_returns_2_when_runner_name_unset(launcher, monkeypatch) -> None:
+    monkeypatch.delenv("RUNNER_NAME", raising=False)
+    rc = launcher.run(_run_args())
+    assert rc == 2
+
+
+def test_run_returns_2_on_preflight_failure(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "invalid-runner")
+    rc = launcher.run(_run_args())
+    assert rc == 2
+
+
+def test_run_returns_2_on_forbidden_volume(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    rc = launcher.run(_run_args(volumes=["/dev:/dev"]))
+    assert rc == 2
+
+
+def test_run_returns_2_on_reserved_env(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    rc = launcher.run(_run_args(envs=["ASCEND_RT_VISIBLE_DEVICES=0"]))
+    assert rc == 2
+
+
+def test_run_returns_container_exit_code_on_success(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    fake_container_id = "abc123"
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            return _FakeCompleted(stdout=fake_container_id, returncode=0)
+        if "inspect" in cmd:
+            return _FakeCompleted(stdout="[]", returncode=0)
+        if "start" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "wait" in cmd:
+            return _FakeCompleted(stdout="0\n", returncode=0)
+        if "logs" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "rm" in cmd:
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("json.loads", return_value=[{"Config": {}, "HostConfig": {}}]),
+        patch.object(launcher, "validate_container_inspect"),
+    ):
+        rc = launcher.run(_run_args())
+    assert rc == 0
+
+
+def test_run_returns_nonzero_when_container_fails(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    fake_container_id = "abc123"
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            return _FakeCompleted(stdout=fake_container_id, returncode=0)
+        if "inspect" in cmd:
+            return _FakeCompleted(stdout="[]", returncode=0)
+        if "start" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "wait" in cmd:
+            return _FakeCompleted(stdout="42\n", returncode=0)
+        if "logs" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "rm" in cmd:
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("json.loads", return_value=[{"Config": {}, "HostConfig": {}}]),
+        patch.object(launcher, "validate_container_inspect"),
+    ):
+        rc = launcher.run(_run_args())
+    assert rc == 42
+
+
+def test_run_returns_1_on_docker_create_failure(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        return _FakeCompleted(returncode=0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        rc = launcher.run(_run_args())
+    assert rc == 1
+
+
+def test_run_cleans_up_container_when_not_keep_container(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    fake_container_id = "abc123"
+    rm_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            return _FakeCompleted(stdout=fake_container_id, returncode=0)
+        if "inspect" in cmd:
+            return _FakeCompleted(stdout="[]", returncode=0)
+        if "start" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "wait" in cmd:
+            return _FakeCompleted(stdout="0\n", returncode=0)
+        if "logs" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "rm" in cmd:
+            rm_calls.append(list(cmd))
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("json.loads", return_value=[{"Config": {}, "HostConfig": {}}]),
+        patch.object(launcher, "validate_container_inspect"),
+    ):
+        launcher.run(_run_args())
+    assert any("rm" in call and "--force" in call for call in rm_calls)
+
+
+def test_run_skips_cleanup_when_keep_container(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    fake_container_id = "abc123"
+    rm_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            return _FakeCompleted(stdout=fake_container_id, returncode=0)
+        if "inspect" in cmd:
+            return _FakeCompleted(stdout="[]", returncode=0)
+        if "start" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "wait" in cmd:
+            return _FakeCompleted(stdout="0\n", returncode=0)
+        if "logs" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "rm" in cmd:
+            rm_calls.append(list(cmd))
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("json.loads", return_value=[{"Config": {}, "HostConfig": {}}]),
+        patch.object(launcher, "validate_container_inspect"),
+    ):
+        launcher.run(_run_args(keep=True))
+    assert not rm_calls
+
+
+def test_run_cleans_up_even_on_validation_failure(launcher, monkeypatch) -> None:
+    monkeypatch.setenv("RUNNER_NAME", "poy-180-21rc-npu0")
+    fake_container_id = "abc123"
+    rm_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if "create" in cmd:
+            return _FakeCompleted(stdout=fake_container_id, returncode=0)
+        if "inspect" in cmd:
+            return _FakeCompleted(stdout="[]", returncode=0)
+        if "start" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "wait" in cmd:
+            return _FakeCompleted(stdout="0\n", returncode=0)
+        if "logs" in cmd:
+            return _FakeCompleted(returncode=0)
+        if "rm" in cmd:
+            rm_calls.append(list(cmd))
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    def fake_validate(*args, **kwargs):
+        raise ValueError("validation failed")
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("json.loads", return_value=[{"Config": {}, "HostConfig": {}}]),
+        patch.object(launcher, "validate_container_inspect", side_effect=fake_validate),
+    ):
+        rc = launcher.run(_run_args())
+    assert rc == 1
+    assert any("rm" in call and "--force" in call for call in rm_calls)


### PR DESCRIPTION
## 背景

PR #148 的 watchdog ownership 功能已被 #150 合入 main（含 review 加固：realpath 符号链接解析、named volume 拒绝、`--` 防注入、强制从 `RUNNER_NAME` 读取）。#148 已被关闭。

#150 引入了 `tests/test_runner_ownership.py`，但遗漏了 launcher 脚本的测试文件 `tests/test_run_watchdog_owned_npu_container.py`。本 PR 补齐该缺口（PR #148 中唯一 main 尚无的增量）。

## 修改内容

- `tests/test_run_watchdog_owned_npu_container.py`（新增）：12 个测试，用 subprocess monkeypatch 覆盖 `scripts/run-watchdog-owned-npu-container.py` 的：
  - argparse 解析（名称/镜像/重复 volume/env/keep-container/命令 remainder）
  - `RUNNER_NAME` 未设置 → exit 2
  - 非法 runner / 非法 volume / 保留 env 覆盖 → exit 2（preflight fail-closed）
  - 成功/失败路径退出码传播（0 / 42）
  - docker create 失败 → exit 1
  - 清理分支：`--keep-container` 未设时 `docker rm --force`；设置时跳过；校验失败也清理

不含 `--runner-name`（main 版已改为强制从 `RUNNER_NAME` 读取）和 `--init`（main 版无此参数），与 main 版 launcher 契约一致。

## 验证

- `PYTHONPATH=src python3 -m pytest tests/test_runner_ownership.py tests/test_run_watchdog_owned_npu_container.py -q`：85 passed
- 全量 `PYTHONPATH=src python3 -m pytest tests/ -q`：1266 passed（唯一失败为服务器缺 `mdformat` 依赖，器无关已知问题）
- `git diff --check`：通过

Refs #127