### PR TITLE
fix(targets): align prefix-repetition prompt and prefix counts

### DIFF
--- a/docs/OFFICIAL_TARGETS.md
+++ b/docs/OFFICIAL_TARGETS.md
@@ -2,8 +2,8 @@
 
 > This file is generated from the official specs. Do not edit it manually.
 
-- Registry version: `1.3.0`
-- Effective from: `2026-08-03`
+- Registry version: `1.3.1`
+- Effective from: `2026-08-11`
 
 Public leaderboard targets and 3B perfgate profiles are separate contracts. Provisional entries are
 not valid public-result comparison targets.

--- a/docs/OFFICIAL_TARGETS.zh-CN.md
+++ b/docs/OFFICIAL_TARGETS.zh-CN.md
@@ -2,8 +2,8 @@
 
 > 本文件由 official specs 自动生成，请勿手工修改。
 
-- Registry version: `1.3.0`
-- Effective from: `2026-08-03`
+- Registry version: `1.3.1`
+- Effective from: `2026-08-11`
 
 公开排行榜固定靶与 3B 快速门禁是不同契约；provisional 记录不得作为公开成果对比。
 

--- a/docs/OFFICIAL_TARGETS_CHANGELOG.md
+++ b/docs/OFFICIAL_TARGETS_CHANGELOG.md
@@ -2,6 +2,14 @@
 
 > Generated from `official_target_versions.json`. Do not edit manually.
 
+## 1.3.1 — 2026-08-11
+
+- English: Align the provisional prefix-repetition workload with its request count by setting eight
+  repeated prefixes for eight prompts.
+- 中文：将 provisional prefix-repetition workload 与请求数量对齐：8 个请求使用 8 个重复前缀。
+- Source set: `d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76`
+- Supersedes: `1.3.0`
+
 ## 1.3.0 — 2026-08-03
 
 - English: Revert non-executable specialty specs to non-executable drafts: remove unsupported vLLM

--- a/docs/OFFICIAL_TARGETS_CHANGELOG.md
+++ b/docs/OFFICIAL_TARGETS_CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## 1.3.1 — 2026-08-11
 
-- English: Align the provisional prefix-repetition workload with its request count by setting eight
-  repeated prefixes for eight prompts.
-- 中文：将 provisional prefix-repetition workload 与请求数量对齐：8 个请求使用 8 个重复前缀。
-- Source set: `d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76`
+- English: Align the provisional prefix-repetition workload with its request count and ensure each
+  prefix is reused at least twice.
+- 中文：确保 provisional prefix-repetition workload 中每个前缀至少复用两次。
+- Source set: `237b1cf782ba1f073dfa9d1a63b278414aefd92ff774857982e140a3c7799110`
 - Supersedes: `1.3.0`
 
 ## 1.3.0 — 2026-08-03

--- a/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
@@ -36,6 +36,7 @@
     "endpoint": "/v1/completions",
     "dataset_name": "prefix_repetition",
     "num_prompts": 8,
+    "prefix_repetition_num_prefixes": 8,
     "input_len": 1024,
     "output_len": 64,
     "request_rate": 1,

--- a/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
+++ b/docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json
@@ -36,7 +36,7 @@
     "endpoint": "/v1/completions",
     "dataset_name": "prefix_repetition",
     "num_prompts": 8,
-    "prefix_repetition_num_prefixes": 8,
+    "prefix_repetition_num_prefixes": 4,
     "input_len": 1024,
     "output_len": 64,
     "request_rate": 1,

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -2,7 +2,7 @@
   "effective_from": "2026-08-11",
   "registry_version": "1.3.1",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
