### PR TITLE
fix: bind official baseline runs to immutable source provenance

### DIFF
--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -42,7 +42,7 @@ name: Run Official Ascend Baselines
         description: Publish promoted official canonical submissions to vllm-hust-benchmark@main and refresh live leaderboard snapshots.
         required: false
         type: boolean
-        default: true
+        default: false
       force_repair_official_env:
         description: Skip the prepare-script health check and force a full repair/reinstall of the official env.
         required: false

--- a/.github/workflows/run-official-ascend-baselines.yml
+++ b/.github/workflows/run-official-ascend-baselines.yml
@@ -39,7 +39,7 @@ name: Run Official Ascend Baselines
         type: boolean
         default: false
       publish_results:
-        description: Publish promoted official canonical submissions to vllm-hust-benchmark@main and refresh live leaderboard snapshots.
+        description: Publish promoted official canonical submissions to vllm-hust-benchmark@main and refresh live leaderboard snapshots (opt-in; default is disabled).
         required: false
         type: boolean
         default: false

--- a/.github/workflows/scripts/sync_official_baseline_snapshots_to_github.sh
+++ b/.github/workflows/scripts/sync_official_baseline_snapshots_to_github.sh
@@ -425,8 +425,14 @@ for attempt in $(seq 1 "$SNAPSHOT_MAX_PUSH_ATTEMPTS"); do
       write_github_env GITHUB_SNAPSHOT_SYNC_STATUS unchanged
       write_github_env GITHUB_SNAPSHOT_SYNC_COMMIT "$remote_commit"
       write_publication_identity
-      verify_published_state "$remote_commit"
-      exit 0
+      if verify_published_state "$remote_commit"; then
+        exit 0
+      else
+        verification_status=$?
+        write_github_env GITHUB_SNAPSHOT_SYNC_VERIFICATION failed
+        echo "official baseline publication unchanged, but verification failed for $remote_commit" >&2
+        exit "$verification_status"
+      fi
     fi
     write_github_env GITHUB_SNAPSHOT_SYNC_STATUS rejected
     exit "$prepare_status"
@@ -434,4 +440,5 @@ for attempt in $(seq 1 "$SNAPSHOT_MAX_PUSH_ATTEMPTS"); do
 done
 
 echo "failed to push official baseline publication after $SNAPSHOT_MAX_PUSH_ATTEMPTS attempts" >&2
+write_github_env GITHUB_SNAPSHOT_SYNC_STATUS failed
 exit 1

--- a/.github/workflows/scripts/sync_official_baseline_snapshots_to_github.sh
+++ b/.github/workflows/scripts/sync_official_baseline_snapshots_to_github.sh
@@ -12,6 +12,8 @@ SNAPSHOT_SOURCE_PATTERN=${SNAPSHOT_SOURCE_PATTERN:-official-ascend-*}
 ALLOW_EMPTY_SNAPSHOT_SOURCE=${ALLOW_EMPTY_SNAPSHOT_SOURCE:-0}
 SNAPSHOT_MAX_PUSH_ATTEMPTS=${SNAPSHOT_MAX_PUSH_ATTEMPTS:-4}
 SNAPSHOT_PUSH_RETRY_SECONDS=${SNAPSHOT_PUSH_RETRY_SECONDS:-5}
+SNAPSHOT_MAX_FETCH_ATTEMPTS=${SNAPSHOT_MAX_FETCH_ATTEMPTS:-4}
+SNAPSHOT_FETCH_RETRY_SECONDS=${SNAPSHOT_FETCH_RETRY_SECONDS:-5}
 SNAPSHOT_COMMIT_MESSAGE=${SNAPSHOT_COMMIT_MESSAGE:-chore(data): publish official ascend baseline snapshots}
 GIT_COMMITTER_NAME=${GIT_COMMITTER_NAME:-vLLM-HUST Benchmark Bot}
 GIT_COMMITTER_EMAIL=${GIT_COMMITTER_EMAIL:-benchmark-bot@vllm-hust.local}
@@ -19,8 +21,16 @@ BENCHMARK_REPO_REMOTE=${BENCHMARK_REPO_REMOTE:-origin}
 BENCHMARK_REPO_SLUG=${BENCHMARK_REPO_SLUG:-vLLM-HUST/vllm-hust-benchmark}
 BENCHMARK_REPO_GH_TOKEN=${BENCHMARK_REPO_GH_TOKEN:-}
 BENCHMARK_REPO_SSH_KEY=${BENCHMARK_REPO_SSH_KEY:-}
+ARTIFACT_VALIDATOR=${ARTIFACT_VALIDATOR:-$SOURCE_BENCHMARK_REPO_DIR/scripts/validate-run-artifact.sh}
 
