### PR TITLE
feat(issue-136): fix dense 1/2/4 matrix target and communication-sensitive specs

### DIFF
--- a/docs/OFFICIAL_TARGETS.md
+++ b/docs/OFFICIAL_TARGETS.md
@@ -2,8 +2,8 @@
 
 > This file is generated from the official specs. Do not edit it manually.
 
-- Registry version: `1.3.2`
-- Effective from: `2026-08-11`
+- Registry version: `1.3.3`
+- Effective from: `2026-08-13`
 
 Public leaderboard targets and 3B perfgate profiles are separate contracts. Provisional entries are
 not valid public-result comparison targets.
@@ -111,6 +111,9 @@ Qwen/Qwen2.5-14B-Instruct | 910B2 × 4 | FP16 | — | — |
 | | specialty | provisional | multi-chip | unified-comm-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
 2 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-910b2.json)
+| | specialty | provisional | multi-chip | unified-comm-online-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json)
 | | specialty | provisional | specialty | kv-tiering-prefix-online | Qwen/Qwen2.5-7B-Instruct |
 910B2 × 1 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json)
@@ -162,6 +165,9 @@ Qwen/Qwen2.5-14B-Instruct | 910B2 × 1 | FP16 | — | — |
 | | specialty | provisional | specialty-text | spec-decode-online | Qwen/Qwen2.5-14B-Instruct |
 910B2 × 1 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-spec-decode-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-spec-decode-online-qwen25-14b-910b2.json)
+| | specialty | provisional | specialty-text | unified-comm-online-1chip | Qwen/Qwen2.5-14B-Instruct
+| 910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json)
 |
 
 Machine-readable snapshot:

--- a/docs/OFFICIAL_TARGETS.zh-CN.md
+++ b/docs/OFFICIAL_TARGETS.zh-CN.md
@@ -2,8 +2,8 @@
 
 > 本文件由 official specs 自动生成，请勿手工修改。
 
-- Registry version: `1.3.2`
-- Effective from: `2026-08-11`
+- Registry version: `1.3.3`
+- Effective from: `2026-08-13`
 
 公开排行榜固定靶与 3B 快速门禁是不同契约；provisional 记录不得作为公开成果对比。
 
@@ -110,6 +110,9 @@ Qwen/Qwen2.5-14B-Instruct | 910B2 × 4 | FP16 | — | — |
 | | specialty | provisional | multi-chip | unified-comm-online | Qwen/Qwen2.5-14B-Instruct | 910B2 ×
 2 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-910b2.json)
+| | specialty | provisional | multi-chip | unified-comm-online-4chip | Qwen/Qwen2.5-14B-Instruct |
+910B2 × 4 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json)
 | | specialty | provisional | specialty | kv-tiering-prefix-online | Qwen/Qwen2.5-7B-Instruct |
 910B2 × 1 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-kv-tiering-prefix-online-qwen25-7b-910b2.json)