+  "source_set_sha256": "237b1cf782ba1f073dfa9d1a63b278414aefd92ff774857982e140a3c7799110",
   "targets": [
     {
       "baseline_runtime": {
@@ -809,7 +809,7 @@
       },
       "source_spec": {
         "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
-        "sha256": "6e65b4a46f9c9621dcd4db3f4c21eebab3dd9e26fda3da72041611a9afa06148"
+        "sha256": "cb5852a41b9395250445a5d8b54535e547bd7745c06d3dd540854451a86bf7a1"
       },
       "status": "provisional",
       "supersedes": [],
@@ -826,7 +826,7 @@
           "num_prompts": 8,
           "output_len": 64,
           "port": 8000,
-          "prefix_repetition_num_prefixes": 8,
+          "prefix_repetition_num_prefixes": 4,
           "request_rate": 1
         },
         "name": "prefix-repetition-online"

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -809,7 +809,7 @@
       },
       "source_spec": {
         "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
-        "sha256": "41e3e89b72248b24418f320f8f498050c0a78fd177e5476d7fd4872f2a867a2d"
+        "sha256": "6e65b4a46f9c9621dcd4db3f4c21eebab3dd9e26fda3da72041611a9afa06148"
       },
       "status": "provisional",
       "supersedes": [],
@@ -825,6 +825,7 @@
           "max_concurrency": 4,
           "num_prompts": 8,
           "output_len": 64,