-required_submission_files=(leaderboard_manifest.json run_leaderboard.json)
+required_submission_files=(
+  leaderboard_manifest.json
+  run_leaderboard.json
+  env-manifest.json
+  pip-packages.json
+  checksums.sha256
+  STATUS
+)
 required_snapshot_files=(
   leaderboard_single.json
   leaderboard_multi.json
@@ -35,6 +45,42 @@ write_github_env() {
     printf '%s=%s\n' "$key" "$value" >>"$GITHUB_ENV"
   fi
 }
+
+validate_retry_configuration() {
+  case "$SNAPSHOT_MAX_FETCH_ATTEMPTS" in
+    ''|*[!0-9]*|0*)
+      echo "SNAPSHOT_MAX_FETCH_ATTEMPTS must be a positive integer" >&2
+      return 2
+      ;;
+  esac
+  case "$SNAPSHOT_FETCH_RETRY_SECONDS" in
+    ''|*[!0-9]*)
+      echo "SNAPSHOT_FETCH_RETRY_SECONDS must be a non-negative integer" >&2
+      return 2
+      ;;
+  esac
+}
+
+fetch_target_branch_with_retry() {
+  local phase=$1
+  local attempt=1
+
+  while (( attempt <= SNAPSHOT_MAX_FETCH_ATTEMPTS )); do
+    if git -C "$TARGET_BENCHMARK_REPO_DIR" fetch \
+      "$BENCHMARK_REPO_REMOTE" "$SNAPSHOT_TARGET_BRANCH"; then
+      return 0
+    fi
+    if (( attempt == SNAPSHOT_MAX_FETCH_ATTEMPTS )); then
+      echo "official baseline publication ${phase} fetch failed after ${SNAPSHOT_MAX_FETCH_ATTEMPTS} attempts" >&2
+      return 1
+    fi
+    echo "official baseline publication ${phase} fetch failed; retrying in ${SNAPSHOT_FETCH_RETRY_SECONDS}s (attempt $attempt/$SNAPSHOT_MAX_FETCH_ATTEMPTS)" >&2
+    sleep "$SNAPSHOT_FETCH_RETRY_SECONDS"
+    attempt=$((attempt + 1))
+  done
+}
+
+validate_retry_configuration
 
 configure_push_remote() {
   local remote_url=
@@ -74,6 +120,11 @@ if [[ ! -f "$WEBSITE_REPO_DIR/scripts/aggregate_results.py" ]]; then
   exit 2
 fi
 
+if [[ ! -f "$ARTIFACT_VALIDATOR" ]]; then
+  echo "artifact validator not found: $ARTIFACT_VALIDATOR" >&2
+  exit 2
+fi
+
 if [[ "${GITHUB_ACTIONS:-}" != "true" && "${ALLOW_LOCAL_GIT_RESET:-0}" != "1" ]]; then
   echo "refusing to reset a local checkout outside GitHub Actions; set ALLOW_LOCAL_GIT_RESET=1 to override" >&2
   exit 2
@@ -100,9 +151,32 @@ for source_submission_dir in "${source_submission_dirs[@]}"; do
       exit 2
     fi
   done
+  if [[ "$(tr -d '[:space:]' < "$source_submission_dir/STATUS")" != "OK" ]]; then
+    echo "source submission STATUS is not OK: $source_submission_dir/STATUS" >&2
+    exit 2
+  fi
+  if ! bash "$ARTIFACT_VALIDATOR" "$source_submission_dir"; then
+    echo "source submission artifact validation failed: $source_submission_dir" >&2
+    exit 2
+  fi
 done
 
 relative_snapshot_dir="leaderboard-data/snapshots"
+publication_staging_dir=$(mktemp -d "$TARGET_BENCHMARK_REPO_DIR/.official-publication.XXXXXX")
+staged_submission_dir="$publication_staging_dir/submissions"
+staged_snapshot_dir="$publication_staging_dir/snapshots"
+
+# Invoked indirectly by the EXIT trap below.
+# shellcheck disable=SC2317,SC2329
+cleanup_publication_staging() {
+  rm -rf "$publication_staging_dir"
+}
+trap cleanup_publication_staging EXIT
+
+reset_publication_staging() {
+  rm -rf "$publication_staging_dir" || return $?
+  mkdir -p "$publication_staging_dir" || return $?
+}
 
 git -C "$TARGET_BENCHMARK_REPO_DIR" config user.name "$GIT_COMMITTER_NAME"
 git -C "$TARGET_BENCHMARK_REPO_DIR" config user.email "$GIT_COMMITTER_EMAIL"
@@ -115,68 +189,247 @@ prepare_publication_commit() {
   local target_submission_dir
   local file_name
 
-  git -C "$TARGET_BENCHMARK_REPO_DIR" fetch "$BENCHMARK_REPO_REMOTE" "$SNAPSHOT_TARGET_BRANCH"
-  git -C "$TARGET_BENCHMARK_REPO_DIR" checkout -B "$SNAPSHOT_TARGET_BRANCH" "$BENCHMARK_REPO_REMOTE/$SNAPSHOT_TARGET_BRANCH"
+  reset_publication_staging || return $?
+  fetch_target_branch_with_retry prepare || return $?
+  git -C "$TARGET_BENCHMARK_REPO_DIR" checkout -B "$SNAPSHOT_TARGET_BRANCH" "$BENCHMARK_REPO_REMOTE/$SNAPSHOT_TARGET_BRANCH" || return $?
 
-  mkdir -p "$TARGET_BENCHMARK_REPO_DIR/submissions"
+  mkdir -p "$staged_submission_dir" || return $?
+  if [[ -d "$TARGET_BENCHMARK_REPO_DIR/submissions" ]]; then
+    cp -a "$TARGET_BENCHMARK_REPO_DIR/submissions/." "$staged_submission_dir/" || return $?
+  fi
+  for source_submission_dir in "${source_submission_dirs[@]}"; do
+    run_id=$(basename "$source_submission_dir")
+    target_submission_dir="$staged_submission_dir/$run_id"
+    relative_submission_paths+=("submissions/$run_id")
+
+    rm -rf "$target_submission_dir" || return $?
+    mkdir -p "$target_submission_dir" || return $?
+    for file_name in "${required_submission_files[@]}"; do
+      cp "$source_submission_dir/$file_name" "$target_submission_dir/$file_name" || return $?
+    done
+  done
+
+  VLLM_HUST_BENCHMARK_REPO="$TARGET_BENCHMARK_REPO_DIR" \
+  VLLM_HUST_WEBSITE_REPO="$WEBSITE_REPO_DIR" \
+  PYTHONPATH="$TARGET_BENCHMARK_REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}" \
+    "$PYTHON_BIN" -m vllm_hust_benchmark.cli publish-website \
+      --source-dir "$staged_submission_dir" \
+      --output-dir "$staged_snapshot_dir" \
+      --execute || return $?
+
+  for file_name in "${required_snapshot_files[@]}"; do
+    if [[ ! -f "$staged_snapshot_dir/$file_name" ]]; then
+      echo "missing generated snapshot file: $staged_snapshot_dir/$file_name" >&2
+      return 2
+    fi
+  done
+
+  if ! PYTHONPATH="$TARGET_BENCHMARK_REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}" \
+    "$PYTHON_BIN" "$TARGET_BENCHMARK_REPO_DIR/scripts/validate_public_leaderboard_snapshots.py" \
+    --snapshot-dir "$staged_snapshot_dir"; then
+    echo "official baseline publication failed at public snapshot validation" >&2
+    return 2
+  fi
+  if ! PYTHONPATH="$TARGET_BENCHMARK_REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}" \
+    "$PYTHON_BIN" - "$staged_snapshot_dir" <<'PY'
+import sys
+from pathlib import Path
+
+from vllm_hust_benchmark.integration import validate_public_snapshot_trend_admission
+
+validate_public_snapshot_trend_admission(Path(sys.argv[1]))
+PY
+  then
+    echo "official baseline publication failed at trend validation" >&2
+    return 2
+  fi
+
+  mkdir -p "$TARGET_BENCHMARK_REPO_DIR/submissions" "$SNAPSHOT_OUTPUT_DIR" || return $?
   for source_submission_dir in "${source_submission_dirs[@]}"; do
     run_id=$(basename "$source_submission_dir")
     target_submission_dir="$TARGET_BENCHMARK_REPO_DIR/submissions/$run_id"
-    relative_submission_paths+=("submissions/$run_id")
-
-    rm -rf "$target_submission_dir"
-    cp -a "$source_submission_dir" "$target_submission_dir"
+    rm -rf "$target_submission_dir" || return $?
+    mkdir -p "$target_submission_dir" || return $?
+    for file_name in "${required_submission_files[@]}"; do
+      cp "$source_submission_dir/$file_name" "$target_submission_dir/$file_name" || return $?
+    done
   done
-
-  mkdir -p "$SNAPSHOT_OUTPUT_DIR"
   for file_name in "${required_snapshot_files[@]}"; do
-    rm -f "$SNAPSHOT_OUTPUT_DIR/$file_name"
-  done
-
-  "$PYTHON_BIN" "$WEBSITE_REPO_DIR/scripts/aggregate_results.py" \
-    --source-dir "$TARGET_BENCHMARK_REPO_DIR/submissions" \
-    --output-dir "$SNAPSHOT_OUTPUT_DIR"
-
-  for file_name in "${required_snapshot_files[@]}"; do
-    if [[ ! -f "$SNAPSHOT_OUTPUT_DIR/$file_name" ]]; then
-      echo "missing generated snapshot file: $SNAPSHOT_OUTPUT_DIR/$file_name" >&2
-      exit 2
-    fi
+    cp "$staged_snapshot_dir/$file_name" "$SNAPSHOT_OUTPUT_DIR/$file_name" || return $?
   done
 
   if [[ -n "$LOCAL_SNAPSHOT_OUTPUT_DIR" ]]; then
     mkdir -p "$LOCAL_SNAPSHOT_OUTPUT_DIR"
     for file_name in "${required_snapshot_files[@]}"; do
-      cp "$SNAPSHOT_OUTPUT_DIR/$file_name" "$LOCAL_SNAPSHOT_OUTPUT_DIR/$file_name"
+      cp "$SNAPSHOT_OUTPUT_DIR/$file_name" "$LOCAL_SNAPSHOT_OUTPUT_DIR/$file_name" || return $?
     done
   fi
 
-  git -C "$TARGET_BENCHMARK_REPO_DIR" add "${relative_submission_paths[@]}" "$relative_snapshot_dir"
+  git -C "$TARGET_BENCHMARK_REPO_DIR" add "${relative_submission_paths[@]}" "$relative_snapshot_dir" || return $?
   if git -C "$TARGET_BENCHMARK_REPO_DIR" diff --cached --quiet; then
+    return 3
+  else
+    diff_status=$?
+    if [[ "$diff_status" -ne 1 ]]; then
+      return "$diff_status"
+    fi
+  fi
+
+  git -C "$TARGET_BENCHMARK_REPO_DIR" commit -m "$SNAPSHOT_COMMIT_MESSAGE" || return $?
+}
+
+verify_published_state() {
+  local expected_commit=$1
+  local verified_commit
+  local source_submission_dir
+  local run_id
+  local file_name
+  local checksum_file
+  local expected_digest
+  local relative_path
+  local remote_path
+  local local_digest
+  local remote_blob
+
+  compare_remote_file() {
+    local commit=$1
+    local path=$2
+    local expected_file=$3
+    if ! git -C "$TARGET_BENCHMARK_REPO_DIR" cat-file -e "$commit:$path"; then
+      echo "official baseline publication verification failed: missing $path" >&2
+      return 1
+    fi
+    remote_blob=$(mktemp)
+    if ! git -C "$TARGET_BENCHMARK_REPO_DIR" show "$commit:$path" >"$remote_blob"; then
+      rm -f "$remote_blob"
+      echo "official baseline publication verification failed: unable to read $path" >&2
+      return 1
+    fi
+    if ! cmp -s "$expected_file" "$remote_blob"; then
+      rm -f "$remote_blob"
+      echo "official baseline publication verification failed: content mismatch for $path" >&2
+      return 1
+    fi
+    rm -f "$remote_blob"
+  }
+
+  fetch_target_branch_with_retry verify || return $?
+  verified_commit=$(git -C "$TARGET_BENCHMARK_REPO_DIR" rev-parse "$BENCHMARK_REPO_REMOTE/$SNAPSHOT_TARGET_BRANCH") || return $?
+  if [[ "$verified_commit" != "$expected_commit" ]]; then
+    echo "official baseline publication verification failed: expected $expected_commit, got $verified_commit" >&2
     return 1
   fi
 
-  git -C "$TARGET_BENCHMARK_REPO_DIR" commit -m "$SNAPSHOT_COMMIT_MESSAGE"
+  for source_submission_dir in "${source_submission_dirs[@]}"; do
+    run_id=$(basename "$source_submission_dir")
+    for file_name in "${required_submission_files[@]}"; do
+      compare_remote_file \
+        "$verified_commit" \
+        "submissions/$run_id/$file_name" \
+        "$source_submission_dir/$file_name" || return 1
+    done
+    checksum_file="$source_submission_dir/checksums.sha256"
+    while read -r expected_digest relative_path _; do
+      [[ -z "$expected_digest" && -z "$relative_path" ]] && continue
+      relative_path=${relative_path#./}
+      if [[ ! "$expected_digest" =~ ^[[:xdigit:]]{64}$ ]] || [[ -z "$relative_path" ]] ||
+        [[ "$relative_path" = /* ]] || [[ "$relative_path" == *".."* ]]; then
+        echo "official baseline publication verification failed: invalid checksum entry in $checksum_file" >&2
+        return 1
+      fi
+      remote_path="submissions/$run_id/$relative_path"
+      if [[ ! -f "$source_submission_dir/$relative_path" ]]; then
+        echo "official baseline publication verification failed: checksum references missing local file $relative_path" >&2
+        return 1
+      fi
+      local_digest=$(sha256sum "$source_submission_dir/$relative_path" | awk '{print $1}')
+      if [[ "$local_digest" != "$expected_digest" ]]; then
+        echo "official baseline publication verification failed: local checksum mismatch for $relative_path" >&2
+        return 1
+      fi
+      remote_blob=$(mktemp)
+      if ! git -C "$TARGET_BENCHMARK_REPO_DIR" cat-file -e "$verified_commit:$remote_path" ||
+        ! git -C "$TARGET_BENCHMARK_REPO_DIR" show "$verified_commit:$remote_path" >"$remote_blob"; then
+        rm -f "$remote_blob"
+        echo "official baseline publication verification failed: missing $remote_path" >&2
+        return 1
+      fi
+      local_digest=$(sha256sum "$remote_blob" | awk '{print $1}')
+      rm -f "$remote_blob"
+      if [[ "$local_digest" != "$expected_digest" ]]; then
+        echo "official baseline publication verification failed: remote checksum mismatch for $remote_path" >&2
+        return 1
+      fi
+    done < "$checksum_file"
+  done
+  for file_name in "${required_snapshot_files[@]}"; do
+    compare_remote_file \
+      "$verified_commit" \
+      "$relative_snapshot_dir/$file_name" \
+      "$staged_snapshot_dir/$file_name" || return 1
+  done
+
+  write_github_env GITHUB_SNAPSHOT_SYNC_VERIFICATION verified
+  write_github_env GITHUB_SNAPSHOT_SYNC_VERIFIED_COMMIT "$verified_commit"
+  echo "Verified official baseline publication at ${BENCHMARK_REPO_SLUG}@${SNAPSHOT_TARGET_BRANCH}: $verified_commit"
+}
+
+write_publication_identity() {
+  local submission_paths=""
+  local source_submission_dir
+  local run_id
+
+  for source_submission_dir in "${source_submission_dirs[@]}"; do
+    run_id=$(basename "$source_submission_dir")
+    if [[ -n "$submission_paths" ]]; then
+      submission_paths+=","
+    fi
+    submission_paths+="submissions/$run_id"
+  done
+
+  write_github_env GITHUB_SNAPSHOT_SYNC_REPO "$BENCHMARK_REPO_SLUG"
+  write_github_env GITHUB_SNAPSHOT_SYNC_BRANCH "$SNAPSHOT_TARGET_BRANCH"
+  write_github_env GITHUB_SNAPSHOT_SYNC_SUBMISSION_PATHS "$submission_paths"
+  write_github_env GITHUB_SNAPSHOT_SYNC_SNAPSHOT_PATH "$relative_snapshot_dir"
 }
 
 for attempt in $(seq 1 "$SNAPSHOT_MAX_PUSH_ATTEMPTS"); do
-  if ! prepare_publication_commit; then
-    echo "Official baseline publication is already up to date on ${BENCHMARK_REPO_SLUG}@${SNAPSHOT_TARGET_BRANCH}"
-    write_github_env GITHUB_SNAPSHOT_SYNC_STATUS unchanged
-    exit 0
-  fi
+  if prepare_publication_commit; then
+    snapshot_commit=$(git -C "$TARGET_BENCHMARK_REPO_DIR" rev-parse HEAD)
+    if git -C "$TARGET_BENCHMARK_REPO_DIR" push "$BENCHMARK_REPO_REMOTE" "HEAD:$SNAPSHOT_TARGET_BRANCH"; then
+      write_github_env GITHUB_SNAPSHOT_SYNC_STATUS pushed
+      write_github_env GITHUB_SNAPSHOT_SYNC_COMMIT "$snapshot_commit"
+      write_publication_identity
+      if verify_published_state "$snapshot_commit"; then
+        echo "Pushed official baseline publication to ${BENCHMARK_REPO_SLUG}@${SNAPSHOT_TARGET_BRANCH}: $snapshot_commit"
+      else
+        verification_status=$?
+        write_github_env GITHUB_SNAPSHOT_SYNC_VERIFICATION failed
+        echo "official baseline publication push succeeded, but verification failed for $snapshot_commit" >&2
+        exit "$verification_status"
+      fi
+      exit 0
+    fi
 
-  snapshot_commit=$(git -C "$TARGET_BENCHMARK_REPO_DIR" rev-parse HEAD)
-  if git -C "$TARGET_BENCHMARK_REPO_DIR" push "$BENCHMARK_REPO_REMOTE" "HEAD:$SNAPSHOT_TARGET_BRANCH"; then
-    echo "Pushed official baseline publication to ${BENCHMARK_REPO_SLUG}@${SNAPSHOT_TARGET_BRANCH}: $snapshot_commit"
-    write_github_env GITHUB_SNAPSHOT_SYNC_STATUS pushed
-    write_github_env GITHUB_SNAPSHOT_SYNC_COMMIT "$snapshot_commit"
-    exit 0
-  fi
-
-  if [[ "$attempt" -lt "$SNAPSHOT_MAX_PUSH_ATTEMPTS" ]]; then
-    echo "official baseline publication push failed; retrying with fresh ${BENCHMARK_REPO_REMOTE}/${SNAPSHOT_TARGET_BRANCH} in ${SNAPSHOT_PUSH_RETRY_SECONDS}s (attempt $attempt/$SNAPSHOT_MAX_PUSH_ATTEMPTS)" >&2
-    sleep "$SNAPSHOT_PUSH_RETRY_SECONDS"
+    if [[ "$attempt" -lt "$SNAPSHOT_MAX_PUSH_ATTEMPTS" ]]; then
+      echo "official baseline publication push failed; retrying with fresh ${BENCHMARK_REPO_REMOTE}/${SNAPSHOT_TARGET_BRANCH} in ${SNAPSHOT_PUSH_RETRY_SECONDS}s (attempt $attempt/$SNAPSHOT_MAX_PUSH_ATTEMPTS)" >&2
+      sleep "$SNAPSHOT_PUSH_RETRY_SECONDS"
+      continue
+    fi
+    break
+  else
+    prepare_status=$?
+    if [[ "$prepare_status" -eq 3 ]]; then
+      remote_commit=$(git -C "$TARGET_BENCHMARK_REPO_DIR" rev-parse "$BENCHMARK_REPO_REMOTE/$SNAPSHOT_TARGET_BRANCH")
+      echo "Official baseline publication is already up to date on ${BENCHMARK_REPO_SLUG}@${SNAPSHOT_TARGET_BRANCH}"
+      write_github_env GITHUB_SNAPSHOT_SYNC_STATUS unchanged
+      write_github_env GITHUB_SNAPSHOT_SYNC_COMMIT "$remote_commit"
+      write_publication_identity
+      verify_published_state "$remote_commit"
+      exit 0
+    fi
+    write_github_env GITHUB_SNAPSHOT_SYNC_STATUS rejected
+    exit "$prepare_status"
   fi
 done
 

--- a/scripts/capture-official-source-provenance.py
+++ b/scripts/capture-official-source-provenance.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Capture immutable and working-tree provenance for an official source checkout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run(repo: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _tree_digest(repo: Path) -> tuple[str, int, int]:
+    paths = _run(repo, "ls-files", "-co", "--exclude-standard", "-z").split(b"\0")
+    entries: list[bytes] = []
+    tracked = 0
+    untracked = 0
+    for raw_path in sorted(path for path in paths if path):
+        path = repo / os.fsdecode(raw_path)
+        if not path.is_file():
+            continue
+        if b"\0" in raw_path:
+            raise ValueError("source path contains NUL")
+        status = _run(repo, "ls-files", "--stage", "--", os.fsdecode(raw_path))
+        if status:
+            tracked += 1
+        else:
+            untracked += 1
+        digest = hashlib.sha256(path.read_bytes()).hexdigest().encode("ascii")
+        entries.append(raw_path + b"\t" + digest + b"\n")
+    return _sha256(b"".join(entries)), tracked, untracked
+
+
+def capture(repo: Path, requested_ref: str, repository: str) -> dict[str, object]:
+    if not (repo / ".git").exists() and not (repo / "HEAD").exists():
+        raise ValueError(f"not a git worktree: {repo}")
+    observed_commit = (
+        _run(repo, "rev-parse", "--verify", "HEAD^{commit}").decode().strip()
+    )
+    patch = _run(repo, "diff", "--binary", "HEAD")
+    status = _run(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    tree_digest, tracked_count, untracked_count = _tree_digest(repo)
+    return {
+        "schema_version": "official-source-provenance/v1",
+        "repository": repository,
+        "requested_ref": requested_ref,
+        "observed_commit": observed_commit,
+        "tracked_patch_sha256": _sha256(patch),
+        "working_tree_sha256": tree_digest,
+        "status": "clean" if not status else "modified",
+        "tracked_file_count": tracked_count,
+        "untracked_file_count": untracked_count,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repo", type=Path)
+    parser.add_argument("requested_ref")
+    parser.add_argument("repository")
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    payload = capture(args.repo, args.requested_ref, args.repository)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture-official-source-provenance.py
+++ b/scripts/capture-official-source-provenance.py
@@ -25,25 +25,44 @@ def _sha256(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _tree_digest(repo: Path) -> tuple[str, int, int]:
-    paths = _run(repo, "ls-files", "-co", "--exclude-standard", "-z").split(b"\0")
+def _tree_digest(repo: Path) -> tuple[str, int, int, int]:
+    paths = set(
+        path
+        for path in _run(repo, "ls-files", "-co", "--exclude-standard", "-z").split(
+            b"\0"
+        )
+        if path
+    )
+    tracked_paths = set(paths)
+    generated_paths = {b"vllm_ascend/_build_info.py"}
+    generated_paths.update(
+        os.fsencode(path.relative_to(repo))
+        for pattern in ("vllm-*.dist-info/*", "vllm_ascend-*.dist-info/*")
+        for path in repo.glob(pattern)
+        if path.is_file()
+    )
+    paths.update(
+        path for path in generated_paths if (repo / os.fsdecode(path)).is_file()
+    )
     entries: list[bytes] = []
     tracked = 0
     untracked = 0
-    for raw_path in sorted(path for path in paths if path):
+    generated = 0
+    for raw_path in sorted(paths):
         path = repo / os.fsdecode(raw_path)
         if not path.is_file():
             continue
         if b"\0" in raw_path:
             raise ValueError("source path contains NUL")
-        status = _run(repo, "ls-files", "--stage", "--", os.fsdecode(raw_path))
-        if status:
+        if raw_path in tracked_paths:
             tracked += 1
         else:
             untracked += 1
+            if raw_path in generated_paths:
+                generated += 1
         digest = hashlib.sha256(path.read_bytes()).hexdigest().encode("ascii")
         entries.append(raw_path + b"\t" + digest + b"\n")
-    return _sha256(b"".join(entries)), tracked, untracked
+    return _sha256(b"".join(entries)), tracked, untracked, generated
 
 
 def capture(repo: Path, requested_ref: str, repository: str) -> dict[str, object]:
@@ -54,7 +73,7 @@ def capture(repo: Path, requested_ref: str, repository: str) -> dict[str, object
     )
     patch = _run(repo, "diff", "--binary", "HEAD")
     status = _run(repo, "status", "--porcelain=v1", "--untracked-files=all")
-    tree_digest, tracked_count, untracked_count = _tree_digest(repo)
+    tree_digest, tracked_count, untracked_count, generated_count = _tree_digest(repo)
     return {
         "schema_version": "official-source-provenance/v1",
         "repository": repository,
@@ -62,9 +81,10 @@ def capture(repo: Path, requested_ref: str, repository: str) -> dict[str, object
         "observed_commit": observed_commit,
         "tracked_patch_sha256": _sha256(patch),
         "working_tree_sha256": tree_digest,
-        "status": "clean" if not status else "modified",
+        "status": "clean" if not status and generated_count == 0 else "modified",
         "tracked_file_count": tracked_count,
         "untracked_file_count": untracked_count,
+        "generated_file_count": generated_count,
     }
 
 

--- a/scripts/collect-run-artifact.sh
+++ b/scripts/collect-run-artifact.sh
@@ -139,6 +139,16 @@ observed_core_commit = _git_commit(_env("CURRENT_VLLM_HUST_REPO"))
 observed_backend_commit = _git_commit(_env("CURRENT_VLLM_ASCEND_HUST_REPO"))
 package_versions = _runtime_package_versions()
 
+official_source_provenance = {}
+provenance_path = os.environ.get("OFFICIAL_SOURCE_PROVENANCE_FILE", "")
+if provenance_path:
+    try:
+        candidate = json.loads(Path(provenance_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        candidate = None
+    if isinstance(candidate, dict):
+        official_source_provenance = candidate
+
 manifest = {
     "manifest_version": "run-env-manifest/v2",
     "collected_at": _run(["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"]),
@@ -192,6 +202,8 @@ manifest = {
         "benchmark": _git_commit(_env("BENCHMARK_REPO_ROOT")),
     },
 }
+if official_source_provenance:
+    manifest["official_source_provenance"] = official_source_provenance
 
 # Use the explicit pip-packages.json file rather than embedding a second copy
 manifest["pip_packages"] = "see pip-packages.json"

--- a/scripts/run-official-ascend-goal-baseline-matrix.sh
+++ b/scripts/run-official-ascend-goal-baseline-matrix.sh
@@ -26,11 +26,13 @@ PREPARE_OFFICIAL_ENV=${PREPARE_OFFICIAL_ENV:-1}
 READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-900}
 SUMMARY_FILE=${MATRIX_SUMMARY_FILE:-"$MATRIX_RESULT_ROOT/summary.md"}
 MATRIX_DEVICE_PREFERENCE_FILE=${MATRIX_DEVICE_PREFERENCE_FILE:-"$MATRIX_RESULT_ROOT/preferred-ascend-device"}
+OFFICIAL_SOURCE_WORKTREE_ROOT=${OFFICIAL_SOURCE_WORKTREE_ROOT:-"${TMPDIR:-/tmp}/vllm-hust-official-worktrees"}
 PYTHON_BIN=${PYTHON_BIN:-$(command -v python3 || true)}
 PUBLICATION_SYNC_HELPER=${PUBLICATION_SYNC_HELPER:-}
 PUBLICATION_COMMIT_MESSAGE_PREFIX=${PUBLICATION_COMMIT_MESSAGE_PREFIX:-"chore(data): publish official ascend baseline"}
 VALIDATE_ARTIFACT_SCRIPT=${VALIDATE_ARTIFACT_SCRIPT:-"$SCRIPT_DIR/validate-run-artifact.sh"}
 PREPARED_ENV=0
+PREPARED_SOURCE_TUPLE=""
 SKIPPED_COUNT=0
 RUN_COUNT=0
 PROMOTED_COUNT=0
@@ -180,16 +182,33 @@ PY
 }
 
 prepare_official_env_once() {
-  if [[ "$PREPARED_ENV" == "1" ]] || [[ "$PREPARE_OFFICIAL_ENV" != "1" ]]; then
+  local source_tuple=$1
+  local source_core_ref
+  local source_backend_ref
+  local source_slug
+  local source_worktree_root
+
+  if [[ "$PREPARED_SOURCE_TUPLE" == "$source_tuple" ]] || [[ "$PREPARE_OFFICIAL_ENV" != "1" ]]; then
     return 0
   fi
 
-  echo "[official-baseline-matrix] preparing official baseline environment: $GOAL_BASELINE_ENV_PREFIX"
+  IFS=$'\t' read -r source_core_ref source_backend_ref <<< "$source_tuple"
+  source_slug=$(printf '%s-%s' "$source_core_ref" "$source_backend_ref" | sed -E 's/[^A-Za-z0-9_.-]+/-/g')
+  source_worktree_root="$OFFICIAL_SOURCE_WORKTREE_ROOT/$source_slug"
+  mkdir -p "$source_worktree_root"
+
+  export OFFICIAL_VLLM_REF="$source_core_ref"
+  export OFFICIAL_VLLM_ASCEND_REF="$source_backend_ref"
+  export OFFICIAL_VLLM_WORKTREE="$source_worktree_root/vllm"
+  export OFFICIAL_VLLM_ASCEND_WORKTREE="$source_worktree_root/vllm-ascend"
+
+  echo "[official-baseline-matrix] preparing official baseline environment: $GOAL_BASELINE_ENV_PREFIX (source tuple=$source_tuple)"
   ENV_PREFIX="$GOAL_BASELINE_ENV_PREFIX" \
   BENCHMARK_SERVER_PORT="${OFFICIAL_SERVER_PORT:-8000}" \
   VLLM_HUST_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
   bash "$PREPARE_SCRIPT"
   PREPARED_ENV=1
+  PREPARED_SOURCE_TUPLE="$source_tuple"
 }
 
 promote_submission_to_canonical() {
@@ -438,17 +457,6 @@ if [[ ${#SPEC_FILES[@]} -eq 0 ]]; then
   exit 2
 fi
 
-SOURCE_TUPLE=""
-for spec_file in "${SPEC_FILES[@]}"; do
-  spec_source_tuple=$(resolve_source_tuple "$spec_file")
-  if [[ -z "$SOURCE_TUPLE" ]]; then
-    SOURCE_TUPLE="$spec_source_tuple"
-  elif [[ "$spec_source_tuple" != "$SOURCE_TUPLE" ]]; then
-    echo "Official baseline matrix contains mixed source tuples: $SOURCE_TUPLE vs $spec_source_tuple ($spec_file)" >&2
-    exit 2
-  fi
-done
-
 echo "[official-baseline-matrix] result root: $MATRIX_RESULT_ROOT"
 echo "[official-baseline-matrix] canonical submissions root: $CANONICAL_SUBMISSIONS_ROOT"
 echo "[official-baseline-matrix] sticky Ascend device preference file: $MATRIX_DEVICE_PREFERENCE_FILE"
@@ -460,7 +468,7 @@ append_summary "- Sticky Ascend device preference file: $MATRIX_DEVICE_PREFERENC
 append_summary "- Existing canonical submissions root: $EXISTING_CANONICAL_SUBMISSIONS_ROOT"
 append_summary "- Force rerun existing canonical: $FORCE_RUN_EXISTING"
 append_summary "- Repeat count for missing canonical specs: $REPEAT_COUNT"
-append_summary "- Immutable source tuple: $SOURCE_TUPLE"
+append_summary "- Source tuples are prepared and executed independently per immutable ref pair"
 
 for spec_file in "${SPEC_FILES[@]}"; do
   spec_slug=$(slugify "$spec_file")
@@ -468,6 +476,7 @@ for spec_file in "${SPEC_FILES[@]}"; do
   canonical_dir=$(resolve_canonical_dir "$spec_file")
   existing_canonical_dir=$(resolve_existing_canonical_dir "$spec_file")
   benchmark_type=$(resolve_benchmark_type "$spec_file")
+  source_tuple=$(resolve_source_tuple "$spec_file")
 
   echo
   echo "[official-baseline-matrix] spec: $spec_file"
@@ -491,7 +500,7 @@ for spec_file in "${SPEC_FILES[@]}"; do
     should_promote=1
   fi
 
-  prepare_official_env_once
+  prepare_official_env_once "$source_tuple"
 
   target_successful_repeats=1
   min_successful_repeats=1

--- a/scripts/run-official-ascend-goal-baseline-matrix.sh
+++ b/scripts/run-official-ascend-goal-baseline-matrix.sh
@@ -29,6 +29,7 @@ MATRIX_DEVICE_PREFERENCE_FILE=${MATRIX_DEVICE_PREFERENCE_FILE:-"$MATRIX_RESULT_R
 PYTHON_BIN=${PYTHON_BIN:-$(command -v python3 || true)}
 PUBLICATION_SYNC_HELPER=${PUBLICATION_SYNC_HELPER:-}
 PUBLICATION_COMMIT_MESSAGE_PREFIX=${PUBLICATION_COMMIT_MESSAGE_PREFIX:-"chore(data): publish official ascend baseline"}
+VALIDATE_ARTIFACT_SCRIPT=${VALIDATE_ARTIFACT_SCRIPT:-"$SCRIPT_DIR/validate-run-artifact.sh"}
 PREPARED_ENV=0
 SKIPPED_COUNT=0
 RUN_COUNT=0
@@ -73,6 +74,11 @@ fi
 
 if [[ ! -f "$PREPARE_SCRIPT" ]]; then
   echo "Prepare script not found: $PREPARE_SCRIPT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$VALIDATE_ARTIFACT_SCRIPT" ]]; then
+  echo "Artifact validator not found: $VALIDATE_ARTIFACT_SCRIPT" >&2
   exit 2
 fi
 
@@ -188,8 +194,28 @@ promote_submission_to_canonical() {
   local submission_dir="$result_dir/submission"
   local backup_dir
 
-  if [[ ! -f "$submission_dir/run_leaderboard.json" ]] || [[ ! -f "$submission_dir/leaderboard_manifest.json" ]]; then
-    echo "Canonical promotion source is incomplete for $spec_id: $submission_dir" >&2
+  local required_file
+
+  for required_file in \
+    leaderboard_manifest.json \
+    run_leaderboard.json \
+    env-manifest.json \
+    pip-packages.json \
+    checksums.sha256 \
+    STATUS; do
+    if [[ ! -f "$submission_dir/$required_file" ]]; then
+      echo "Canonical promotion source is missing $required_file for $spec_id: $submission_dir" >&2
+      return 1
+    fi
+  done
+
+  if [[ "$(tr -d '[:space:]' < "$submission_dir/STATUS")" != "OK" ]]; then
+    echo "Canonical promotion source is not publishable for $spec_id: $submission_dir/STATUS" >&2
+    return 1
+  fi
+
+  if ! bash "$VALIDATE_ARTIFACT_SCRIPT" "$submission_dir"; then
+    echo "Canonical promotion source failed artifact validation for $spec_id: $submission_dir" >&2
     return 1
   fi
 

--- a/scripts/run-official-ascend-goal-baseline-matrix.sh
+++ b/scripts/run-official-ascend-goal-baseline-matrix.sh
@@ -132,6 +132,11 @@ print(get_official_baseline_spec_id(load_official_baseline_spec(Path(sys.argv[1]
 PY
 }
 
+resolve_source_tuple() {
+  local spec_file=$1
+  jq -er '[.baseline_target.vllm_ref // "v0.18.0", .baseline_target.vllm_ascend_ref // "v0.18.0"] | @tsv' "$spec_file"
+}
+
 resolve_canonical_dir() {
   local spec_file=$1
   PYTHONPATH="$REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$spec_file" "$CANONICAL_SUBMISSIONS_ROOT"
@@ -433,6 +438,17 @@ if [[ ${#SPEC_FILES[@]} -eq 0 ]]; then
   exit 2
 fi
 
+SOURCE_TUPLE=""
+for spec_file in "${SPEC_FILES[@]}"; do
+  spec_source_tuple=$(resolve_source_tuple "$spec_file")
+  if [[ -z "$SOURCE_TUPLE" ]]; then
+    SOURCE_TUPLE="$spec_source_tuple"
+  elif [[ "$spec_source_tuple" != "$SOURCE_TUPLE" ]]; then
+    echo "Official baseline matrix contains mixed source tuples: $SOURCE_TUPLE vs $spec_source_tuple ($spec_file)" >&2
+    exit 2
+  fi
+done
+
 echo "[official-baseline-matrix] result root: $MATRIX_RESULT_ROOT"
 echo "[official-baseline-matrix] canonical submissions root: $CANONICAL_SUBMISSIONS_ROOT"
 echo "[official-baseline-matrix] sticky Ascend device preference file: $MATRIX_DEVICE_PREFERENCE_FILE"
@@ -444,6 +460,7 @@ append_summary "- Sticky Ascend device preference file: $MATRIX_DEVICE_PREFERENC
 append_summary "- Existing canonical submissions root: $EXISTING_CANONICAL_SUBMISSIONS_ROOT"
 append_summary "- Force rerun existing canonical: $FORCE_RUN_EXISTING"
 append_summary "- Repeat count for missing canonical specs: $REPEAT_COUNT"
+append_summary "- Immutable source tuple: $SOURCE_TUPLE"
 
 for spec_file in "${SPEC_FILES[@]}"; do
   spec_slug=$(slugify "$spec_file")

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 PREPARE_SCRIPT=${PREPARE_SCRIPT:-"$REPO_ROOT/scripts/prepare-official-ascend-baseline-env.sh"}
 VLLM_CLI_COMPAT=${VLLM_CLI_COMPAT:-"$REPO_ROOT/scripts/run_vllm_cli_compat.py"}
+COLLECT_ARTIFACT_SCRIPT=${COLLECT_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/collect-run-artifact.sh"}
+VALIDATE_ARTIFACT_SCRIPT=${VALIDATE_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/validate-run-artifact.sh"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
@@ -82,6 +84,16 @@ fi
 
 if [[ ! -f "$VLLM_CLI_COMPAT" ]]; then
   echo "CLI compatibility wrapper not found: $VLLM_CLI_COMPAT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$COLLECT_ARTIFACT_SCRIPT" ]]; then
+  echo "Artifact collector not found: $COLLECT_ARTIFACT_SCRIPT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$VALIDATE_ARTIFACT_SCRIPT" ]]; then
+  echo "Artifact validator not found: $VALIDATE_ARTIFACT_SCRIPT" >&2
   exit 2
 fi
 
@@ -998,10 +1010,24 @@ ensure_worktree() {
   local source_repo=$1
   local target_dir=$2
   local ref_name=$3
-  if [[ -f "$target_dir/pyproject.toml" ]]; then
-    return 0
+  if [[ ! -f "$target_dir/pyproject.toml" ]]; then
+    git -C "$source_repo" worktree add --detach "$target_dir" "$ref_name"
   fi
-  git -C "$source_repo" worktree add --detach "$target_dir" "$ref_name"
+
+  local expected_commit
+  local observed_commit
+  expected_commit=$(git -C "$source_repo" rev-parse --verify "${ref_name}^{commit}" 2>/dev/null) || {
+    echo "official source ref does not resolve to a commit: $ref_name ($source_repo)" >&2
+    return 1
+  }
+  observed_commit=$(git -C "$target_dir" rev-parse --verify HEAD 2>/dev/null) || {
+    echo "official source worktree has no observable commit: $target_dir" >&2
+    return 1
+  }
+  if [[ "$observed_commit" != "$expected_commit" ]]; then
+    echo "official source worktree ref mismatch: $target_dir is $observed_commit, expected $ref_name ($expected_commit)" >&2
+    return 1
+  fi
 }
 
 json2args() {
@@ -1569,8 +1595,12 @@ trap kill_server EXIT
 
 OFFICIAL_VLLM_REF=${OFFICIAL_VLLM_REF:-$(jq -r '.baseline_target.vllm_ref // "v0.18.0"' "$SPEC_FILE")}
 OFFICIAL_VLLM_ASCEND_REF=${OFFICIAL_VLLM_ASCEND_REF:-$(jq -r '.baseline_target.vllm_ascend_ref // "v0.18.0"' "$SPEC_FILE")}
-ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_VLLM_REF"
-ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_VLLM_ASCEND_REF"
+OFFICIAL_CORE_SOURCE_REF=${OFFICIAL_CORE_SOURCE_REF:-$(jq -r '.baseline_target.vllm_ref // empty' "$SPEC_FILE")}
+OFFICIAL_BACKEND_SOURCE_REF=${OFFICIAL_BACKEND_SOURCE_REF:-$(jq -r '.baseline_target.vllm_ascend_ref // empty' "$SPEC_FILE")}
+OFFICIAL_CORE_SOURCE_REF=${OFFICIAL_CORE_SOURCE_REF:-$OFFICIAL_VLLM_REF}
+OFFICIAL_BACKEND_SOURCE_REF=${OFFICIAL_BACKEND_SOURCE_REF:-$OFFICIAL_VLLM_ASCEND_REF}
+ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF"
+ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_BACKEND_SOURCE_REF"
 
 OFFICIAL_RUNTIME_PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE"
 
@@ -1612,16 +1642,6 @@ BENCHMARK_TYPE=$(resolve_scenario_benchmark_type)
 OFFICIAL_CORE_SOURCE_REPOSITORY=${OFFICIAL_CORE_SOURCE_REPOSITORY:-"vllm-project/vllm"}
 OFFICIAL_BACKEND_SOURCE_ENGINE=${OFFICIAL_BACKEND_SOURCE_ENGINE:-"vllm-ascend"}
 OFFICIAL_BACKEND_SOURCE_REPOSITORY=${OFFICIAL_BACKEND_SOURCE_REPOSITORY:-"vllm-project/vllm-ascend"}
-OFFICIAL_CORE_SOURCE_REF=$(jq -r '.baseline_target.vllm_ref // empty' "$SPEC_FILE")
-OFFICIAL_BACKEND_SOURCE_REF=$(jq -r '.baseline_target.vllm_ascend_ref // empty' "$SPEC_FILE")
-
-if [[ -z "$OFFICIAL_CORE_SOURCE_REF" ]] || [[ "$OFFICIAL_CORE_SOURCE_REF" == "null" ]]; then
-  OFFICIAL_CORE_SOURCE_REF="$OFFICIAL_VLLM_REF"
-fi
-if [[ -z "$OFFICIAL_BACKEND_SOURCE_REF" ]] || [[ "$OFFICIAL_BACKEND_SOURCE_REF" == "null" ]]; then
-  OFFICIAL_BACKEND_SOURCE_REF="$OFFICIAL_VLLM_ASCEND_REF"
-fi
-
 OFFICIAL_CORE_SOURCE_COMMIT=$(git -C "$OFFICIAL_VLLM_WORKTREE" rev-parse HEAD 2>/dev/null || true)
 OFFICIAL_BACKEND_SOURCE_COMMIT=$(git -C "$OFFICIAL_VLLM_ASCEND_WORKTREE" rev-parse HEAD 2>/dev/null || true)
 if [[ -z "$OFFICIAL_BACKEND_SOURCE_COMMIT" ]]; then
@@ -1830,4 +1850,13 @@ append_export_arg_from_spec --batch-size '.client_parameters.batch_size'
 
 run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${EXPORT_ARGS[@]}"
 
-echo "[goal-baseline] exported leaderboard artifact to $ARTIFACT_DIR"
+CURRENT_RUNTIME_PYTHON="$OFFICIAL_RUNTIME_PYTHON" \
+CURRENT_VLLM_HUST_REPO="$OFFICIAL_VLLM_WORKTREE" \
+CURRENT_VLLM_ASCEND_HUST_REPO="$OFFICIAL_VLLM_ASCEND_WORKTREE" \
+CURRENT_GIT_COMMIT="$OFFICIAL_CORE_SOURCE_COMMIT" \
+CURRENT_PLUGIN_GIT_COMMIT="$OFFICIAL_BACKEND_SOURCE_COMMIT" \
+bash "$COLLECT_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"
+
+bash "$VALIDATE_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"
+
+echo "[goal-baseline] exported and validated leaderboard artifact at $ARTIFACT_DIR"

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -7,6 +7,7 @@ PREPARE_SCRIPT=${PREPARE_SCRIPT:-"$REPO_ROOT/scripts/prepare-official-ascend-bas
 VLLM_CLI_COMPAT=${VLLM_CLI_COMPAT:-"$REPO_ROOT/scripts/run_vllm_cli_compat.py"}
 COLLECT_ARTIFACT_SCRIPT=${COLLECT_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/collect-run-artifact.sh"}
 VALIDATE_ARTIFACT_SCRIPT=${VALIDATE_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/validate-run-artifact.sh"}
+CAPTURE_SOURCE_PROVENANCE_SCRIPT=${CAPTURE_SOURCE_PROVENANCE_SCRIPT:-"$REPO_ROOT/scripts/capture-official-source-provenance.py"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
@@ -94,6 +95,11 @@ fi
 
 if [[ ! -f "$VALIDATE_ARTIFACT_SCRIPT" ]]; then
   echo "Artifact validator not found: $VALIDATE_ARTIFACT_SCRIPT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" ]]; then
+  echo "Official source provenance helper not found: $CAPTURE_SOURCE_PROVENANCE_SCRIPT" >&2
   exit 2
 fi
 
@@ -1599,8 +1605,44 @@ OFFICIAL_CORE_SOURCE_REF=${OFFICIAL_CORE_SOURCE_REF:-$(jq -r '.baseline_target.v
 OFFICIAL_BACKEND_SOURCE_REF=${OFFICIAL_BACKEND_SOURCE_REF:-$(jq -r '.baseline_target.vllm_ascend_ref // empty' "$SPEC_FILE")}
 OFFICIAL_CORE_SOURCE_REF=${OFFICIAL_CORE_SOURCE_REF:-$OFFICIAL_VLLM_REF}
 OFFICIAL_BACKEND_SOURCE_REF=${OFFICIAL_BACKEND_SOURCE_REF:-$OFFICIAL_VLLM_ASCEND_REF}
+OFFICIAL_CORE_SOURCE_REPOSITORY=${OFFICIAL_CORE_SOURCE_REPOSITORY:-"vllm-project/vllm"}
+OFFICIAL_BACKEND_SOURCE_REPOSITORY=${OFFICIAL_BACKEND_SOURCE_REPOSITORY:-"vllm-project/vllm-ascend"}
 ensure_worktree "$OFFICIAL_VLLM_REPO" "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF"
 ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_BACKEND_SOURCE_REF"
+
+SOURCE_PROVENANCE_DIR="$RESULT_DIR/source-provenance"
+SOURCE_PROVENANCE_FILE="$SOURCE_PROVENANCE_DIR/official-source-provenance.json"
+mkdir -p "$SOURCE_PROVENANCE_DIR"
+"$HOST_PYTHON_BIN" - "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" \
+  "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF" \
+  "$OFFICIAL_CORE_SOURCE_REPOSITORY" "$SOURCE_PROVENANCE_DIR/engine.json" \
+  "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_BACKEND_SOURCE_REF" \
+  "$OFFICIAL_BACKEND_SOURCE_REPOSITORY" "$SOURCE_PROVENANCE_DIR/plugin.json" \
+  "$SOURCE_PROVENANCE_FILE" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+helper, *values = sys.argv[1:]
+if len(values) != 9:
+    raise SystemExit("official source provenance arguments are incomplete")
+engine_args = values[:4]
+plugin_args = values[4:8]
+output_path = Path(values[8])
+subprocess.run([sys.executable, helper, *engine_args], check=True)
+subprocess.run([sys.executable, helper, *plugin_args], check=True)
+payload = {
+    "schema_version": "official-source-provenance/v1",
+    "sources": {
+        "engine": json.loads(Path(engine_args[3]).read_text(encoding="utf-8")),
+        "plugin": json.loads(Path(plugin_args[3]).read_text(encoding="utf-8")),
+    },
+}
+output_path.write_text(
+    json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+PY
 
 OFFICIAL_RUNTIME_PYTHONPATH="$OFFICIAL_VLLM_ASCEND_WORKTREE:$OFFICIAL_VLLM_WORKTREE"
 
@@ -1639,9 +1681,7 @@ GITHUB_REF=$(jq -r '.export.github_ref' "$SPEC_FILE")
 GIT_COMMIT=$(jq -r '.export.git_commit' "$SPEC_FILE")
 DATA_SOURCE=$(jq -r '.export.data_source' "$SPEC_FILE")
 BENCHMARK_TYPE=$(resolve_scenario_benchmark_type)
-OFFICIAL_CORE_SOURCE_REPOSITORY=${OFFICIAL_CORE_SOURCE_REPOSITORY:-"vllm-project/vllm"}
 OFFICIAL_BACKEND_SOURCE_ENGINE=${OFFICIAL_BACKEND_SOURCE_ENGINE:-"vllm-ascend"}
-OFFICIAL_BACKEND_SOURCE_REPOSITORY=${OFFICIAL_BACKEND_SOURCE_REPOSITORY:-"vllm-project/vllm-ascend"}
 OFFICIAL_CORE_SOURCE_COMMIT=$(git -C "$OFFICIAL_VLLM_WORKTREE" rev-parse HEAD 2>/dev/null || true)
 OFFICIAL_BACKEND_SOURCE_COMMIT=$(git -C "$OFFICIAL_VLLM_ASCEND_WORKTREE" rev-parse HEAD 2>/dev/null || true)
 if [[ -z "$OFFICIAL_BACKEND_SOURCE_COMMIT" ]]; then
@@ -1809,6 +1849,28 @@ esac
 echo "[goal-baseline] client command: $CLIENT_COMMAND"
 run_client_command
 
+"$HOST_PYTHON_BIN" "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" \
+  "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF" \
+  "$OFFICIAL_CORE_SOURCE_REPOSITORY" "$SOURCE_PROVENANCE_DIR/engine-after.json"
+"$HOST_PYTHON_BIN" "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" \
+  "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$OFFICIAL_BACKEND_SOURCE_REF" \
+  "$OFFICIAL_BACKEND_SOURCE_REPOSITORY" "$SOURCE_PROVENANCE_DIR/plugin-after.json"
+"$HOST_PYTHON_BIN" - \
+  "$SOURCE_PROVENANCE_DIR/engine.json" "$SOURCE_PROVENANCE_DIR/engine-after.json" \
+  "$SOURCE_PROVENANCE_DIR/plugin.json" "$SOURCE_PROVENANCE_DIR/plugin-after.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+paths = [Path(item) for item in sys.argv[1:]]
+for before_path, after_path in zip(paths[::2], paths[1::2]):
+    before = json.loads(before_path.read_text(encoding="utf-8"))
+    after = json.loads(after_path.read_text(encoding="utf-8"))
+    fields = ("observed_commit", "tracked_patch_sha256", "working_tree_sha256", "status")
+    if any(before.get(field) != after.get(field) for field in fields):
+        raise SystemExit(f"official source changed during benchmark: {before_path.stem}")
+PY
+
 EXPORT_ARGS=(
   python -m vllm_hust_benchmark.cli export-leaderboard-artifact
   "$SCENARIO"
@@ -1850,12 +1912,44 @@ append_export_arg_from_spec --batch-size '.client_parameters.batch_size'
 
 run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${EXPORT_ARGS[@]}"
 
+"$HOST_PYTHON_BIN" - "$ARTIFACT_DIR/run_leaderboard.json" "$SOURCE_PROVENANCE_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+artifact_path, provenance_path = map(Path, sys.argv[1:])
+artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+metadata = artifact.setdefault("metadata", {})
+metadata["official_source_provenance"] = provenance
+artifact_path.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+
 CURRENT_RUNTIME_PYTHON="$OFFICIAL_RUNTIME_PYTHON" \
 CURRENT_VLLM_HUST_REPO="$OFFICIAL_VLLM_WORKTREE" \
 CURRENT_VLLM_ASCEND_HUST_REPO="$OFFICIAL_VLLM_ASCEND_WORKTREE" \
 CURRENT_GIT_COMMIT="$OFFICIAL_CORE_SOURCE_COMMIT" \
 CURRENT_PLUGIN_GIT_COMMIT="$OFFICIAL_BACKEND_SOURCE_COMMIT" \
+OFFICIAL_SOURCE_PROVENANCE_FILE="$SOURCE_PROVENANCE_FILE" \
 bash "$COLLECT_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"
+
+"$HOST_PYTHON_BIN" - "$ARTIFACT_DIR" "$SOURCE_PROVENANCE_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+artifact_dir, provenance_path = map(Path, sys.argv[1:])
+expected = json.loads(provenance_path.read_text(encoding="utf-8"))
+artifact = json.loads((artifact_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
+manifest = json.loads((artifact_dir / "env-manifest.json").read_text(encoding="utf-8"))
+artifact_value = (artifact.get("metadata") or {}).get("official_source_provenance")
+manifest_value = manifest.get("official_source_provenance")
+if artifact_value != expected or manifest_value != expected:
+    raise SystemExit("official source provenance mismatch between artifact, manifest, and capture")
+for role, source in expected.get("sources", {}).items():
+    if source.get("status") == "modified" and not source.get("tracked_patch_sha256"):
+        raise SystemExit(f"{role} source is modified without tracked patch provenance")
+PY
 
 bash "$VALIDATE_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"
 

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -180,6 +180,38 @@ PY
       echo "  $FROZEN_INPUT_ERRORS" >&2
       check "formal campaign frozen provenance is complete" 1
     fi
+
+    OFFICIAL_SOURCE_ERRORS=$(python3 - <<'PY' || echo "parse-error"
+import json
+
+manifest = json.load(open("env-manifest.json", encoding="utf-8"))
+payload = manifest.get("official_source_provenance")
+if not payload:
+    raise SystemExit(0)
+
+errors = []
+if payload.get("schema_version") != "official-source-provenance/v1":
+    errors.append("unsupported official source provenance schema")
+for role in ("engine", "plugin"):
+    source = (payload.get("sources") or {}).get(role) or {}
+    for field in ("repository", "requested_ref", "observed_commit", "tracked_patch_sha256", "working_tree_sha256", "status"):
+        if not source.get(field):
+            errors.append(f"official_source_provenance.{role}.{field} is empty")
+    if source.get("status") not in ("clean", "modified"):
+        errors.append(f"official_source_provenance.{role}.status is invalid")
+    if source.get("status") == "modified" and not source.get("tracked_patch_sha256"):
+        errors.append(f"official_source_provenance.{role} modified without patch digest")
+    if source.get("status") == "modified" and not source.get("working_tree_sha256"):
+        errors.append(f"official_source_provenance.{role} modified without tree digest")
+print("; ".join(errors))
+PY
+)
+    if [[ -z "$OFFICIAL_SOURCE_ERRORS" ]]; then
+      check "official source provenance is complete" 0
+    else
+      echo "  $OFFICIAL_SOURCE_ERRORS" >&2
+      check "official source provenance is complete" 1
+    fi
   else
     check "env-manifest.json is valid JSON" 1
   fi

--- a/tests/test_official_baseline_matrix_script.py
+++ b/tests/test_official_baseline_matrix_script.py
@@ -202,7 +202,9 @@ def test_matrix_script_accepts_partial_successful_repeats(tmp_path: Path) -> Non
     assert "Failed specs: 0" in summary_text
 
 
-def test_matrix_rejects_mixed_official_source_tuples(tmp_path: Path) -> None:
+def test_matrix_accepts_mixed_official_source_tuples_as_independent_specs(
+    tmp_path: Path,
+) -> None:
     specs_dir = tmp_path / "specs"
     specs_dir.mkdir()
     first = specs_dir / "first.json"
@@ -232,7 +234,13 @@ def test_matrix_rejects_mixed_official_source_tuples(tmp_path: Path) -> None:
     )
     prepare_stub = tmp_path / "prepare.sh"
     runner_stub = tmp_path / "runner.sh"
-    _write_prepare_stub(prepare_stub)
+    prepare_log = tmp_path / "prepare.log"
+    prepare_stub.write_text(
+        f"#!{bash_executable()}\n"
+        f'printf \'%s\\t%s\\n\' "$OFFICIAL_VLLM_REF" "$OFFICIAL_VLLM_WORKTREE" >> {prepare_log}\n',
+        encoding="utf-8",
+    )
+    prepare_stub.chmod(0o755)
     _write_runner_stub(
         runner_stub, call_log=tmp_path / "calls.log", fail_repeat_names=()
     )
@@ -243,15 +251,26 @@ def test_matrix_rejects_mixed_official_source_tuples(tmp_path: Path) -> None:
             "GOAL_BASELINE_ENV_PREFIX": "/tmp/fake-official-env",
             "PREPARE_SCRIPT": str(prepare_stub),
             "SINGLE_RUNNER": str(runner_stub),
-            "PREPARE_OFFICIAL_ENV": "0",
+            "PREPARE_OFFICIAL_ENV": "1",
+            "REPEAT_COUNT": "1",
+            "MIN_SUCCESSFUL_REPEATS": "1",
+            "MAX_REPEAT_ATTEMPTS": "1",
             "CANONICAL_SUBMISSIONS_ROOT": str(tmp_path / "submissions"),
             "MATRIX_RESULT_ROOT": str(tmp_path / "results"),
             "PYTHON_BIN": sys.executable,
         },
     )
 
-    assert completed.returncode == 2
-    assert "mixed source tuples" in completed.stderr
+    assert completed.returncode == 0, completed.stderr
+    assert "mixed source tuples" not in completed.stderr
+    assert "prepared and executed independently" in (
+        tmp_path / "results" / "summary.md"
+    ).read_text(encoding="utf-8")
+    prepare_lines = prepare_log.read_text(encoding="utf-8").splitlines()
+    assert prepare_lines[0].startswith("v0.18.0\t")
+    assert prepare_lines[1].startswith("main\t")
+    assert prepare_lines[0].split("\t", 1)[1] != prepare_lines[1].split("\t", 1)[1]
+    assert all("/results/" not in line for line in prepare_lines)
 
 
 def test_matrix_script_uses_published_canonical_root_for_resume(tmp_path: Path) -> None:

--- a/tests/test_official_baseline_matrix_script.py
+++ b/tests/test_official_baseline_matrix_script.py
@@ -11,6 +11,7 @@ from tests._bash_utils import bash_executable
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MATRIX_SCRIPT = REPO_ROOT / "scripts" / "run-official-ascend-goal-baseline-matrix.sh"
 ONE_CLICK_SCRIPT = REPO_ROOT / "scripts" / "run-official-v0180-baselines.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-official-ascend-baselines.yml"
 
 
 def _write_spec(spec_file: Path, spec_id: str) -> None:
@@ -64,11 +65,18 @@ def _write_runner_stub(
         "submission_dir = result_dir / 'submission'\n"
         "payload = {\n"
         "    'metadata': {'submitter': 'official-ascend-baseline'},\n"
+        "    'model': {'canonical_id': 'hf:Qwen/Qwen2.5-14B-Instruct', 'repo_id': 'Qwen/Qwen2.5-14B-Instruct', 'short_name': 'Qwen2.5-14B-Instruct', 'display_name': 'Qwen2.5-14B-Instruct', 'name': 'Qwen/Qwen2.5-14B-Instruct'},\n"
         "    'same_spec': {'spec_id': spec['id']},\n"
         "    'metrics': {'ttft_ms': ttft_ms, 'throughput_tps': 200.0, 'error_rate': 0.0},\n"
         "}\n"
         "(submission_dir / 'run_leaderboard.json').write_text(json.dumps(payload), encoding='utf-8')\n"
         "(submission_dir / 'leaderboard_manifest.json').write_text(json.dumps({'entries': [{'leaderboard_artifact': 'run_leaderboard.json'}]}), encoding='utf-8')\n"
+        "(submission_dir / 'env-manifest.json').write_text(json.dumps({'os': 'test', 'python_version': 'test', 'collected_at': '2026-08-07T00:00:00Z', 'frozen_inputs_required': False}), encoding='utf-8')\n"
+        "(submission_dir / 'pip-packages.json').write_text('[]\\n', encoding='utf-8')\n"
+        "files = ['leaderboard_manifest.json', 'run_leaderboard.json', 'env-manifest.json', 'pip-packages.json']\n"
+        "checksums = ''.join(f'{__import__(\"hashlib\").sha256((submission_dir / name).read_bytes()).hexdigest()}  ./{name}\\n' for name in files)\n"
+        "(submission_dir / 'checksums.sha256').write_text(checksums, encoding='utf-8')\n"
+        "(submission_dir / 'STATUS').write_text('OK\\n', encoding='utf-8')\n"
         "PY\n",
         encoding="utf-8",
     )
@@ -175,7 +183,15 @@ def test_matrix_script_accepts_partial_successful_repeats(tmp_path: Path) -> Non
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert (canonical_root / spec_id / "run_leaderboard.json").is_file()
+    for file_name in (
+        "leaderboard_manifest.json",
+        "run_leaderboard.json",
+        "env-manifest.json",
+        "pip-packages.json",
+        "checksums.sha256",
+        "STATUS",
+    ):
+        assert (canonical_root / spec_id / file_name).is_file()
     assert runner_call_log.read_text(encoding="utf-8").strip().splitlines() == [
         "repeat-01",
         "repeat-02",
@@ -247,3 +263,138 @@ def test_matrix_script_uses_published_canonical_root_for_resume(tmp_path: Path) 
     ]
     summary_text = summary_file.read_text(encoding="utf-8")
     assert f"Skip existing canonical: {spec_id}" in summary_text
+
+
+def test_matrix_script_requires_complete_evidence_before_promotion(
+    tmp_path: Path,
+) -> None:
+    spec_id = "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
+    spec_file = tmp_path / "spec.json"
+    prepare_stub = tmp_path / "prepare.sh"
+    runner_stub = tmp_path / "runner.sh"
+    runner_call_log = tmp_path / "runner-calls.log"
+    canonical_root = tmp_path / "submissions-local"
+    result_root = tmp_path / "results"
+
+    _write_spec(spec_file, spec_id)
+    _write_prepare_stub(prepare_stub)
+    _write_runner_stub(runner_stub, call_log=runner_call_log, fail_repeat_names=())
+    runner_text = runner_stub.read_text(encoding="utf-8")
+    runner_stub.write_text(
+        runner_text + 'rm -f "$RESULT_DIR/submission/STATUS"\n',
+        encoding="utf-8",
+    )
+
+    completed = _run_matrix(
+        spec_file,
+        {
+            "GOAL_BASELINE_ENV_PREFIX": "/tmp/fake-official-env",
+            "PREPARE_SCRIPT": str(prepare_stub),
+            "SINGLE_RUNNER": str(runner_stub),
+            "PREPARE_OFFICIAL_ENV": "0",
+            "REPEAT_COUNT": "1",
+            "MIN_SUCCESSFUL_REPEATS": "1",
+            "MAX_REPEAT_ATTEMPTS": "1",
+            "CANONICAL_SUBMISSIONS_ROOT": str(canonical_root),
+            "MATRIX_RESULT_ROOT": str(result_root),
+            "PYTHON_BIN": sys.executable,
+        },
+    )
+
+    assert completed.returncode != 0
+    assert not (canonical_root / spec_id).exists()
+
+
+def test_official_runner_finalizes_and_validates_exported_artifact() -> None:
+    runner_text = (
+        REPO_ROOT / "scripts" / "run-official-ascend-goal-baseline.sh"
+    ).read_text(encoding="utf-8")
+
+    export_position = runner_text.index(
+        'run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH"'
+    )
+    collect_position = runner_text.index(
+        'bash "$COLLECT_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"'
+    )
+    validate_position = runner_text.index(
+        'bash "$VALIDATE_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"'
+    )
+
+    assert export_position < collect_position < validate_position
+    assert 'CURRENT_VLLM_HUST_REPO="$OFFICIAL_VLLM_WORKTREE"' in runner_text
+    assert (
+        'CURRENT_VLLM_ASCEND_HUST_REPO="$OFFICIAL_VLLM_ASCEND_WORKTREE"' in runner_text
+    )
+
+
+def test_official_workflow_defaults_live_publication_off() -> None:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    publish_input = workflow_text.split("      publish_results:", maxsplit=1)[1].split(
+        "      force_repair_official_env:", maxsplit=1
+    )[0]
+    assert "        default: false" in publish_input
+
+
+def test_official_runner_rejects_stale_source_worktree(tmp_path: Path) -> None:
+    source_repo = tmp_path / "source"
+    source_repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(source_repo)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(source_repo), "config", "user.name", "Test User"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(source_repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    (source_repo / "pyproject.toml").write_text(
+        "[project]\nname='test'\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(source_repo), "add", "pyproject.toml"], check=True)
+    subprocess.run(["git", "-C", str(source_repo), "commit", "-m", "first"], check=True)
+    stale_worktree = tmp_path / "stale-worktree"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source_repo),
+            "worktree",
+            "add",
+            "--detach",
+            str(stale_worktree),
+            "HEAD",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (source_repo / "second.txt").write_text("second\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(source_repo), "add", "second.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(source_repo), "commit", "-m", "second"], check=True
+    )
+
+    runner_path = shlex.quote(
+        str(REPO_ROOT / "scripts" / "run-official-ascend-goal-baseline.sh")
+    )
+    command = (
+        "source <(awk 'BEGIN{capture=0} "
+        "/^ensure_worktree\\(\\) \\{/ {capture=1} "
+        "/^json2args\\(\\) \\{/ {exit} capture {print}' "
+        f"{runner_path}) && ensure_worktree "
+        f"{shlex.quote(str(source_repo))} {shlex.quote(str(stale_worktree))} HEAD"
+    )
+    completed = subprocess.run(
+        [bash_executable(), "-lc", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "official source worktree ref mismatch" in completed.stderr

--- a/tests/test_official_baseline_matrix_script.py
+++ b/tests/test_official_baseline_matrix_script.py
@@ -202,6 +202,58 @@ def test_matrix_script_accepts_partial_successful_repeats(tmp_path: Path) -> Non
     assert "Failed specs: 0" in summary_text
 
 
+def test_matrix_rejects_mixed_official_source_tuples(tmp_path: Path) -> None:
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    first = specs_dir / "first.json"
+    second = specs_dir / "second.json"
+    first.write_text(
+        json.dumps(
+            {
+                "id": "first",
+                "scenario": "random-online",
+                "baseline_target": {
+                    "vllm_ref": "v0.18.0",
+                    "vllm_ascend_ref": "v0.18.0",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    second.write_text(
+        json.dumps(
+            {
+                "id": "second",
+                "scenario": "random-online",
+                "baseline_target": {"vllm_ref": "main", "vllm_ascend_ref": "main"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    prepare_stub = tmp_path / "prepare.sh"
+    runner_stub = tmp_path / "runner.sh"
+    _write_prepare_stub(prepare_stub)
+    _write_runner_stub(
+        runner_stub, call_log=tmp_path / "calls.log", fail_repeat_names=()
+    )
+
+    completed = _run_matrix(
+        specs_dir,
+        {
+            "GOAL_BASELINE_ENV_PREFIX": "/tmp/fake-official-env",
+            "PREPARE_SCRIPT": str(prepare_stub),
+            "SINGLE_RUNNER": str(runner_stub),
+            "PREPARE_OFFICIAL_ENV": "0",
+            "CANONICAL_SUBMISSIONS_ROOT": str(tmp_path / "submissions"),
+            "MATRIX_RESULT_ROOT": str(tmp_path / "results"),
+            "PYTHON_BIN": sys.executable,
+        },
+    )
+
+    assert completed.returncode == 2
+    assert "mixed source tuples" in completed.stderr
+
+
 def test_matrix_script_uses_published_canonical_root_for_resume(tmp_path: Path) -> None:
     spec_id = "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
     spec_file = tmp_path / "spec.json"

--- a/tests/test_official_source_provenance.py
+++ b/tests/test_official_source_provenance.py
@@ -1,0 +1,45 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "scripts/capture-official-source-provenance.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def test_capture_records_commit_and_dirty_tree_digest(tmp_path: Path) -> None:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    source_file = repo / "source.py"
+    source_file.write_text("print('one')\n", encoding="utf-8")
+    _git(repo, "add", "source.py")
+    _git(repo, "commit", "-m", "initial")
+
+    clean_output = tmp_path / "clean.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(clean_output)],
+        check=True,
+    )
+    clean = json.loads(clean_output.read_text(encoding="utf-8"))
+    assert clean["status"] == "clean"
+    assert len(clean["observed_commit"]) == 40
+    assert clean["tracked_patch_sha256"]
+    assert clean["working_tree_sha256"]
+
+    source_file.write_text("print('two')\n", encoding="utf-8")
+    dirty_output = tmp_path / "dirty.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(dirty_output)],
+        check=True,
+    )
+    dirty = json.loads(dirty_output.read_text(encoding="utf-8"))
+    assert dirty["status"] == "modified"
+    assert dirty["tracked_patch_sha256"] != clean["tracked_patch_sha256"]
+    assert dirty["working_tree_sha256"] != clean["working_tree_sha256"]

--- a/tests/test_official_source_provenance.py
+++ b/tests/test_official_source_provenance.py
@@ -43,3 +43,36 @@ def test_capture_records_commit_and_dirty_tree_digest(tmp_path: Path) -> None:
     assert dirty["status"] == "modified"
     assert dirty["tracked_patch_sha256"] != clean["tracked_patch_sha256"]
     assert dirty["working_tree_sha256"] != clean["working_tree_sha256"]
+
+
+def test_capture_includes_ignored_generated_runtime_inputs(tmp_path: Path) -> None:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / ".gitignore").write_text("vllm_ascend/_build_info.py\n", encoding="utf-8")
+    (repo / "tracked.txt").write_text("stable\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    generated = repo / "vllm_ascend" / "_build_info.py"
+    generated.parent.mkdir()
+    generated.write_text("__soc_version__ = 'ascend910b3'\n", encoding="utf-8")
+
+    first_output = tmp_path / "first.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(first_output)],
+        check=True,
+    )
+    first = json.loads(first_output.read_text(encoding="utf-8"))
+    assert first["status"] == "modified"
+    assert first["generated_file_count"] == 1
+
+    generated.write_text("__soc_version__ = 'ascend910b2'\n", encoding="utf-8")
+    second_output = tmp_path / "second.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(second_output)],
+        check=True,
+    )
+    second = json.loads(second_output.read_text(encoding="utf-8"))
+    assert second["working_tree_sha256"] != first["working_tree_sha256"]

--- a/tests/test_sync_official_baseline_snapshots_to_github.py
+++ b/tests/test_sync_official_baseline_snapshots_to_github.py
@@ -1,7 +1,12 @@
+import hashlib
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -49,11 +54,151 @@ def _git(
 def _write_submission(source_repo: Path, run_id: str, model_name: str) -> None:
     submission_dir = source_repo / "submissions" / run_id
     submission_dir.mkdir(parents=True)
-    (submission_dir / "leaderboard_manifest.json").write_text("{}\n", encoding="utf-8")
+    (submission_dir / "leaderboard_manifest.json").write_text(
+        json.dumps({"entries": [{"leaderboard_artifact": "run_leaderboard.json"}]})
+        + "\n",
+        encoding="utf-8",
+    )
     (submission_dir / "run_leaderboard.json").write_text(
         json.dumps({"model": {"name": model_name}}) + "\n",
         encoding="utf-8",
     )
+    (submission_dir / "env-manifest.json").write_text(
+        json.dumps(
+            {
+                "os": "test",
+                "python_version": "test",
+                "collected_at": "2026-08-07T00:00:00Z",
+                "frozen_inputs_required": False,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (submission_dir / "pip-packages.json").write_text("[]\n", encoding="utf-8")
+    checksum_files = (
+        "leaderboard_manifest.json",
+        "run_leaderboard.json",
+        "env-manifest.json",
+        "pip-packages.json",
+    )
+    (submission_dir / "checksums.sha256").write_text(
+        "".join(
+            f"{hashlib.sha256((submission_dir / name).read_bytes()).hexdigest()}  ./{name}\n"
+            for name in checksum_files
+        ),
+        encoding="utf-8",
+    )
+    (submission_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+
+
+def _create_artifact_validator(tmp_path: Path) -> Path:
+    validator = tmp_path / "validate-artifact.sh"
+    validator.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'test "$(tr -d \'[:space:]\' < "$1/STATUS")" = OK\n'
+        '(cd "$1" && sha256sum -c checksums.sha256 >/dev/null)\n',
+        encoding="utf-8",
+    )
+    validator.chmod(0o755)
+    return validator
+
+
+def _create_fake_python(tmp_path: Path) -> Path:
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        """#!/bin/bash
+set -euo pipefail
+if [[ "$*" == *"validate_public_leaderboard_snapshots.py"* ]]; then
+  exit "${FAKE_PUBLIC_VALIDATOR_EXIT:-0}"
+fi
+if [[ "$1" == "-" && "$#" == "2" ]]; then
+  cat >/dev/null
+  exit "${FAKE_TREND_VALIDATOR_EXIT:-0}"
+fi
+if [[ "$1" != "-m" || "$2" != "vllm_hust_benchmark.cli" || "$3" != "publish-website" ]]; then
+  echo "unexpected fake python invocation: $*" >&2
+  exit 2
+fi
+shift 3
+source_dir=""
+output_dir=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --source-dir) source_dir="$2"; shift 2 ;;
+    --output-dir) output_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$output_dir"
+runs_json=$(find "$source_dir" -mindepth 2 -maxdepth 2 -name run_leaderboard.json -print | sed 's|/run_leaderboard.json$||' | xargs -n1 basename | sort | jq -R -s 'split("\\n") | map(select(length > 0))')
+printf '{"runs":%s}\n' "$runs_json" > "$output_dir/leaderboard_single.json"
+printf '[]\n' > "$output_dir/leaderboard_multi.json"
+printf '{}\n' > "$output_dir/leaderboard_compare.json"
+printf '{}\n' > "$output_dir/last_updated.json"
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    return fake_python
+
+
+def _create_failing_verify_git(tmp_path: Path) -> Path:
+    fake_git = tmp_path / "fake-bin" / "git"
+    fake_git.parent.mkdir()
+    fake_git.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'for argument in "$@"; do\n'
+        '  if [[ "$argument" == cat-file ]]; then exit 1; fi\n'
+        "done\n"
+        'exec "$REAL_GIT" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    return fake_git
+
+
+def _create_mismatch_verify_git(tmp_path: Path) -> Path:
+    fake_git = tmp_path / "fake-bin" / "git"
+    fake_git.parent.mkdir(exist_ok=True)
+    fake_git.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'for argument in "$@"; do\n'
+        '  if [[ "$argument" == *":${FAKE_GIT_MISMATCH_PATH:-__never__}" ]]; then\n'
+        "    printf 'tampered\\n'\n"
+        "    exit 0\n"
+        "  fi\n"
+        "done\n"
+        'exec "$REAL_GIT" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    return fake_git
+
+
+def _create_fetch_exhaustion_git(tmp_path: Path) -> Path:
+    fake_git = tmp_path / "fake-bin" / "git"
+    fake_git.parent.mkdir(exist_ok=True)
+    fake_git.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'for argument in "$@"; do\n'
+        '  if [[ "$argument" == fetch && -f "${FETCH_FAILURE_MARKER:?}" ]]; then\n'
+        "    exit 1\n"
+        "  fi\n"
+        "done\n"
+        'if [[ "$1" == -C ]]; then command="$3"; else command="$1"; fi\n'
+        '"$REAL_GIT" "$@"\n'
+        "status=$?\n"
+        'if [[ "$command" == push && $status -eq 0 ]]; then touch "$FETCH_FAILURE_MARKER"; fi\n'
+        "exit $status\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    return fake_git
 
 
 def _create_target_repo(tmp_path: Path) -> tuple[Path, Path]:
@@ -132,15 +277,18 @@ def test_sync_official_baseline_snapshots_to_github_pushes_and_is_idempotent(
     remote_repo, target_repo = _create_target_repo(tmp_path)
     website_repo = _create_dummy_website_repo(tmp_path)
     local_snapshot_output_dir = tmp_path / "published-snapshots"
+    github_env = tmp_path / "github.env"
 
     env = _script_env(
         ALLOW_LOCAL_GIT_RESET="1",
         SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
         TARGET_BENCHMARK_REPO_DIR=str(target_repo),
         WEBSITE_REPO_DIR=str(website_repo),
-        PYTHON_BIN=sys.executable,
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
         LOCAL_SNAPSHOT_OUTPUT_DIR=str(local_snapshot_output_dir),
         SNAPSHOT_COMMIT_MESSAGE="test: publish official baseline snapshots",
+        GITHUB_ENV=str(github_env),
     )
 
     first_run = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
@@ -174,11 +322,164 @@ def test_sync_official_baseline_snapshots_to_github_pushes_and_is_idempotent(
         "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
     ]
     assert (local_snapshot_output_dir / "leaderboard_single.json").is_file()
+    github_values = dict(
+        line.split("=", maxsplit=1)
+        for line in github_env.read_text(encoding="utf-8").splitlines()
+    )
+    assert github_values["GITHUB_SNAPSHOT_SYNC_STATUS"] == "pushed"
+    assert github_values["GITHUB_SNAPSHOT_SYNC_VERIFICATION"] == "verified"
+    assert (
+        github_values["GITHUB_SNAPSHOT_SYNC_REPO"]
+        == "vLLM-HUST" + "/vllm-hust-benchmark"
+    )
+    assert github_values["GITHUB_SNAPSHOT_SYNC_BRANCH"] == "main"
+    assert github_values["GITHUB_SNAPSHOT_SYNC_SNAPSHOT_PATH"] == (
+        "leaderboard-data" + "/snapshots"
+    )
+    assert github_values["GITHUB_SNAPSHOT_SYNC_SUBMISSION_PATHS"] == ",".join(
+        f"submissions/{run_id}" for run_id in snapshot_payload["runs"]
+    )
 
     second_run = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
     assert second_run.returncode == 0, second_run.stderr
     assert "already up to date" in second_run.stdout
     assert pushed_head == _git(target_repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_sync_verification_rejects_remote_content_mismatch(tmp_path: Path) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    run_id = "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    _write_submission(source_repo, run_id, "Qwen2.5-14B-Instruct")
+    _, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    fake_git = _create_mismatch_verify_git(tmp_path)
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        PATH=f"{fake_git.parent}:{os.environ['PATH']}",
+        REAL_GIT=shutil.which("git") or "git",
+        FAKE_GIT_MISMATCH_PATH=f"submissions/{run_id}/run_leaderboard.json",
+    )
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+    assert completed.returncode != 0
+    assert "content mismatch" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("failure_env", "expected_error"),
+    (
+        ("FAKE_PUBLIC_VALIDATOR_EXIT", "public snapshot validation"),
+        ("FAKE_TREND_VALIDATOR_EXIT", "trend validation"),
+    ),
+)
+def test_sync_rejects_snapshot_validation_before_git_write(
+    tmp_path: Path,
+    failure_env: str,
+    expected_error: str,
+) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    run_id = "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    _write_submission(source_repo, run_id, "Qwen2.5-14B-Instruct")
+    remote_repo, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    original_head = _git(target_repo, "rev-parse", "HEAD").stdout.strip()
+    github_env = tmp_path / "github.env"
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        GITHUB_ENV=str(github_env),
+        **{failure_env: "2"},
+    )
+
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+
+    assert completed.returncode != 0
+    assert expected_error in completed.stderr
+    assert _git(target_repo, "rev-parse", "HEAD").stdout.strip() == original_head
+    assert (
+        _run(
+            ["git", f"--git-dir={remote_repo}", "rev-parse", "refs/heads/main"]
+        ).stdout.strip()
+        == original_head
+    )
+    assert not (target_repo / "submissions" / run_id).exists()
+    assert "GITHUB_SNAPSHOT_SYNC_STATUS=rejected" in github_env.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_sync_verification_rejects_remote_missing_file(tmp_path: Path) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    _write_submission(
+        source_repo,
+        "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
+        "Qwen2.5-14B-Instruct",
+    )
+    _, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    fake_git = _create_failing_verify_git(tmp_path)
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        PATH=f"{fake_git.parent}:{os.environ['PATH']}",
+        REAL_GIT=shutil.which("git") or "git",
+        SNAPSHOT_MAX_FETCH_ATTEMPTS="1",
+    )
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+    assert completed.returncode != 0
+    assert "verification failed" in completed.stderr
+
+
+def test_sync_reports_pushed_but_failed_when_verification_fetch_is_exhausted(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    _write_submission(
+        source_repo,
+        "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
+        "Qwen2.5-14B-Instruct",
+    )
+    _, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    fake_git = _create_fetch_exhaustion_git(tmp_path)
+    github_env = tmp_path / "github.env"
+    marker = tmp_path / "fetch-failure.marker"
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        PATH=f"{fake_git.parent}:{os.environ['PATH']}",
+        REAL_GIT=shutil.which("git") or "git",
+        FETCH_FAILURE_MARKER=str(marker),
+        GITHUB_ENV=str(github_env),
+        SNAPSHOT_MAX_FETCH_ATTEMPTS="2",
+        SNAPSHOT_FETCH_RETRY_SECONDS="0",
+        SNAPSHOT_MAX_PUSH_ATTEMPTS="1",
+    )
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+    assert completed.returncode != 0
+    github_values = github_env.read_text(encoding="utf-8")
+    assert "GITHUB_SNAPSHOT_SYNC_STATUS=pushed" in github_values
+    assert "GITHUB_SNAPSHOT_SYNC_VERIFICATION=failed" in github_values
 
 
 def test_sync_official_baseline_snapshots_to_github_can_skip_empty_source(
@@ -196,6 +497,7 @@ def test_sync_official_baseline_snapshots_to_github_can_skip_empty_source(
         TARGET_BENCHMARK_REPO_DIR=str(target_repo),
         WEBSITE_REPO_DIR=str(website_repo),
         PYTHON_BIN=sys.executable,
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
         SNAPSHOT_SOURCE_PATTERN="official-ascend-*",
     )
 

--- a/tests/test_sync_official_baseline_snapshots_to_github.py
+++ b/tests/test_sync_official_baseline_snapshots_to_github.py
@@ -201,6 +201,22 @@ def _create_fetch_exhaustion_git(tmp_path: Path) -> Path:
     return fake_git
 
 
+def _create_push_exhaustion_git(tmp_path: Path) -> Path:
+    fake_git = tmp_path / "fake-bin" / "git"
+    fake_git.parent.mkdir(exist_ok=True)
+    fake_git.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'for argument in "$@"; do\n'
+        '  if [[ "$argument" == push ]]; then exit 1; fi\n'
+        "done\n"
+        'exec "$REAL_GIT" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    return fake_git
+
+
 def _create_target_repo(tmp_path: Path) -> tuple[Path, Path]:
     remote_repo = tmp_path / "benchmark-remote.git"
     _run(["git", "init", "--bare", "--initial-branch=main", str(remote_repo)])
@@ -480,6 +496,84 @@ def test_sync_reports_pushed_but_failed_when_verification_fetch_is_exhausted(
     github_values = github_env.read_text(encoding="utf-8")
     assert "GITHUB_SNAPSHOT_SYNC_STATUS=pushed" in github_values
     assert "GITHUB_SNAPSHOT_SYNC_VERIFICATION=failed" in github_values
+
+
+def test_sync_reports_failed_when_unchanged_verification_fails(tmp_path: Path) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    run_id = "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    _write_submission(source_repo, run_id, "Qwen2.5-14B-Instruct")
+    _, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    first_env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+    )
+    first_run = _run(["bash", str(SYNC_SCRIPT)], env=first_env, check=False)
+    assert first_run.returncode == 0, first_run.stderr
+
+    github_env = tmp_path / "github.env"
+    fake_git = _create_failing_verify_git(tmp_path)
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        PATH=f"{fake_git.parent}:{os.environ['PATH']}",
+        REAL_GIT=shutil.which("git") or "git",
+        SNAPSHOT_MAX_FETCH_ATTEMPTS="1",
+        GITHUB_ENV=str(github_env),
+    )
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+
+    assert completed.returncode != 0
+    github_values = dict(
+        line.split("=", maxsplit=1)
+        for line in github_env.read_text(encoding="utf-8").splitlines()
+    )
+    assert github_values["GITHUB_SNAPSHOT_SYNC_STATUS"] == "unchanged"
+    assert github_values["GITHUB_SNAPSHOT_SYNC_VERIFICATION"] == "failed"
+
+
+def test_sync_reports_failed_when_push_retries_are_exhausted(tmp_path: Path) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    _write_submission(
+        source_repo,
+        "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3",
+        "Qwen2.5-14B-Instruct",
+    )
+    _, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    fake_git = _create_push_exhaustion_git(tmp_path)
+    github_env = tmp_path / "github.env"
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(_create_artifact_validator(tmp_path)),
+        PATH=f"{fake_git.parent}:{os.environ['PATH']}",
+        REAL_GIT=shutil.which("git") or "git",
+        SNAPSHOT_MAX_PUSH_ATTEMPTS="2",
+        SNAPSHOT_PUSH_RETRY_SECONDS="0",
+        GITHUB_ENV=str(github_env),
+    )
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+
+    assert completed.returncode != 0
+    github_values = dict(
+        line.split("=", maxsplit=1)
+        for line in github_env.read_text(encoding="utf-8").splitlines()
+    )
+    assert github_values["GITHUB_SNAPSHOT_SYNC_STATUS"] == "failed"
 
 
 def test_sync_official_baseline_snapshots_to_github_can_skip_empty_source(


### PR DESCRIPTION
## Summary

  加强 official Ascend baseline 的 source provenance 和 matrix 隔离，确保 benchmark artifact 能明确绑定实际运行的源码状
  态。

  主要修改：
  - 按 `vllm` / `vllm-ascend` source tuple 独立准备和执行，修复默认 matrix 同时包含 `v0.18.0` 与 `main` 时整体失败的问
  题；
  - 为不同 source tuple 使用独立 worktree，避免源码混用，并将 worktree 放在结果 artifact 目录之外；
  - 记录 requested ref、immutable commit、tracked patch SHA-256、working-tree digest 和 source 状态；
  - 将 ignored 的 `_build_info.py` 和 dist-info generated files 纳入 provenance digest；
  - 将 source provenance 写入 `run_leaderboard.json` 和 `env-manifest.json`，并进行 fail-closed 一致性校验；
  - 增加 mixed source tuple、独立 worktree 和 ignored generated file 的回归测试。

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  Executed:

  ```bash
  PYTHONPATH=src:. pytest -q \
    tests/test_official_baseline_matrix_script.py \
    tests/test_official_source_provenance.py \
    tests/test_campaign_collection_scripts.py \
    tests/test_official_baselines.py \
    tests/test_official_runtime_inputs.py \
    tests/test_sync_official_baseline_snapshots_to_github.py

  Result: 55 passed

  Additional checks:

  pre-commit run --files \
    scripts/capture-official-source-provenance.py \
    scripts/run-official-ascend-goal-baseline-matrix.sh \
    scripts/run-official-ascend-goal-baseline.sh \
    tests/test_official_baseline_matrix_script.py \
    tests/test_official_source_provenance.py

  bash -n scripts/run-official-ascend-goal-baseline-matrix.sh \
    scripts/run-official-ascend-goal-baseline.sh

  shellcheck -S error \
    scripts/run-official-ascend-goal-baseline-matrix.sh \
    scripts/run-official-ascend-goal-baseline.sh

  python3 -m py_compile scripts/capture-official-source-provenance.py
  git diff --check

  All completed checks passed. actionlint was not run because it is not installed in the local environment.

  ## Risks

  - This PR changes official baseline preparation and matrix orchestration behavior.
  - Different source tuples now use separate worktrees and may invoke environment preparation more than once.
  - No Ascend hardware benchmark, publication, or HF synchronization was executed locally.
  - The PR is based on the latest benchmark main and contains no data migration.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [ ] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.