@@ -161,6 +164,9 @@ Qwen/Qwen2.5-14B-Instruct | 910B2 × 1 | FP16 | — | — |
 | | specialty | provisional | specialty-text | spec-decode-online | Qwen/Qwen2.5-14B-Instruct |
 910B2 × 1 | FP16 | — | — |
 [`official-ascend-jan-2026-v0180-spec-decode-online-qwen25-14b-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-spec-decode-online-qwen25-14b-910b2.json)
+| | specialty | provisional | specialty-text | unified-comm-online-1chip | Qwen/Qwen2.5-14B-Instruct
+| 910B2 × 1 | FP16 | — | — |
+[`official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json`](../docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json)
 |
 
 机器可读快照：[`leaderboard-data/official-targets.json`](../leaderboard-data/official-targets.json)

--- a/docs/OFFICIAL_TARGETS_CHANGELOG.md
+++ b/docs/OFFICIAL_TARGETS_CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > Generated from `official_target_versions.json`. Do not edit manually.
 
+## 1.3.3 — 2026-08-13
+
+- English: Derive unified-comm-online 1chip and 4chip single-node non-executable draft specs from
+  the existing 2chip draft as provisional specialty profiles for the Issue #136
+  communication-sensitive Dense matrix cells.
+- 中文：从现有 2chip 草案派生 unified-comm-online 1chip 和 4chip 单节点不可执行草案 spec，作为 provisional specialty
+  profile，用于 Issue #136 通信敏感Dense 矩阵的 cell。
+- Source set: `b27e7d5b6d8f8e77edf6fff003f15fb1d1396c803ba5ddae8d729a66d6371a43`
+- Supersedes: `1.3.2`
+
 ## 1.3.2 — 2026-08-11
 
 - English: Add 7 Ascend 910B3 full-graph-parallel inplace specialty specs

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json
@@ -1,0 +1,51 @@
+{
+  "id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-1chip-910b2",
+  "label": "Official Ascend Jan 2026 unified communication baseline (1chip, non-executable draft — pending custom comm path upstream support)",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.18.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.18.0",
+    "vllm_ascend_ref": "v0.18.0"
+  },
+  "scenario": "unified-comm-online-1chip",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 1,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 1,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "random",
+    "num_prompts": 200,
+    "input_len": 1024,
+    "output_len": 256,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.18.0",
+    "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json
+++ b/docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json
@@ -1,0 +1,51 @@
+{
+  "id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-4chip-910b2",
+  "label": "Official Ascend Jan 2026 unified communication baseline (4chip, non-executable draft — pending custom comm path upstream support)",
+  "baseline_target": {
+    "id": "official-ascend-jan-2026-v0.18.0",
+    "label": "Official Ascend Jan 2026",
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "github_repository": "vllm-project/vllm-ascend",
+    "vllm_ref": "v0.18.0",
+    "vllm_ascend_ref": "v0.18.0"
+  },
+  "scenario": "unified-comm-online-4chip",
+  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model_parameters": "14B",
+  "model_precision": "FP16",
+  "hardware_vendor": "Huawei",
+  "hardware_chip_model": "910B2",
+  "chip_count": 4,
+  "node_count": 1,
+  "server_parameters": {
+    "tensor_parallel_size": 4,
+    "enforce_eager": "",
+    "trust_remote_code": "",
+    "disable_log_stats": "",
+    "disable_log_requests": "",
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "client_parameters": {
+    "backend": "vllm",
+    "endpoint": "/v1/completions",
+    "dataset_name": "random",
+    "num_prompts": 200,
+    "input_len": 1024,
+    "output_len": 256,
+    "request_rate": 1,
+    "host": "127.0.0.1",
+    "port": 8000
+  },
+  "export": {
+    "engine": "vllm",
+    "engine_version": "0.18.0",
+    "submitter": "official-ascend-baseline",
+    "baseline_engine": "vllm",
+    "github_repository": "vllm-project/vllm-ascend",
+    "github_ref": "v0.18.0",
+    "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+    "data_source": "reference-vllm-ascend-benchmark"
+  }
+}

--- a/leaderboard-data/dense-matrix-issue-136.json
+++ b/leaderboard-data/dense-matrix-issue-136.json
@@ -19,6 +19,9 @@
       "workload": "random-online",
       "model": "Qwen2.5-14B-Instruct",
       "precision": "FP16",
+      "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",
+      "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+      "node_topology": "single-node",
       "cells": {
         "1chip": {
           "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
@@ -50,6 +53,9 @@
       "workload": "sharegpt-online",
       "model": "Qwen2.5-14B-Instruct",
       "precision": "FP16",
+      "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",
+      "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+      "node_topology": "single-node",
       "cells": {
         "1chip": {
           "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
@@ -81,6 +87,9 @@
       "workload": "prefix-repetition-online",
       "model": "Qwen2.5-14B-Instruct",
       "precision": "FP16",
+      "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",
+      "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+      "node_topology": "single-node",
       "cells": {
         "1chip": {
           "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
@@ -112,6 +121,9 @@
       "workload": "agent-research-online",
       "model": "Qwen2.5-14B-Instruct",
       "precision": "FP16",
+      "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",
+      "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+      "node_topology": "single-node",
       "cells": {
         "1chip": {
           "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
@@ -143,6 +155,9 @@
       "workload": "communication-sensitive",
       "model": "Qwen2.5-14B-Instruct",
       "precision": "FP16",
+      "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",
+      "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+      "node_topology": "single-node",
       "cells": {
         "1chip": {
           "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json",

--- a/leaderboard-data/dense-matrix-issue-136.json
+++ b/leaderboard-data/dense-matrix-issue-136.json
@@ -1,0 +1,196 @@
+{
+  "schema_version": "dense-matrix-issue-136/v1",
+  "issue": "https://github.com/vLLM-HUST/vllm-hust-benchmark/issues/136",
+  "hardware": {
+    "chip_model": "910B2",
+    "node_count": 1
+  },
+  "model_revision_contract": "All dense cells must use the same frozen model revision, precision, core/backend commit, node type, and HCCS/network topology (per #136 and docs/issue-136-ascend-evidence-execution.md).",
+  "load_profiles": {
+    "fixed-1-rps": {
+      "description": "fixed 1 RPS low-load latency checkpoint; not for capacity scaling conclusions"
+    },
+    "matched-load": {
+      "description": "capacity-matched load determined by a capacity pilot on the frozen stack; required for scaling efficiency"
+    }
+  },
+  "workloads": [
+    {
+      "workload": "random-online",
+      "model": "Qwen2.5-14B-Instruct",
+      "precision": "FP16",
+      "cells": {
+        "1chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "2chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-2chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "4chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-4chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        }
+      }
+    },
+    {
+      "workload": "sharegpt-online",
+      "model": "Qwen2.5-14B-Instruct",
+      "precision": "FP16",
+      "cells": {
+        "1chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "2chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-2chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "4chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-sharegpt-online-qwen25-14b-4chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        }
+      }
+    },
+    {
+      "workload": "prefix-repetition-online",
+      "model": "Qwen2.5-14B-Instruct",
+      "precision": "FP16",
+      "cells": {
+        "1chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "2chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-2chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "4chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-prefix-repetition-online-qwen25-14b-4chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        }
+      }
+    },
+    {
+      "workload": "agent-research-online",
+      "model": "Qwen2.5-14B-Instruct",
+      "precision": "FP16",
+      "cells": {
+        "1chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "2chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-2chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        },
+        "4chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-agent-research-online-qwen25-14b-4chip-910b2.json",
+          "status": "spec-ready",
+          "load_profiles": [
+            "fixed-1-rps",
+            "matched-load"
+          ]
+        }
+      }
+    },
+    {
+      "workload": "communication-sensitive",
+      "model": "Qwen2.5-14B-Instruct",
+      "precision": "FP16",
+      "cells": {
+        "1chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json",
+          "status": "blocked",
+          "load_profiles": [
+            "matched-load"
+          ],
+          "blocker_reason": "unified-comm custom comm path not supported upstream; single-node 1-chip comm spec is non-executable"
+        },
+        "2chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-910b2.json",
+          "status": "blocked",
+          "load_profiles": [
+            "matched-load"
+          ],
+          "blocker_reason": "unified-comm custom comm path not supported upstream (existing spec is non-executable draft)"
+        },
+        "4chip": {
+          "spec": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json",
+          "status": "blocked",
+          "load_profiles": [
+            "matched-load"
+          ],
+          "blocker_reason": "unified-comm custom comm path not supported upstream; single-node 4-chip comm spec is non-executable"
+        }
+      }
+    }
+  ],
+  "profiler": {
+    "required": true,
+    "profiler_script": "run-current-ascend-same-spec-msprof.sh",
+    "note": "Collect an unprofiled three-service series first; never mix profiler-affected metrics. Per-rank AI Core/Vector, copy, communication, visible-idle, HCCL collectives, compute/comm overlap, scheduler/pipeline waits."
+  },
+  "evidence_rules": {
+    "reps_per_cell": 3,
+    "independent_services": "3 independent service processes per cell (strict repetition, not same-server PERFGATE_MEASURED_RUNS=3)",
+    "no_cross_stack_percentage": "Do not compute scaling percentages across different model revisions, chip counts, topologies, or workloads",
+    "no_cross_sha_anchor": "Re-run affected cells after implementation commits merge and a unique current-main stack is frozen",
+    "missing_baseline": "Mark cell blocked and publish no delta if comparable baseline missing"
+  },
+  "status": {
+    "overall": "matrix-target-fixed",
+    "spec_ready_cells": 12,
+    "blocked_cells": 3,
+    "performance_percentages_published": false,
+    "blockers": [
+      "Ascend PR #186/#196/#201 not merged; unique current-main commit pair not frozen",
+      "communication-sensitive single-node spec non-executable (custom comm path upstream support pending)"
+    ]
+  }
+}

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -1,8 +1,8 @@
 {
-  "effective_from": "2026-08-11",
-  "registry_version": "1.3.2",
+  "effective_from": "2026-08-13",
+  "registry_version": "1.3.3",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "550fb56cfa642490f1a4d82c19032711bbb01acc2a7eb7498d0fd2a00a1481ae",
+  "source_set_sha256": "b27e7d5b6d8f8e77edf6fff003f15fb1d1396c803ba5ddae8d729a66d6371a43",
   "targets": [
     {
       "baseline_runtime": {
@@ -20,7 +20,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -52,7 +52,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -84,7 +84,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -116,7 +116,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -147,7 +147,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -179,7 +179,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -212,7 +212,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -241,7 +241,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -270,7 +270,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -302,7 +302,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -335,7 +335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -367,7 +367,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -399,7 +399,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -428,7 +428,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -457,7 +457,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -486,7 +486,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -515,7 +515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -550,7 +550,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -583,7 +583,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -615,7 +615,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -648,7 +648,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -683,7 +683,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -716,7 +716,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -748,7 +748,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -780,7 +780,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -814,7 +814,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -848,7 +848,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -878,7 +878,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 1,
@@ -906,7 +906,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -939,7 +939,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -972,7 +972,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1004,7 +1004,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1036,7 +1036,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1065,7 +1065,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1093,7 +1093,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1122,7 +1122,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1150,7 +1150,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1180,7 +1180,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1211,7 +1211,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1241,7 +1241,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1272,7 +1272,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1303,7 +1303,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-eplb-expert-rebalance-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1335,7 +1335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1366,7 +1366,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-transfer-latency-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "host": "127.0.0.1",
@@ -1394,7 +1394,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1424,7 +1424,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-moe-alltoall-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1456,7 +1456,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1486,7 +1486,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-multi-nic-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "dataset_name": "sharegpt",
@@ -1515,7 +1515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1545,7 +1545,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1577,7 +1577,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1607,7 +1607,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1639,7 +1639,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1669,7 +1669,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1701,7 +1701,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1731,7 +1731,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1763,7 +1763,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1793,7 +1793,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1824,7 +1824,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1854,7 +1854,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1885,7 +1885,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1912,7 +1912,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1943,7 +1943,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1970,7 +1970,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2001,7 +2001,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 8,
         "chip_model": "910B2",
@@ -2028,7 +2028,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2059,7 +2059,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -2089,7 +2089,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2121,7 +2121,69 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "088fb3cd5e82bb25472e75b95bcd4b56b738a8c3222fc33952e4eafb54b6e95a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.3.3",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "unified-comm-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2151,7 +2213,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2185,7 +2247,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2215,7 +2277,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2246,7 +2308,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2277,7 +2339,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-cache-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -2309,7 +2371,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2341,7 +2403,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-attention-boundary-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2374,7 +2436,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2406,7 +2468,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-instructcoder-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2438,7 +2500,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2469,7 +2531,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-knorm-kv-compression-longctx-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2501,7 +2563,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2532,7 +2594,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2565,7 +2627,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2595,7 +2657,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2628,7 +2690,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2660,7 +2722,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-prefix-repetition-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2693,7 +2755,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2722,7 +2784,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-random-latency-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -2751,7 +2813,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2783,7 +2845,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-random-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2816,7 +2878,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2847,7 +2909,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-saturated-warm-cache-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2880,7 +2942,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2912,7 +2974,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sharegpt-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2944,7 +3006,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2973,7 +3035,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sharegpt-throughput-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3002,7 +3064,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -3032,7 +3094,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-slicegpt-compression-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3064,7 +3126,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -3093,7 +3155,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sonnet-throughput-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3122,7 +3184,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -3152,7 +3214,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-spec-decode-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3166,6 +3228,68 @@
           "request_rate": 1
         },
         "name": "spec-decode-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-08-13",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "specialty-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json",
+        "sha256": "b3be912206f228d61a603d024a3c535632fdc56485d9abea244e4c9658b19752"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-1chip-910b2",
+      "target_version": "1.3.3",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "unified-comm-online-1chip"
       }
     }
   ]

--- a/leaderboard-data/official-targets.sha256
+++ b/leaderboard-data/official-targets.sha256
@@ -1,1 +1,1 @@
-4231c31a49fec88305b62efa82cb7caabf1b5d48c089ce219390ee98b139e980  official-targets.json
+6c3d4aead8bd2caca657c3d93d2babe13f20d5e4ae192fa383577194c3ec9730  official-targets.json

--- a/src/vllm_hust_benchmark/data/official_scenarios.json
+++ b/src/vllm_hust_benchmark/data/official_scenarios.json
@@ -733,6 +733,60 @@
       }
     },
     {
+      "name": "unified-comm-online-1chip",
+      "title": "Unified communication abstraction online serving benchmark (1-chip)",
+      "benchmark_type": "serve",
+      "description": "Communication-sensitive single-chip online workload for unified_comm abstraction evaluation. Non-executable draft pending upstream custom comm path support (Issue #136).",
+      "tags": [
+        "official",
+        "online",
+        "communication",
+        "multi-chip",
+        "issue-89",
+        "1chip"
+      ],
+      "leaderboard": {
+        "workload_name": "unified-comm-online-1chip",
+        "representative_business_scenario": "multi-chip-serving",
+        "default_config_type": "single_gpu"
+      },
+      "defaults": {
+        "backend": "vllm",
+        "endpoint": "/v1/completions",
+        "dataset_name": "random",
+        "num_prompts": 200,
+        "input_len": 1024,
+        "output_len": 256
+      }
+    },
+    {
+      "name": "unified-comm-online-4chip",
+      "title": "Unified communication abstraction online serving benchmark (4-chip)",
+      "benchmark_type": "serve",
+      "description": "Communication-sensitive four-chip single-node online workload for unified_comm abstraction evaluation. Non-executable draft pending upstream custom comm path support (Issue #136).",
+      "tags": [
+        "official",
+        "online",
+        "communication",
+        "multi-chip",
+        "issue-89",
+        "4chip"
+      ],
+      "leaderboard": {
+        "workload_name": "unified-comm-online-4chip",
+        "representative_business_scenario": "multi-chip-serving",
+        "default_config_type": "multi_gpu"
+      },
+      "defaults": {
+        "backend": "vllm",
+        "endpoint": "/v1/completions",
+        "dataset_name": "random",
+        "num_prompts": 200,
+        "input_len": 1024,
+        "output_len": 256
+      }
+    },
+    {
       "name": "multi-nic-throughput",
       "title": "Multi-NIC throughput benchmark (issue #89)",
       "benchmark_type": "throughput",

--- a/src/vllm_hust_benchmark/data/official_target_versions.json
+++ b/src/vllm_hust_benchmark/data/official_target_versions.json
@@ -40,6 +40,14 @@
       "supersedes": "1.3.1",
       "summary_en": "Add 7 Ascend 910B3 full-graph-parallel inplace specialty specs (cudagraph_mode=FULL_DECODE_ONLY + split_batch inplace_parallel, temperature 0.0) as provisional profiles, one per workload (random-online, random-latency, sharegpt-online, sharegpt-throughput, sonnet-throughput, prefix-repetition-online, instructcoder-online). Registry classifier now gates public-leaderboard/active on hardware_chip_model == 910B2; 910B3 specs are always specialty/provisional.",
       "summary_zh": "新增 7 个 Ascend 910B3 full-graph-parallel inplace 专用 spec（cudagraph_mode=FULL_DECODE_ONLY + split_batch inplace_parallel、temperature 0.0）作为 provisional profile，每个 workload 一份（random-online、random-latency、sharegpt-online、sharegpt-throughput、sonnet-throughput、prefix-repetition-online、instructcoder-online）。registry 分类器新增硬件门禁：仅 hardware_chip_model == 910B2 可判为 public-leaderboard/active；910B3 一律为 specialty/provisional。"
+    },
+    {
+      "version": "1.3.3",
+      "effective_from": "2026-08-13",
+      "source_set_sha256": "b27e7d5b6d8f8e77edf6fff003f15fb1d1396c803ba5ddae8d729a66d6371a43",
+      "supersedes": "1.3.2",
+      "summary_en": "Derive unified-comm-online 1chip and 4chip single-node non-executable draft specs from the existing 2chip draft as provisional specialty profiles for the Issue #136 communication-sensitive Dense matrix cells.",
+      "summary_zh": "从现有 2chip 草案派生 unified-comm-online 1chip 和 4chip 单节点不可执行草案 spec，作为 provisional specialty profile，用于 Issue #136 通信敏感Dense 矩阵的 cell。"
     }
   ]
 }

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -1,8 +1,8 @@
 {
-  "effective_from": "2026-08-11",
-  "registry_version": "1.3.2",
+  "effective_from": "2026-08-13",
+  "registry_version": "1.3.3",
   "schema_version": "official-target-registry/v1",
-  "source_set_sha256": "550fb56cfa642490f1a4d82c19032711bbb01acc2a7eb7498d0fd2a00a1481ae",
+  "source_set_sha256": "b27e7d5b6d8f8e77edf6fff003f15fb1d1396c803ba5ddae8d729a66d6371a43",
   "targets": [
     {
       "baseline_runtime": {
@@ -20,7 +20,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -52,7 +52,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-instructcoder-online-qwen25-coder-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -84,7 +84,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -116,7 +116,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -147,7 +147,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -179,7 +179,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -212,7 +212,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -241,7 +241,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-latency-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -270,7 +270,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -302,7 +302,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -335,7 +335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -367,7 +367,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -399,7 +399,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -428,7 +428,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -457,7 +457,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -486,7 +486,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -515,7 +515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -550,7 +550,7 @@
       "status": "active",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-visionarena-online-qwen25-vl-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -583,7 +583,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -615,7 +615,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-instructcoder-online-qwen25-coder-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -648,7 +648,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -683,7 +683,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-visionarena-online-qwen25-vl-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -716,7 +716,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -748,7 +748,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-agent-research-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -780,7 +780,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -814,7 +814,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-prefix-repetition-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -848,7 +848,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -878,7 +878,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-random-latency-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 1,
@@ -906,7 +906,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -939,7 +939,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -972,7 +972,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1004,7 +1004,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-online-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1036,7 +1036,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1065,7 +1065,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sharegpt-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1093,7 +1093,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -1122,7 +1122,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "perfgate-ascend-sonnet-throughput-qwen25-3b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1150,7 +1150,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1180,7 +1180,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1211,7 +1211,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1241,7 +1241,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-research-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -1272,7 +1272,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1303,7 +1303,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-eplb-expert-rebalance-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1335,7 +1335,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1366,7 +1366,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-transfer-latency-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "host": "127.0.0.1",
@@ -1394,7 +1394,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1424,7 +1424,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-moe-alltoall-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1456,7 +1456,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1486,7 +1486,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-multi-nic-throughput-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "dataset_name": "sharegpt",
@@ -1515,7 +1515,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1545,7 +1545,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1577,7 +1577,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1607,7 +1607,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-prefix-repetition-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1639,7 +1639,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1669,7 +1669,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1701,7 +1701,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1731,7 +1731,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1763,7 +1763,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1793,7 +1793,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1824,7 +1824,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1854,7 +1854,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1885,7 +1885,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -1912,7 +1912,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-2chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -1943,7 +1943,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 4,
         "chip_model": "910B2",
@@ -1970,7 +1970,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-4chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2001,7 +2001,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 8,
         "chip_model": "910B2",
@@ -2028,7 +2028,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-sonnet-throughput-qwen25-14b-8chip-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2059,7 +2059,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 2,
         "chip_model": "910B2",
@@ -2089,7 +2089,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2121,7 +2121,69 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
+      "hardware": {
+        "chip_count": 4,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "multi-chip",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 4,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-4chip-910b2.json",
+        "sha256": "088fb3cd5e82bb25472e75b95bcd4b56b738a8c3222fc33952e4eafb54b6e95a"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-4chip-910b2",
+      "target_version": "1.3.3",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "unified-comm-online-4chip"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2151,7 +2213,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-tiering-prefix-online-qwen25-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2185,7 +2247,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2215,7 +2277,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-ngram-instructcoder-online-qwen25-7b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2246,7 +2308,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2277,7 +2339,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-agent-cache-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "openai-chat",
@@ -2309,7 +2371,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2341,7 +2403,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-attention-boundary-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2374,7 +2436,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2406,7 +2468,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-instructcoder-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2438,7 +2500,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2469,7 +2531,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-knorm-kv-compression-longctx-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2501,7 +2563,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2532,7 +2594,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-kv-pressure-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2565,7 +2627,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2595,7 +2657,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-logprobs-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2628,7 +2690,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2660,7 +2722,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-prefix-repetition-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2693,7 +2755,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2722,7 +2784,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-random-latency-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "batch_size": 8,
@@ -2751,7 +2813,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2783,7 +2845,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-random-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2816,7 +2878,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -2847,7 +2909,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-saturated-warm-cache-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2880,7 +2942,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2912,7 +2974,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sharegpt-online-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -2944,7 +3006,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -2973,7 +3035,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sharegpt-throughput-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3002,7 +3064,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -3032,7 +3094,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-slicegpt-compression-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3064,7 +3126,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B3",
@@ -3093,7 +3155,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "specialty-ascend-full-graph-parallel-inplace-sonnet-throughput-qwen25-14b-910b3",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3122,7 +3184,7 @@
         "server_parameters": "exact",
         "workload_parameters": "exact"
       },
-      "effective_from": "2026-08-11",
+      "effective_from": "2026-08-13",
       "hardware": {
         "chip_count": 1,
         "chip_model": "910B2",
@@ -3152,7 +3214,7 @@
       "status": "provisional",
       "supersedes": [],
       "target_id": "official-ascend-jan-2026-v0.18.0-spec-decode-online-qwen25-14b-910b2",
-      "target_version": "1.3.2",
+      "target_version": "1.3.3",
       "workload": {
         "client_parameters": {
           "backend": "vllm",
@@ -3166,6 +3228,68 @@
           "request_rate": 1
         },
         "name": "spec-decode-online"
+      }
+    },
+    {
+      "baseline_runtime": {
+        "engine": "vllm",
+        "engine_version": "0.18.0",
+        "git_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",
+        "github_repository": "vllm-project/vllm-ascend",
+        "vllm_ascend_ref": "v0.18.0",
+        "vllm_ref": "v0.18.0"
+      },
+      "compatibility_policy": {
+        "exceptions": "new-target-version-required",
+        "hardware": "exact",
+        "model": "exact",
+        "server_parameters": "exact",
+        "workload_parameters": "exact"
+      },
+      "effective_from": "2026-08-13",
+      "hardware": {
+        "chip_count": 1,
+        "chip_model": "910B2",
+        "node_count": 1,
+        "vendor": "Huawei"
+      },
+      "intended_use": "specialty",
+      "model": {
+        "id": "Qwen/Qwen2.5-14B-Instruct",
+        "parameters": "14B",
+        "precision": "FP16"
+      },
+      "profile": "specialty-text",
+      "server_parameters": {
+        "disable_log_requests": "",
+        "disable_log_stats": "",
+        "enforce_eager": "",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tensor_parallel_size": 1,
+        "trust_remote_code": ""
+      },
+      "source_spec": {
+        "path": "docs/official-baselines/official-ascend-jan-2026-v0180-unified-comm-online-qwen25-14b-1chip-910b2.json",
+        "sha256": "b3be912206f228d61a603d024a3c535632fdc56485d9abea244e4c9658b19752"
+      },
+      "status": "provisional",
+      "supersedes": [],
+      "target_id": "official-ascend-jan-2026-v0.18.0-unified-comm-online-qwen25-14b-1chip-910b2",
+      "target_version": "1.3.3",
+      "workload": {
+        "client_parameters": {
+          "backend": "vllm",
+          "dataset_name": "random",
+          "endpoint": "/v1/completions",
+          "host": "127.0.0.1",
+          "input_len": 1024,
+          "num_prompts": 200,
+          "output_len": 256,
+          "port": 8000,
+          "request_rate": 1
+        },
+        "name": "unified-comm-online-1chip"
       }
     }
   ]

--- a/src/vllm_hust_benchmark/dense_matrix_target.py
+++ b/src/vllm_hust_benchmark/dense_matrix_target.py
@@ -5,11 +5,17 @@ that the fixed Dense 1/2/4 matrix target is internally consistent:
 
 * every ``spec-ready`` cell's spec file exists and its ``chip_count`` /
   ``server_parameters.tensor_parallel_size`` match the declared chip key;
+* ``server_parameters.tensor_parallel_size`` is required and matches the chip key;
 * every ``blocked`` cell carries a ``blocker_reason``;
 * every workload has exactly the ``1chip`` / ``2chip`` / ``4chip`` cells;
 * cell status is a legal value (``spec-ready`` / ``blocked``);
+* the workload set is exactly the four core workloads plus
+  ``communication-sensitive`` (no duplicates, no unknown workloads);
 * the four core workloads are fully ``spec-ready``;
-* the ``communication-sensitive`` cells are all ``blocked``.
+* the ``communication-sensitive`` cells are all ``blocked``;
+* every workload declares the same frozen-stack identity (``model``,
+  ``precision``, ``model_revision``, ``engine_backend_commit``,
+  ``node_topology``), so all cells run the same frozen stack (#136).
 
 This module only fixes the matrix target/config/provenance. It never computes
 or publishes performance percentages.
@@ -33,6 +39,15 @@ CORE_WORKLOADS: tuple[str, ...] = (
     "agent-research-online",
 )
 COMMUNICATION_WORKLOAD = "communication-sensitive"
+EXPECTED_WORKLOADS: tuple[str, ...] = CORE_WORKLOADS + (COMMUNICATION_WORKLOAD,)
+# Frozen-stack identity fields that all dense cells must share (#136).
+IDENTITY_FIELDS: tuple[str, ...] = (
+    "model",
+    "precision",
+    "model_revision",
+    "engine_backend_commit",
+    "node_topology",
+)
 DEFAULT_MATRIX_PATH = Path("leaderboard-data/dense-matrix-issue-136.json")
 
 
@@ -73,12 +88,22 @@ def validate_dense_matrix_target(path: Path | None = None) -> DenseMatrixStatus:
     errors: list[str] = []
     spec_ready_count = 0
     blocked_count = 0
+    seen_workloads: set[str] = set()
+    identity: dict[str, str] = {}
 
     for index, workload in enumerate(workloads):
         if not isinstance(workload, Mapping):
             _error(f"workloads[{index}] must be a JSON object", errors)
             continue
         workload_name = str(workload.get("workload") or "")
+        if not workload_name:
+            _error(f"workloads[{index}] is missing 'workload'", errors)
+            continue
+        if workload_name in seen_workloads:
+            _error(f"duplicate workload {workload_name!r}", errors)
+            continue
+        seen_workloads.add(workload_name)
+
         cells = workload.get("cells")
         if not isinstance(cells, Mapping):
             _error(f"workload {workload_name!r}: 'cells' must be a JSON object", errors)
@@ -101,6 +126,9 @@ def validate_dense_matrix_target(path: Path | None = None) -> DenseMatrixStatus:
         if workload_name == COMMUNICATION_WORKLOAD:
             _require_status(workload_name, cells, "blocked", errors)
 
+        _check_identity(workload, workload_name, identity, errors)
+
+    _validate_workload_set(seen_workloads, errors)
     _check_declared_count(status, "spec_ready_cells", spec_ready_count, errors)
     _check_declared_count(status, "blocked_cells", blocked_count, errors)
 
@@ -221,18 +249,69 @@ def _validate_cell(
             errors,
         )
     server_parameters = spec.get("server_parameters")
-    if isinstance(server_parameters, Mapping):
-        tensor_parallel_size = server_parameters.get("tensor_parallel_size")
-        if (
-            tensor_parallel_size is not None
-            and int(tensor_parallel_size) != expected_chip
-        ):
+    if not isinstance(server_parameters, Mapping):
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec is missing required "
+            "'server_parameters'",
+            errors,
+        )
+        return
+    tensor_parallel_size = server_parameters.get("tensor_parallel_size")
+    if tensor_parallel_size is None:
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec server_parameters is "
+            "missing required 'tensor_parallel_size'",
+            errors,
+        )
+    elif int(tensor_parallel_size) != expected_chip:
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec server "
+            f"tensor_parallel_size {tensor_parallel_size!r} does not match "
+            f"{chip_key!r}",
+            errors,
+        )
+
+
+def _check_identity(
+    workload: Mapping[str, Any],
+    workload_name: str,
+    identity: dict[str, str],
+    errors: list[str],
+) -> None:
+    """Collect each workload's frozen-stack identity and enforce consistency."""
+    for field in IDENTITY_FIELDS:
+        value = workload.get(field)
+        if value in (None, ""):
             _error(
-                f"workload {workload_name!r} {chip_key}: spec server "
-                f"tensor_parallel_size {tensor_parallel_size!r} does not match "
-                f"{chip_key!r}",
+                f"workload {workload_name!r}: missing required identity field "
+                f"{field!r}",
                 errors,
             )
+            continue
+        value = str(value)
+        if field in identity:
+            if identity[field] != value:
+                _error(
+                    f"workload {workload_name!r}: identity field {field!r} "
+                    f"{value!r} differs from other workloads "
+                    f"({identity[field]!r})",
+                    errors,
+                )
+        else:
+            identity[field] = value
+
+
+def _validate_workload_set(
+    seen: set[str],
+    errors: list[str],
+) -> None:
+    """Ensure the workload set is exactly the expected workloads."""
+    expected = set(EXPECTED_WORKLOADS)
+    actual = set(seen)
+    for missing in sorted(expected - actual):
+        _error(f"missing required workload {missing!r}", errors)
+    for unknown in sorted(actual - expected):
+        _error(f"unknown workload {unknown!r}", errors)
 
 
 def _require_status(

--- a/src/vllm_hust_benchmark/dense_matrix_target.py
+++ b/src/vllm_hust_benchmark/dense_matrix_target.py
@@ -1,0 +1,273 @@
+"""Validate the fixed Dense 1/2/4 matrix target (Issue #136).
+
+This module loads ``leaderboard-data/dense-matrix-issue-136.json`` and checks
+that the fixed Dense 1/2/4 matrix target is internally consistent:
+
+* every ``spec-ready`` cell's spec file exists and its ``chip_count`` /
+  ``server_parameters.tensor_parallel_size`` match the declared chip key;
+* every ``blocked`` cell carries a ``blocker_reason``;
+* every workload has exactly the ``1chip`` / ``2chip`` / ``4chip`` cells;
+* cell status is a legal value (``spec-ready`` / ``blocked``);
+* the four core workloads are fully ``spec-ready``;
+* the ``communication-sensitive`` cells are all ``blocked``.
+
+This module only fixes the matrix target/config/provenance. It never computes
+or publishes performance percentages.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "dense-matrix-issue-136/v1"
+VALID_STATUS: tuple[str, ...] = ("spec-ready", "blocked")
+CHIP_KEYS: tuple[str, ...] = ("1chip", "2chip", "4chip")
+CORE_WORKLOADS: tuple[str, ...] = (
+    "random-online",
+    "sharegpt-online",
+    "prefix-repetition-online",
+    "agent-research-online",
+)
+COMMUNICATION_WORKLOAD = "communication-sensitive"
+DEFAULT_MATRIX_PATH = Path("leaderboard-data/dense-matrix-issue-136.json")
+
+
+@dataclass(frozen=True)
+class DenseMatrixStatus:
+    """Result of validating the fixed Dense matrix target."""
+
+    schema_version: str
+    overall: str
+    spec_ready_cells: int
+    blocked_cells: int
+    performance_percentages_published: bool
+    errors: tuple[str, ...]
+
+
+def validate_dense_matrix_target(path: Path | None = None) -> DenseMatrixStatus:
+    """Validate the Dense matrix definition file.
+
+    Raise ``ValueError`` for structural problems (missing file, invalid JSON,
+    wrong schema version). Semantic inconsistencies are collected into
+    ``DenseMatrixStatus.errors``.
+    """
+    target = path or DEFAULT_MATRIX_PATH
+    payload = _load_matrix(target)
+    repo_root = target.resolve().parent.parent
+
+    status = payload["status"]
+    status = status if isinstance(status, Mapping) else {}
+    overall = str(status.get("overall") or "")
+    performance_percentages_published = bool(
+        status.get("performance_percentages_published", False)
+    )
+
+    workloads = payload["workloads"]
+    if not isinstance(workloads, list):
+        raise ValueError("matrix 'workloads' must be a list")
+
+    errors: list[str] = []
+    spec_ready_count = 0
+    blocked_count = 0
+
+    for index, workload in enumerate(workloads):
+        if not isinstance(workload, Mapping):
+            _error(f"workloads[{index}] must be a JSON object", errors)
+            continue
+        workload_name = str(workload.get("workload") or "")
+        cells = workload.get("cells")
+        if not isinstance(cells, Mapping):
+            _error(f"workload {workload_name!r}: 'cells' must be a JSON object", errors)
+            continue
+
+        _validate_cells(workload_name, cells, repo_root, errors)
+
+        for chip_key in CHIP_KEYS:
+            cell = cells.get(chip_key)
+            if not isinstance(cell, Mapping):
+                continue
+            cell_status = str(cell.get("status") or "")
+            if cell_status == "spec-ready":
+                spec_ready_count += 1
+            elif cell_status == "blocked":
+                blocked_count += 1
+
+        if workload_name in CORE_WORKLOADS:
+            _require_status(workload_name, cells, "spec-ready", errors)
+        if workload_name == COMMUNICATION_WORKLOAD:
+            _require_status(workload_name, cells, "blocked", errors)
+
+    _check_declared_count(status, "spec_ready_cells", spec_ready_count, errors)
+    _check_declared_count(status, "blocked_cells", blocked_count, errors)
+
+    return DenseMatrixStatus(
+        schema_version=str(payload["schema_version"]),
+        overall=overall,
+        spec_ready_cells=spec_ready_count,
+        blocked_cells=blocked_count,
+        performance_percentages_published=performance_percentages_published,
+        errors=tuple(errors),
+    )
+
+
+def _load_matrix(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"matrix file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"matrix file is not valid JSON: {path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("matrix top-level payload must be a JSON object")
+    if str(payload.get("schema_version") or "") != SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {SCHEMA_VERSION!r}, got "
+            f"{str(payload.get('schema_version') or '')!r}"
+        )
+    if "workloads" not in payload:
+        raise ValueError("matrix is missing required field 'workloads'")
+    return dict(payload)
+
+
+def _validate_cells(
+    workload_name: str,
+    cells: Mapping[str, Any],
+    repo_root: Path,
+    errors: list[str],
+) -> None:
+    for chip_key in CHIP_KEYS:
+        if chip_key not in cells:
+            _error(
+                f"workload {workload_name!r}: missing required cell {chip_key!r}",
+                errors,
+            )
+            continue
+        cell = cells[chip_key]
+        if not isinstance(cell, Mapping):
+            _error(
+                f"workload {workload_name!r} {chip_key}: cell must be a JSON object",
+                errors,
+            )
+            continue
+        _validate_cell(workload_name, chip_key, cell, repo_root, errors)
+
+
+def _validate_cell(
+    workload_name: str,
+    chip_key: str,
+    cell: Mapping[str, Any],
+    repo_root: Path,
+    errors: list[str],
+) -> None:
+    cell_status = str(cell.get("status") or "")
+    if cell_status not in VALID_STATUS:
+        _error(
+            f"workload {workload_name!r} {chip_key}: invalid status "
+            f"{cell_status!r}, expected one of {VALID_STATUS}",
+            errors,
+        )
+        return
+
+    if cell_status == "blocked":
+        if not cell.get("blocker_reason"):
+            _error(
+                f"workload {workload_name!r} {chip_key}: blocked cell is missing "
+                "'blocker_reason'",
+                errors,
+            )
+        return
+
+    spec_rel = cell.get("spec")
+    if not spec_rel:
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec-ready cell is missing 'spec'",
+            errors,
+        )
+        return
+
+    spec_path = repo_root / str(spec_rel)
+    if not spec_path.is_file():
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec file not found: {spec_rel}",
+            errors,
+        )
+        return
+
+    try:
+        spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec file unreadable: "
+            f"{spec_rel} ({exc})",
+            errors,
+        )
+        return
+
+    expected_chip = _chip_count(chip_key)
+    if not isinstance(spec, Mapping):
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec must be a JSON object",
+            errors,
+        )
+        return
+    if int(spec.get("chip_count", -1)) != expected_chip:
+        _error(
+            f"workload {workload_name!r} {chip_key}: spec chip_count "
+            f"{spec.get('chip_count')!r} does not match {chip_key!r}",
+            errors,
+        )
+    server_parameters = spec.get("server_parameters")
+    if isinstance(server_parameters, Mapping):
+        tensor_parallel_size = server_parameters.get("tensor_parallel_size")
+        if (
+            tensor_parallel_size is not None
+            and int(tensor_parallel_size) != expected_chip
+        ):
+            _error(
+                f"workload {workload_name!r} {chip_key}: spec server "
+                f"tensor_parallel_size {tensor_parallel_size!r} does not match "
+                f"{chip_key!r}",
+                errors,
+            )
+
+
+def _require_status(
+    workload_name: str,
+    cells: Mapping[str, Any],
+    expected: str,
+    errors: list[str],
+) -> None:
+    for chip_key in CHIP_KEYS:
+        cell = cells.get(chip_key)
+        if not isinstance(cell, Mapping):
+            continue
+        cell_status = str(cell.get("status") or "")
+        if cell_status != expected:
+            _error(
+                f"workload {workload_name!r} {chip_key}: expected status "
+                f"{expected!r}, got {cell_status!r}",
+                errors,
+            )
+
+
+def _check_declared_count(
+    status: Mapping[str, Any],
+    key: str,
+    computed: int,
+    errors: list[str],
+) -> None:
+    declared = status.get(key)
+    if declared is not None and int(declared) != computed:
+        _error(f"status.{key} declares {declared!r} but computed {computed}", errors)
+
+
+def _chip_count(chip_key: str) -> int:
+    return int(chip_key[: -len("chip")])
+
+
+def _error(message: str, errors: list[str]) -> None:
+    errors.append(message)

--- a/src/vllm_hust_benchmark/official_targets.py
+++ b/src/vllm_hust_benchmark/official_targets.py
@@ -9,8 +9,8 @@ from typing import Any
 from vllm_hust_benchmark.same_spec import PREFIX_REPETITION_DEFAULT_NUM_PREFIXES
 
 SCHEMA_VERSION = "official-target-registry/v1"
-REGISTRY_VERSION = "1.3.2"
-EFFECTIVE_FROM = "2026-08-11"
+REGISTRY_VERSION = "1.3.3"
+EFFECTIVE_FROM = "2026-08-13"
 PUBLIC_TEXT_MODEL = "Qwen/Qwen2.5-14B-Instruct"
 PUBLIC_CODE_MODEL = "Qwen/Qwen2.5-Coder-14B-Instruct"
 PUBLIC_VISION_MODEL = "Qwen/Qwen2.5-VL-7B-Instruct"

--- a/tests/test_dense_matrix_target.py
+++ b/tests/test_dense_matrix_target.py
@@ -1,0 +1,285 @@
+"""Tests for the fixed Dense 1/2/4 matrix target validator (Issue #136).
+
+These tests build a scratch matrix definition and spec files under
+``tmp_path`` and exercise ``validate_dense_matrix_target`` against both the
+valid matrix and deliberately-broken variants.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_hust_benchmark.dense_matrix_target import (
+    CHIP_KEYS,
+    COMMUNICATION_WORKLOAD,
+    CORE_WORKLOADS,
+    SCHEMA_VERSION,
+    VALID_STATUS,
+    validate_dense_matrix_target,
+)
+
+CORE_CELLS = {
+    "1chip": "spec-ready",
+    "2chip": "spec-ready",
+    "4chip": "spec-ready",
+}
+COMM_CELLS = {
+    "1chip": "blocked",
+    "2chip": "blocked",
+    "4chip": "blocked",
+}
+
+
+def _spec_filename(scenario: str, chip_key: str) -> str:
+    if chip_key == "1chip":
+        return f"official-ascend-jan-2026-v0180-{scenario}-qwen25-14b-910b2.json"
+    return f"official-ascend-jan-2026-v0180-{scenario}-qwen25-14b-{chip_key}-910b2.json"
+
+
+def _spec(chip_count: int, scenario: str) -> dict:
+    return {
+        "id": f"official-ascend-jan-2026-v0.18.0-{scenario}-qwen25-14b-{chip_count}chip-910b2",
+        "label": f"test {scenario} {chip_count}chip",
+        "baseline_target": {},
+        "scenario": scenario,
+        "model": "Qwen/Qwen2.5-14B-Instruct",
+        "model_precision": "FP16",
+        "hardware_chip_model": "910B2",
+        "chip_count": chip_count,
+        "node_count": 1,
+        "server_parameters": {"tensor_parallel_size": chip_count},
+        "client_parameters": {},
+        "export": {},
+    }
+
+
+def _workload(
+    name: str, cell_statuses: dict[str, str], spec_scenario: str | None = None
+) -> dict:
+    spec_scenario = spec_scenario or name
+    cells: dict[str, dict] = {}
+    for chip_key in CHIP_KEYS:
+        status = cell_statuses[chip_key]
+        if status == "spec-ready":
+            cell: dict = {
+                "spec": f"docs/official-baselines/{_spec_filename(spec_scenario, chip_key)}",
+                "status": status,
+                "load_profiles": ["fixed-1-rps", "matched-load"],
+            }
+        else:
+            cell = {
+                "status": status,
+                "load_profiles": ["matched-load"],
+                "blocker_reason": f"blocked {name} {chip_key}",
+            }
+        cells[chip_key] = cell
+    return {
+        "workload": name,
+        "model": "Qwen2.5-14B-Instruct",
+        "precision": "FP16",
+        "cells": cells,
+    }
+
+
+def _base_matrix() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": "https://github.com/vLLM-HUST/vllm-hust-benchmark/issues/136",
+        "hardware": {"chip_model": "910B2", "node_count": 1},
+        "model_revision_contract": "test contract",
+        "load_profiles": {
+            "fixed-1-rps": {"description": "fixed 1 RPS"},
+            "matched-load": {"description": "matched load"},
+        },
+        "workloads": [
+            _workload("random-online", CORE_CELLS),
+            _workload("sharegpt-online", CORE_CELLS),
+            _workload("prefix-repetition-online", CORE_CELLS),
+            _workload("agent-research-online", CORE_CELLS),
+            _workload(
+                "communication-sensitive",
+                COMM_CELLS,
+                spec_scenario="unified-comm-online",
+            ),
+        ],
+        "profiler": {"required": True, "profiler_script": "unused.sh", "note": ""},
+        "evidence_rules": {
+            "reps_per_cell": 3,
+            "independent_services": "3 independent service processes per cell",
+            "no_cross_stack_percentage": "do not compute",
+            "no_cross_sha_anchor": "re-run after freeze",
+            "missing_baseline": "mark blocked",
+        },
+        "status": {
+            "overall": "matrix-target-fixed",
+            "spec_ready_cells": 12,
+            "blocked_cells": 3,
+            "performance_percentages_published": False,
+            "blockers": ["test blocker"],
+        },
+    }
+
+
+def _write_specs(root: Path, matrix: dict) -> None:
+    for workload in matrix["workloads"]:
+        for chip_key, cell in workload["cells"].items():
+            if cell["status"] != "spec-ready":
+                continue
+            spec_path = root / cell["spec"]
+            spec_path.parent.mkdir(parents=True, exist_ok=True)
+            chip_count = int(chip_key[: -len("chip")])
+            spec_path.write_text(
+                json.dumps(_spec(chip_count, workload["workload"])), encoding="utf-8"
+            )
+
+
+def _setup(tmp_path: Path, mutate=None) -> Path:
+    matrix = _base_matrix()
+    if mutate is not None:
+        mutate(matrix)
+    matrix_dir = tmp_path / "leaderboard-data"
+    matrix_dir.mkdir(parents=True, exist_ok=True)
+    matrix_path = matrix_dir / "dense-matrix-issue-136.json"
+    matrix_path.write_text(json.dumps(matrix), encoding="utf-8")
+    _write_specs(tmp_path, matrix)
+    return matrix_path
+
+
+def test_matrix_schema_loads(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    status = validate_dense_matrix_target(matrix_path)
+    assert status.schema_version == SCHEMA_VERSION
+    assert status.overall == "matrix-target-fixed"
+    assert list(status.errors) == []
+
+
+def test_core_workloads_all_spec_ready(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for workload in matrix["workloads"]:
+        if workload["workload"] in CORE_WORKLOADS:
+            for chip_key in CHIP_KEYS:
+                assert workload["cells"][chip_key]["status"] == "spec-ready"
+
+
+def test_spec_files_exist_for_spec_ready_cells(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for workload in matrix["workloads"]:
+        for chip_key, cell in workload["cells"].items():
+            if cell["status"] == "spec-ready":
+                spec_path = tmp_path / cell["spec"]
+                assert spec_path.is_file(), f"missing {cell['spec']}"
+    status = validate_dense_matrix_target(matrix_path)
+    assert list(status.errors) == []
+
+
+def test_communication_cells_all_blocked(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for workload in matrix["workloads"]:
+        if workload["workload"] == COMMUNICATION_WORKLOAD:
+            for chip_key in CHIP_KEYS:
+                assert workload["cells"][chip_key]["status"] == "blocked"
+
+
+def test_each_workload_has_three_cells(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for workload in matrix["workloads"]:
+        assert set(workload["cells"].keys()) == set(CHIP_KEYS)
+
+
+def test_status_values_are_legal(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for workload in matrix["workloads"]:
+        for chip_key in CHIP_KEYS:
+            assert workload["cells"][chip_key]["status"] in VALID_STATUS
+
+
+def test_counts_match_status_block(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    status = validate_dense_matrix_target(matrix_path)
+    assert status.spec_ready_cells == 12
+    assert status.blocked_cells == 3
+
+
+def test_no_performance_percentages_published(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    assert matrix["status"]["performance_percentages_published"] is False
+    status = validate_dense_matrix_target(matrix_path)
+    assert status.performance_percentages_published is False
+
+
+def test_detects_missing_spec_file(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    spec_path = tmp_path / matrix["workloads"][0]["cells"]["1chip"]["spec"]
+    spec_path.unlink()
+
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("spec file not found" in error for error in status.errors)
+
+
+def test_detects_chip_count_mismatch(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    spec_path = tmp_path / matrix["workloads"][0]["cells"]["2chip"]["spec"]
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["chip_count"] = 4
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+    status = validate_dense_matrix_target(matrix_path)
+    assert any(
+        "chip_count" in error and "does not match" in error for error in status.errors
+    )
+
+
+def test_detects_blocked_missing_blocker_reason(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        comm = next(
+            w for w in matrix["workloads"] if w["workload"] == COMMUNICATION_WORKLOAD
+        )
+        del comm["cells"]["1chip"]["blocker_reason"]
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("blocker_reason" in error for error in status.errors)
+
+
+def test_detects_missing_cell(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        del matrix["workloads"][0]["cells"]["4chip"]
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("missing required cell" in error for error in status.errors)
+
+
+def test_detects_invalid_status(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"][0]["cells"]["1chip"]["status"] = "done"
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("invalid status" in error for error in status.errors)
+
+
+def test_detects_core_workload_not_spec_ready(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"][0]["cells"]["1chip"]["status"] = "blocked"
+        matrix["workloads"][0]["cells"]["1chip"]["blocker_reason"] = "blocked"
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("expected status 'spec-ready'" in error for error in status.errors)
+
+
+def test_missing_matrix_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        validate_dense_matrix_target(tmp_path / "nope.json")

--- a/tests/test_dense_matrix_target.py
+++ b/tests/test_dense_matrix_target.py
@@ -80,6 +80,9 @@ def _workload(
         "workload": name,
         "model": "Qwen2.5-14B-Instruct",
         "precision": "FP16",
+        "model_revision": "cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8",  # pragma: allowlist secret
+        "engine_backend_commit": "e18643f8a4d5bd9990727654318ad069ea0b56e2",  # pragma: allowlist secret
+        "node_topology": "single-node",
         "cells": cells,
     }
 
@@ -283,3 +286,67 @@ def test_detects_core_workload_not_spec_ready(tmp_path: Path) -> None:
 def test_missing_matrix_file_raises(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="not found"):
         validate_dense_matrix_target(tmp_path / "nope.json")
+
+
+def test_detects_duplicate_workload(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"].append(matrix["workloads"][0])
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("duplicate workload" in error for error in status.errors)
+
+
+def test_detects_unknown_workload(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"].append(_workload("unknown-workload", CORE_CELLS))
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("unknown workload" in error for error in status.errors)
+
+
+def test_detects_missing_core_workload(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"] = [
+            w for w in matrix["workloads"] if w["workload"] != "random-online"
+        ]
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("missing required workload" in error for error in status.errors)
+
+
+def test_detects_missing_identity_field(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        del matrix["workloads"][0]["model_revision"]
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any("missing required identity" in error for error in status.errors)
+
+
+def test_detects_identity_mismatch_across_workloads(tmp_path: Path) -> None:
+    def _mutate(matrix: dict) -> None:
+        matrix["workloads"][1]["model_revision"] = "0" * 40
+
+    matrix_path = _setup(tmp_path, mutate=_mutate)
+    status = validate_dense_matrix_target(matrix_path)
+    assert any(
+        "identity field 'model_revision'" in error and "differs" in error
+        for error in status.errors
+    )
+
+
+def test_detects_missing_tensor_parallel_size(tmp_path: Path) -> None:
+    matrix_path = _setup(tmp_path)
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    spec_path = tmp_path / matrix["workloads"][0]["cells"]["1chip"]["spec"]
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    del spec["server_parameters"]["tensor_parallel_size"]
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+    status = validate_dense_matrix_target(matrix_path)
+    assert any(
+        "missing required 'tensor_parallel_size'" in error for error in status.errors
+    )


### PR DESCRIPTION
## Summary

Delivers the "fix Dense 1/2/4 matrix target/config/provenance" scope for [issue #136](https://github.com/vLLM-HUST/vllm-hust-benchmark/issues/136). This PR **does not** generate or publish any performance percentages — it fixes the matrix target, config, and provenance so later evidence collection runs against a consistent, auditable matrix.

Follows the execution contract from PR #137 (`docs/issue-136-ascend-evidence-execution.md`).

## Changes

### 1. Machine-readable matrix target — `leaderboard-data/dense-matrix-issue-136.json`
- Fixes Dense 1/2/4 matrix for 4 core workloads (random-online, sharegpt-online, prefix-repetition-online, agent-research-online), each with 1chip/2chip/4chip cells (12 spec-ready cells).
- Load profiles: `fixed-1-rps` + `matched-load` (capacity pilot required).
- Provenance contract: same frozen model revision/precision/core-backend commit/node topology across all cells.
- Communication-sensitive cells (1/2/4chip) marked `blocked` (custom comm path upstream support pending).
- `status.performance_percentages_published: false` — no cross-stack percentages.

### 2. Communication-sensitive specs
- Added single-node 1chip and 4chip variants of `unified-comm-online` (non-executable draft, pending custom comm path), so the matrix is fully enumerated.
- Registry (`official_targets`, `official_scenarios`, `official_target_versions`) bumped to v1.3.3 and regenerated to keep CI green.

### 3. Validator — `src/vllm_hust_benchmark/dense_matrix_target.py`
- `validate_dense_matrix_target()` checks spec file existence for spec-ready cells, chip_count/TP match, blocked cells carry `blocker_reason`, core workloads spec-ready, and communication-sensitive cells blocked.

### 4. Tests — `tests/test_dense_matrix_target.py` (15 tests)
- Schema validation, spec coverage, blocked-cell semantics, and negative tests (missing spec, chip mismatch, missing blocker_reason, invalid status, etc.).

## Verification

- `pre-commit run`: all passed (ruff check/format, check-json, mdformat, detect-secrets)
- `pytest tests/test_dense_matrix_target.py`: 15 passed
- `pytest tests/test_dense_matrix_target.py tests/test_official_targets.py tests/test_registry.py tests/test_specialty_spec_params.py`: 42 passed
- Full suite: 1361 passed, 2 failed, 2 skipped (2 failures are pre-existing cgroup permission issues in `test_process_identity.py`, unrelated to this PR)

## Note

Issue #136 remains open (multi-stage). Future PRs will run the actual Dense matrix experiments and MoE/EPLB/LatchMoE evidence once the implementation commits merge and a unique current-main stack is frozen.