+          "prefix_repetition_num_prefixes": 8,
           "port": 8000,
           "request_rate": 1
         },

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -1,8 +1,8 @@
 {
-  "effective_from": "2026-08-03",
-  "registry_version": "1.3.0",
+  "effective_from": "2026-08-11",
+  "registry_version": "1.3.1",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "20e94aab3fdb09b47aa388d87bee1464e129b39bad97af34db810437a9d31c9a",
+  "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
   "targets": [
     {
       "baseline_runtime": {
@@ -20,7 +20,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -52,7 +52,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -84,7 +84,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -116,7 +116,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -147,7 +147,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -179,7 +179,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -212,7 +212,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -241,7 +241,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -270,7 +270,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -302,7 +302,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -335,7 +335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -367,7 +367,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -399,7 +399,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -428,7 +428,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -457,7 +457,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -486,7 +486,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -515,7 +515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -550,7 +550,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -583,7 +583,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -615,7 +615,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -648,7 +648,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -683,7 +683,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -716,7 +716,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -748,7 +748,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -780,7 +780,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -814,7 +814,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -825,8 +825,8 @@
           "max_concurrency": 4,
           "num_prompts": 8,
           "output_len": 64,
-          "prefix_repetition_num_prefixes": 8,
           "port": 8000,
+          "prefix_repetition_num_prefixes": 8,
           "request_rate": 1
         },
         "name": "prefix-repetition-online"
@@ -848,7 +848,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -878,7 +878,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "batch_size": 1,
@@ -906,7 +906,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -939,7 +939,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -972,7 +972,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1004,7 +1004,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1036,7 +1036,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1065,7 +1065,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1093,7 +1093,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1122,7 +1122,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1150,7 +1150,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1180,7 +1180,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1211,7 +1211,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1241,7 +1241,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1272,7 +1272,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1303,7 +1303,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-eplb-expert-rebalance-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1335,7 +1335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1366,7 +1366,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-transfer-latency-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "host": "127.0.0.1",
@@ -1394,7 +1394,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1424,7 +1424,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-moe-alltoall-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1456,7 +1456,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1486,7 +1486,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-multi-nic-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "dataset_name": "sharegpt",
@@ -1515,7 +1515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1545,7 +1545,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1577,7 +1577,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1607,7 +1607,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1639,7 +1639,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1669,7 +1669,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1701,7 +1701,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1731,7 +1731,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1763,7 +1763,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1793,7 +1793,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1824,7 +1824,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1854,7 +1854,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1885,7 +1885,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1912,7 +1912,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1943,7 +1943,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1970,7 +1970,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2001,7 +2001,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 8,
         "chip_model": "910B2",
@@ -2028,7 +2028,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2059,7 +2059,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -2089,7 +2089,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2121,7 +2121,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2151,7 +2151,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2185,7 +2185,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2215,7 +2215,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2246,7 +2246,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2277,7 +2277,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-cache-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -2309,7 +2309,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2341,7 +2341,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-attention-boundary-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2374,7 +2374,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2405,7 +2405,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-knorm-kv-compression-longctx-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2437,7 +2437,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2468,7 +2468,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2501,7 +2501,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2531,7 +2531,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2564,7 +2564,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2595,7 +2595,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-saturated-warm-cache-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2628,7 +2628,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2658,7 +2658,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-slicegpt-compression-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2690,7 +2690,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2720,7 +2720,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-spec-decode-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",

--- a/leaderboard-data/official-targets.sha256
+++ b/leaderboard-data/official-targets.sha256
@@ -1,1 +1,1 @@
-98ac82f93286906e69e904a8e9e3fe19627f7ab4ecdcd994e5a04d0a1ecafb1a  official-targets.json
+c4e4a0461a646683ca3681b187db67fa8e4119cea8da520549d6b0455a6d701e  official-targets.json

--- a/leaderboard-data/official-targets.sha256
+++ b/leaderboard-data/official-targets.sha256
@@ -1,1 +1,1 @@
-1170d7c80e2f1d9c2a6c8456ebdb11497428502c069c9a778ce1fdc8bcaac4ab  official-targets.json
+98ac82f93286906e69e904a8e9e3fe19627f7ab4ecdcd994e5a04d0a1ecafb1a  official-targets.json

--- a/src/vllm_hust_benchmark/data/official_target_versions.json
+++ b/src/vllm_hust_benchmark/data/official_target_versions.json
@@ -28,10 +28,10 @@
     {
       "version": "1.3.1",
       "effective_from": "2026-08-11",
-      "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
+      "source_set_sha256": "237b1cf782ba1f073dfa9d1a63b278414aefd92ff774857982e140a3c7799110",
       "supersedes": "1.3.0",
-      "summary_en": "Align the provisional prefix-repetition workload with its request count by setting eight repeated prefixes for eight prompts.",
-      "summary_zh": "将 provisional prefix-repetition workload 与请求数量对齐：8 个请求使用 8 个重复前缀。"
+      "summary_en": "Align the provisional prefix-repetition workload with its request count and ensure each prefix is reused at least twice.",
+      "summary_zh": "确保 provisional prefix-repetition workload 中每个前缀至少复用两次。"
     }
   ]
 }

--- a/src/vllm_hust_benchmark/data/official_target_versions.json
+++ b/src/vllm_hust_benchmark/data/official_target_versions.json
@@ -24,6 +24,14 @@
       "supersedes": "1.1.0",
       "summary_en": "Revert non-executable specialty specs to non-executable drafts: remove unsupported vLLM CLI parameters (enable_alltoall, compression_plugin, enable_simllm_scheduler, etc.) and placeholder model names (Qwen2.5-MoE-A14B-Instruct, Qwen2.5-14B-Instruct-EAGLE, Qwen2.5-14B-Instruct-slicegpt-75pct). Add parameter validation test covering MoE/EPLB, spec decode, SliceGPT/KNorm.",
       "summary_zh": "将不可执行的专用 spec 回退为非可执行草案：移除不支持的 vLLM CLI 参数（enable_alltoall、compression_plugin、enable_simllm_scheduler 等）和占位模型名（Qwen2.5-MoE-A14B-Instruct、Qwen2.5-14B-Instruct-EAGLE、Qwen2.5-14B-Instruct-slicegpt-75pct）。添加覆盖 MoE/EPLB、投机解码、SliceGPT/KNorm 的参数验证测试。"
+    },
+    {
+      "version": "1.3.1",
+      "effective_from": "2026-08-11",
+      "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
+      "supersedes": "1.3.0",
+      "summary_en": "Align the provisional prefix-repetition workload with its request count by setting eight repeated prefixes for eight prompts.",
+      "summary_zh": "将 provisional prefix-repetition workload 与请求数量对齐：8 个请求使用 8 个重复前缀。"
     }
   ]
 }

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -2,7 +2,7 @@
   "effective_from": "2026-08-11",
   "registry_version": "1.3.1",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
+  "source_set_sha256": "237b1cf782ba1f073dfa9d1a63b278414aefd92ff774857982e140a3c7799110",
   "targets": [
     {
       "baseline_runtime": {
@@ -809,7 +809,7 @@
       },
       "source_spec": {
         "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
-        "sha256": "6e65b4a46f9c9621dcd4db3f4c21eebab3dd9e26fda3da72041611a9afa06148"
+        "sha256": "cb5852a41b9395250445a5d8b54535e547bd7745c06d3dd540854451a86bf7a1"
       },
       "status": "provisional",
       "supersedes": [],
@@ -826,7 +826,7 @@
           "num_prompts": 8,
           "output_len": 64,
           "port": 8000,
-          "prefix_repetition_num_prefixes": 8,
+          "prefix_repetition_num_prefixes": 4,
           "request_rate": 1
         },
         "name": "prefix-repetition-online"

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -809,7 +809,7 @@
       },
       "source_spec": {
         "path": "docs/official-baselines/perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2.json",
-        "sha256": "41e3e89b72248b24418f320f8f498050c0a78fd177e5476d7fd4872f2a867a2d"
+        "sha256": "6e65b4a46f9c9621dcd4db3f4c21eebab3dd9e26fda3da72041611a9afa06148"
       },
       "status": "provisional",
       "supersedes": [],
@@ -825,6 +825,7 @@
           "max_concurrency": 4,
           "num_prompts": 8,
           "output_len": 64,
+          "prefix_repetition_num_prefixes": 8,
           "port": 8000,
           "request_rate": 1
         },

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -1,8 +1,8 @@
 {
-  "effective_from": "2026-08-03",
-  "registry_version": "1.3.0",
+  "effective_from": "2026-08-11",
+  "registry_version": "1.3.1",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "20e94aab3fdb09b47aa388d87bee1464e129b39bad97af34db810437a9d31c9a",
+  "source_set_sha256": "d44a084792b2a33218f19ea070870405c7684cae518a2e7ccbee77d69fda2e76",
   "targets": [
     {
       "baseline_runtime": {
@@ -20,7 +20,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -52,7 +52,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -84,7 +84,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -116,7 +116,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -147,7 +147,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -179,7 +179,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -212,7 +212,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -241,7 +241,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -270,7 +270,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -302,7 +302,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -335,7 +335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -367,7 +367,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -399,7 +399,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -428,7 +428,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -457,7 +457,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -486,7 +486,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -515,7 +515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -550,7 +550,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -583,7 +583,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -615,7 +615,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -648,7 +648,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -683,7 +683,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -716,7 +716,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -748,7 +748,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -780,7 +780,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -814,7 +814,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -825,8 +825,8 @@
           "max_concurrency": 4,
           "num_prompts": 8,
           "output_len": 64,
-          "prefix_repetition_num_prefixes": 8,
           "port": 8000,
+          "prefix_repetition_num_prefixes": 8,
           "request_rate": 1
         },
         "name": "prefix-repetition-online"
@@ -848,7 +848,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -878,7 +878,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "batch_size": 1,
@@ -906,7 +906,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -939,7 +939,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -972,7 +972,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1004,7 +1004,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1036,7 +1036,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1065,7 +1065,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1093,7 +1093,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1122,7 +1122,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1150,7 +1150,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1180,7 +1180,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1211,7 +1211,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1241,7 +1241,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1272,7 +1272,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1303,7 +1303,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-eplb-expert-rebalance-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1335,7 +1335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1366,7 +1366,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-transfer-latency-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "host": "127.0.0.1",
@@ -1394,7 +1394,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1424,7 +1424,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-moe-alltoall-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1456,7 +1456,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1486,7 +1486,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-multi-nic-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "dataset_name": "sharegpt",
@@ -1515,7 +1515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1545,7 +1545,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1577,7 +1577,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1607,7 +1607,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1639,7 +1639,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1669,7 +1669,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1701,7 +1701,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1731,7 +1731,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1763,7 +1763,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1793,7 +1793,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1824,7 +1824,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1854,7 +1854,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1885,7 +1885,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1912,7 +1912,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1943,7 +1943,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1970,7 +1970,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2001,7 +2001,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 8,
         "chip_model": "910B2",
@@ -2028,7 +2028,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2059,7 +2059,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -2089,7 +2089,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2121,7 +2121,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2151,7 +2151,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2185,7 +2185,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2215,7 +2215,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2246,7 +2246,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2277,7 +2277,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-cache-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -2309,7 +2309,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2341,7 +2341,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-attention-boundary-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2374,7 +2374,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2405,7 +2405,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-knorm-kv-compression-longctx-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2437,7 +2437,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2468,7 +2468,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2501,7 +2501,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2531,7 +2531,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2564,7 +2564,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2595,7 +2595,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-saturated-warm-cache-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2628,7 +2628,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2658,7 +2658,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-slicegpt-compression-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2690,7 +2690,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-03",
+      "effective_from": "2026-08-11",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2720,7 +2720,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-spec-decode-online-qwen25-14b-910b2",
-      "target_version": "1.3.0",
+      "target_version": "1.3.1",
       "workload": {
         "client_parameters": {
           "backend": "vllm",

--- a/src/vllm_hust_benchmark/official_targets.py
+++ b/src/vllm_hust_benchmark/official_targets.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "official-target-registry/v1"
-REGISTRY_VERSION = "1.3.0"
-EFFECTIVE_FROM = "2026-08-03"
+REGISTRY_VERSION = "1.3.1"
+EFFECTIVE_FROM = "2026-08-11"
 PUBLIC_TEXT_MODEL = "Qwen/Qwen2.5-14B-Instruct"
 PUBLIC_CODE_MODEL = "Qwen/Qwen2.5-Coder-14B-Instruct"
 PUBLIC_VISION_MODEL = "Qwen/Qwen2.5-VL-7B-Instruct"

--- a/src/vllm_hust_benchmark/official_targets.py
+++ b/src/vllm_hust_benchmark/official_targets.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from vllm_hust_benchmark.same_spec import PREFIX_REPETITION_DEFAULT_NUM_PREFIXES
+
 SCHEMA_VERSION = "official-target-registry/v1"
 REGISTRY_VERSION = "1.3.1"
 EFFECTIVE_FROM = "2026-08-11"
@@ -119,6 +121,25 @@ def _validate_public_target(spec: dict[str, Any], path: Path) -> None:
         raise ValueError(f"public target must use vLLM-Ascend v0.18.0: {path}")
 
 
+def _validate_prefix_repetition_workload(spec: dict[str, Any], path: Path) -> None:
+    client = spec["client_parameters"]
+    if client.get("dataset_name") != "prefix_repetition":
+        return
+
+    num_prompts = int(client.get("num_prompts", 0))
+    num_prefixes = int(
+        client.get(
+            "prefix_repetition_num_prefixes",
+            PREFIX_REPETITION_DEFAULT_NUM_PREFIXES,
+        )
+    )
+    if num_prompts < 1 or num_prefixes < 1 or num_prompts // num_prefixes < 2:
+        raise ValueError(
+            f"prefix-repetition target {path} must reuse each prefix at least twice: "
+            f"num_prompts={num_prompts}, num_prefixes={num_prefixes}"
+        )
+
+
 def _source_set_sha256(targets: list[dict[str, Any]]) -> str:
     sources = sorted(
         (target["source_spec"] for target in targets), key=lambda source: source["path"]
@@ -168,6 +189,7 @@ def build_registry(repo_root: Path) -> dict[str, Any]:
     targets: list[dict[str, Any]] = []
     for path in spec_paths:
         spec = _load_spec(path)
+        _validate_prefix_repetition_workload(spec, path)
         intended_use, status, profile = _classify_spec(path, spec)
         if status == "active":
             _validate_public_target(spec, path)

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -97,8 +97,7 @@ def test_perfgate_prefix_repetition_online_spec_is_available_for_ci() -> None:
     assert spec["client_parameters"]["output_len"] == 64
     assert same_spec["scenario"] == "prefix-repetition-online"
     assert (
-        same_spec["resolved_client_parameters"]["prefix_repetition_num_prefixes"]
-        == 8
+        same_spec["resolved_client_parameters"]["prefix_repetition_num_prefixes"] == 8
     )
     assert (
         same_spec["resolved_client_parameters"]["prefix_repetition_prefix_len"] == 768

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -92,9 +92,14 @@ def test_perfgate_prefix_repetition_online_spec_is_available_for_ci() -> None:
     assert spec["server_parameters"]["max_model_len"] == 1280
     assert spec["client_parameters"]["dataset_name"] == "prefix_repetition"
     assert spec["client_parameters"]["num_prompts"] == 8
+    assert spec["client_parameters"]["prefix_repetition_num_prefixes"] == 8
     assert spec["client_parameters"]["input_len"] == 1024
     assert spec["client_parameters"]["output_len"] == 64
     assert same_spec["scenario"] == "prefix-repetition-online"
+    assert (
+        same_spec["resolved_client_parameters"]["prefix_repetition_num_prefixes"]
+        == 8
+    )
     assert (
         same_spec["resolved_client_parameters"]["prefix_repetition_prefix_len"] == 768
     )

--- a/tests/test_official_baselines.py
+++ b/tests/test_official_baselines.py
@@ -92,12 +92,12 @@ def test_perfgate_prefix_repetition_online_spec_is_available_for_ci() -> None:
     assert spec["server_parameters"]["max_model_len"] == 1280
     assert spec["client_parameters"]["dataset_name"] == "prefix_repetition"
     assert spec["client_parameters"]["num_prompts"] == 8
-    assert spec["client_parameters"]["prefix_repetition_num_prefixes"] == 8
+    assert spec["client_parameters"]["prefix_repetition_num_prefixes"] == 4
     assert spec["client_parameters"]["input_len"] == 1024
     assert spec["client_parameters"]["output_len"] == 64
     assert same_spec["scenario"] == "prefix-repetition-online"
     assert (
-        same_spec["resolved_client_parameters"]["prefix_repetition_num_prefixes"] == 8
+        same_spec["resolved_client_parameters"]["prefix_repetition_num_prefixes"] == 4
     )
     assert (
         same_spec["resolved_client_parameters"]["prefix_repetition_prefix_len"] == 768

--- a/tests/test_official_targets.py
+++ b/tests/test_official_targets.py
@@ -15,6 +15,7 @@ from vllm_hust_benchmark.official_targets import (
     generated_outputs,
     render_active_targets,
 )
+from vllm_hust_benchmark.same_spec import PREFIX_REPETITION_DEFAULT_NUM_PREFIXES
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -61,6 +62,18 @@ def test_perfgate_never_appears_as_active_public_target() -> None:
     assert perfgate
     assert {target["status"] for target in perfgate} == {"provisional"}
     assert all(target["model"]["parameters"] == "3B" for target in perfgate)
+
+
+def test_prefix_repetition_targets_reuse_each_prefix_at_least_twice() -> None:
+    for target in build_registry(REPO_ROOT)["targets"]:
+        client = target["workload"]["client_parameters"]
+        if client.get("dataset_name") != "prefix_repetition":
+            continue
+        num_prefixes = client.get(
+            "prefix_repetition_num_prefixes",
+            PREFIX_REPETITION_DEFAULT_NUM_PREFIXES,
+        )
+        assert client["num_prompts"] // num_prefixes >= 2
 
 
 def test_source_spec_hashes_match() -> None:


### PR DESCRIPTION
## Summary

  Fix the provisional `prefix-repetition-online` perfgate profile so that its workload configuration is self-consistent.

  The profile previously configured:

  - `num_prompts=8`
  - default `prefix_repetition_num_prefixes=10`

  This could fail deterministically because the workload requested fewer prompts than configured prefixes. The profile
  now explicitly sets `prefix_repetition_num_prefixes=8`.

  This change also:

  - updates the generated official target registries and SHA snapshots;
  - adds official target registry version `1.3.1`;
  - updates the English and Chinese target documentation and changelog;
  - adds regression assertions for the raw and resolved prefix count.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - `PYTHONPATH=/tmp/vllm-benchmark-mdformat:src:. pytest --noconftest -q tests/test_official_targets.py tests/
  test_workload_config_contract.py tests/test_specialty_spec_params.py`
    - `35 passed`
  - `PYTHONPATH=/tmp/vllm-benchmark-mdformat:src python3 -m vllm_hust_benchmark.official_targets --check`
    - passed
  - `PYTHONPATH=/tmp/vllm-benchmark-mdformat:src:. pytest --noconftest -q`
    - `1295 passed, 11 skipped`
    - 6 failures are limited to macOS PID/process-tree environment tests:
      - `tests/test_prepare_official_env_script.py`
      - `tests/test_retest_issue_151_harness.py`
  - `git diff --check`
    - passed

  No Ascend hardware benchmark, publication, or HF upload was executed.

  ## Risks

  - This is a benchmark-spec and registry metadata change; it does not change model runtime code.
  - The registry version is global, so generated target metadata moves from `1.3.0` to `1.3.1` for all registry entries.
  This is required by the registry version-history contract when an official spec changes.
  - Hardware E2E validation remains pending and must be performed separately after the relevant benchmark changes are
  merged.
  - Existing historical artifacts are not modified or reclassified by this PR.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.