### PR TITLE
fix(scripts): expose --spec-path for 910B3 specialty rerun binding

### DIFF
--- a/scripts/backfill_single_gpu.py
+++ b/scripts/backfill_single_gpu.py
@@ -2517,7 +2517,63 @@ def _official_spec_path(workload: str, model: str | None = None) -> Path:
     return REPO_ROOT / "docs" / "official-baselines" / spec_name
 
 
-def _generate_same_spec(workload: str, model: str | None = None) -> dict[str, Any]:
+def _resolve_spec_path(
+    workload: str, model: str | None = None, spec_path: str | None = None
+) -> Path:
+    """Resolve the spec file for a backfill run.
+
+    An explicit ``spec_path`` (e.g. a 910B3 specialty spec) takes precedence
+    and bypasses the default 910B2 auto-resolution.  Otherwise fall back to
+    ``_official_spec_path``.
+    """
+    if spec_path is not None:
+        path = Path(spec_path)
+        if not path.is_absolute():
+            path = (REPO_ROOT / path).resolve()
+        if not path.is_file():
+            raise ValueError(f"--spec-path does not exist: {path}")
+        return path
+    return _official_spec_path(workload, model)
+
+
+def _validate_explicit_spec(
+    spec: dict[str, Any], workload: str, model: str | None
+) -> None:
+    """Validate that an explicit spec matches the run being submitted.
+
+    Guards against pairing a 910B3 rerun against a mismatched workload, model,
+    or chip-count contract, which would corrupt goal-progress pairing and the
+    hardware-series isolation required by issue #178.
+    """
+    spec_scenario = str(spec.get("scenario") or "")
+    if spec_scenario != workload:
+        raise ValueError(
+            f"--spec-path scenario {spec_scenario!r} does not match "
+            f"workload {workload!r}"
+        )
+
+    if model is not None:
+        spec_model = str(spec.get("model") or "")
+        spec_short = spec_model.rstrip("/").rsplit("/", maxsplit=1)[-1]
+        model_short = model.rstrip("/").rsplit("/", maxsplit=1)[-1]
+        if model_short != spec_short and model != spec_model:
+            raise ValueError(
+                f"--spec-path model {spec_model!r} does not match --model {model!r}"
+            )
+
+    chip_count = int(spec.get("chip_count") or 0)
+    if chip_count != CHIP_COUNT:
+        raise ValueError(
+            f"--spec-path chip_count {chip_count} does not match runner "
+            f"chip_count {CHIP_COUNT}"
+        )
+    if not spec.get("hardware_chip_model"):
+        raise ValueError("--spec-path is missing hardware_chip_model")
+
+
+def _generate_same_spec(
+    workload: str, model: str | None = None, spec_path: str | None = None
+) -> dict[str, Any]:
     """Generate a same_spec payload matching the official baseline hash.
 
     The official v0.18.0 baseline was generated at commit ``2d6f5de`` using
@@ -2526,8 +2582,10 @@ def _generate_same_spec(workload: str, model: str | None = None) -> dict[str, An
     that exact logic so the ``resolved_spec_hash`` matches the official
     baseline, enabling leaderboard goal-progress pairing.
     """
-    spec_path = _official_spec_path(workload, model)
-    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    resolved_path = _resolve_spec_path(workload, model, spec_path)
+    spec = json.loads(resolved_path.read_text(encoding="utf-8"))
+    if spec_path is not None:
+        _validate_explicit_spec(spec, workload, model)
 
     # ------------------------------------------------------------------
     # Replicate the old ``resolve_server_parameters`` (commit 2d6f5de).
@@ -2607,7 +2665,7 @@ def _generate_same_spec(workload: str, model: str | None = None) -> dict[str, An
         "schema_version": "benchmark-same-spec/v1",
         "spec_id": spec["id"],
         "spec_label": str(spec.get("label") or ""),
-        "spec_source": str(spec_path.resolve()),
+        "spec_source": str(resolved_path.resolve()),
         "scenario": spec["scenario"],
         "model": spec["model"],
         "model_parameters": spec["model_parameters"],
@@ -2776,19 +2834,47 @@ def submit_artifact(
     temperature: float | None = None,
     additional_config: str | None = None,
     compilation_config: str | None = None,
+    spec_path: str | None = None,
 ) -> Path:
-    # 对提交元数据使用规范的模型名（非本地文件系统路径）
-    if model is not None and model.startswith("/"):
-        basename = model.rstrip("/").rsplit("/", maxsplit=1)[-1]
-        try:
-            from vllm_hust_benchmark.model_registry import resolve_model_identity
+    # Resolve the spec source: an explicit --spec-path (e.g. a 910B3 specialty
+    # spec) takes precedence over the default 910B2 official-spec auto-resolve.
+    resolved_spec_path = _resolve_spec_path(workload, model, spec_path)
+    explicit_spec: dict[str, Any] | None = None
+    if spec_path is not None:
+        explicit_spec = json.loads(resolved_spec_path.read_text(encoding="utf-8"))
+        _validate_explicit_spec(explicit_spec, workload, model)
 
-            resolve_model_identity(basename)
-            model_to_use = basename
-        except Exception:
-            model_to_use = MODEL_NAME.rsplit("/", maxsplit=1)[-1]
+    # Derive submission identity fields.  An explicit spec is authoritative for
+    # its hardware/model contract (issue #173: a 910B3 rerun must bind 910B3);
+    # otherwise use the runner's 910B2 official-baseline defaults.
+    if explicit_spec is not None:
+        model_to_use = str(explicit_spec["model"])
+        model_parameters = str(
+            explicit_spec.get("model_parameters") or MODEL_PARAMETERS
+        )
+        model_precision = str(explicit_spec.get("model_precision") or MODEL_PRECISION)
+        hardware_chip_model = str(
+            explicit_spec.get("hardware_chip_model") or HARDWARE_CHIP_MODEL
+        )
+        chip_count = int(explicit_spec.get("chip_count") or CHIP_COUNT)
     else:
-        model_to_use = model if model is not None else MODEL_NAME
+        # 对提交元数据使用规范的模型名（非本地文件系统路径）
+        if model is not None and model.startswith("/"):
+            basename = model.rstrip("/").rsplit("/", maxsplit=1)[-1]
+            try:
+                from vllm_hust_benchmark.model_registry import resolve_model_identity
+
+                resolve_model_identity(basename)
+                model_to_use = basename
+            except Exception:
+                model_to_use = MODEL_NAME.rsplit("/", maxsplit=1)[-1]
+        else:
+            model_to_use = model if model is not None else MODEL_NAME
+        model_parameters = MODEL_PARAMETERS
+        model_precision = MODEL_PRECISION
+        hardware_chip_model = HARDWARE_CHIP_MODEL
+        chip_count = CHIP_COUNT
+
     if engine_version is None:
         engine_version = _derive_engine_version(HUST_REPO, hust_commit)
 
@@ -2797,7 +2883,7 @@ def submit_artifact(
     constraints = REPO_ROOT / "docs" / "examples" / "constraints_metrics.sample.json"
 
     # Generate same_spec so the submission passes the public-snapshot filter.
-    same_spec = _generate_same_spec(workload, model)
+    same_spec = _generate_same_spec(workload, model, spec_path)
     same_spec_file = STATE_DIR / f"same_spec_{workload}.json"
     same_spec_file.parent.mkdir(parents=True, exist_ok=True)
     same_spec_file.write_text(json.dumps(same_spec, indent=2) + "\n", encoding="utf-8")
@@ -2815,7 +2901,7 @@ def submit_artifact(
         "--same-spec-file",
         str(same_spec_file),
         "--spec-path",
-        str(_official_spec_path(workload, model)),
+        str(resolved_spec_path),
         "--run-id",
         run_id,
         "--engine",
@@ -2827,15 +2913,15 @@ def submit_artifact(
         "--model-name",
         model_to_use,
         "--model-parameters",
-        MODEL_PARAMETERS,
+        model_parameters,
         "--model-precision",
-        MODEL_PRECISION,
+        model_precision,
         "--hardware-vendor",
         HARDWARE_VENDOR,
         "--hardware-chip-model",
-        HARDWARE_CHIP_MODEL,
+        hardware_chip_model,
         "--chip-count",
-        str(CHIP_COUNT),
+        str(chip_count),
         "--node-count",
         str(NODE_COUNT),
         "--submitter",
@@ -3100,6 +3186,7 @@ def run_cell(
     additional_config: str | None = None,
     compilation_config: str | None = None,
     temperature: float | None = None,
+    spec_path: str | None = None,
     allow_plugin_override: bool = False,
     run_id_override: str | None = None,
 ) -> dict[str, Any]:
@@ -3248,6 +3335,7 @@ def run_cell(
             temperature=temperature,
             additional_config=additional_config,
             compilation_config=compilation_config,
+            spec_path=spec_path,
         )
 
         # Reject results where all requests failed (error_rate == 1.0).
@@ -3720,6 +3808,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                     additional_config=args.additional_config,
                     compilation_config=args.compilation_config,
                     temperature=args.temperature,
+                    spec_path=args.spec_path,
                     allow_plugin_override=bool(args.force_mismatched_plugin_commit),
                 )
                 state["cells"][key] = result
@@ -4104,6 +4193,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--model",
         default=MODEL_NAME,
         help="Model name or path (default: %(default)s).",
+    )
+    p_run.add_argument(
+        "--spec-path",
+        type=str,
+        default=None,
+        help=(
+            "Explicit spec file (e.g. a 910B3 specialty spec under "
+            "docs/official-baselines/). When supplied, it overrides the default "
+            "910B2 official-baseline auto-resolution and drives the same_spec "
+            "hash, --spec-path, hardware chip model, and model contract."
+        ),
     )
     p_run.add_argument(
         "--additional-config",

--- a/tests/test_backfill_single_gpu.py
+++ b/tests/test_backfill_single_gpu.py
@@ -552,3 +552,150 @@ def test_run_cell_propagates_temperature_and_configs(tmp_path: Path) -> None:
     assert seen["submit_kwargs"]["compilation_config"] == (
         '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
     )
+
+
+# ---------------------------------------------------------------------------
+# --spec-path: explicit specialty spec binding (issue #173)
+# ---------------------------------------------------------------------------
+
+
+def _write_910b3_spec(
+    tmp_path: Path,
+    workload: str = "random-online",
+    model: str = "Qwen/Qwen2.5-14B-Instruct",
+    chip_model: str = "910B3",
+    chip_count: int = 1,
+) -> tuple[Path, dict]:
+    spec = {
+        "id": (
+            f"specialty-ascend-full-graph-parallel-inplace-{workload}-qwen25-14b-910b3"
+        ),
+        "label": "Specialty Ascend full-graph-parallel inplace dual-stream",
+        "scenario": workload,
+        "model": model,
+        "model_parameters": "14B",
+        "model_precision": "FP16",
+        "hardware_vendor": "Huawei",
+        "hardware_chip_model": chip_model,
+        "chip_count": chip_count,
+        "node_count": 1,
+        "server_parameters": {
+            "tensor_parallel_size": 1,
+            "gpu_memory_utilization": 0.6,
+            "max_model_len": 32768,
+        },
+        "client_parameters": {
+            "backend": "vllm",
+            "endpoint": "/v1/completions",
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "request_rate": 1,
+        },
+    }
+    spec_dir = tmp_path / "docs" / "official-baselines"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    path = spec_dir / (
+        f"specialty-ascend-full-graph-parallel-inplace-{workload}-qwen25-14b-910b3.json"
+    )
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    return path, spec
+
+
+def test_resolve_spec_path_explicit_overrides_default(tmp_path: Path) -> None:
+    mod = load_module()
+    spec_path, _ = _write_910b3_spec(tmp_path)
+    with patch.object(mod, "REPO_ROOT", tmp_path):
+        resolved = mod._resolve_spec_path(
+            "random-online", "Qwen/Qwen2.5-14B-Instruct", str(spec_path)
+        )
+        assert resolved == spec_path.resolve()
+        # 不传 spec_path 时回到默认 910B2 official spec
+        default = mod._resolve_spec_path("random-online", "Qwen/Qwen2.5-14B-Instruct")
+        assert default.name.endswith("qwen25-14b-910b2.json")
+
+
+def test_resolve_spec_path_rejects_missing_file(tmp_path: Path) -> None:
+    mod = load_module()
+    with patch.object(mod, "REPO_ROOT", tmp_path):
+        with pytest.raises(ValueError, match="--spec-path does not exist"):
+            mod._resolve_spec_path("random-online", None, str(tmp_path / "nope.json"))
+
+
+def test_validate_explicit_spec_accepts_matching(tmp_path: Path) -> None:
+    mod = load_module()
+    _, spec = _write_910b3_spec(tmp_path)
+    mod._validate_explicit_spec(spec, "random-online", "Qwen/Qwen2.5-14B-Instruct")
+
+
+def test_validate_explicit_spec_rejects_mismatched_scenario(tmp_path: Path) -> None:
+    mod = load_module()
+    _, spec = _write_910b3_spec(tmp_path, workload="random-online")
+    with pytest.raises(ValueError, match="scenario"):
+        mod._validate_explicit_spec(
+            spec, "sharegpt-online", "Qwen/Qwen2.5-14B-Instruct"
+        )
+
+
+def test_validate_explicit_spec_rejects_mismatched_model(tmp_path: Path) -> None:
+    mod = load_module()
+    _, spec = _write_910b3_spec(tmp_path, model="Qwen/Qwen2.5-14B-Instruct")
+    with pytest.raises(ValueError, match="model"):
+        mod._validate_explicit_spec(
+            spec, "random-online", "Qwen/Qwen2.5-Coder-14B-Instruct"
+        )
+
+
+def test_validate_explicit_spec_rejects_mismatched_chip_count(tmp_path: Path) -> None:
+    mod = load_module()
+    _, spec = _write_910b3_spec(tmp_path, chip_count=2)
+    with pytest.raises(ValueError, match="chip_count"):
+        mod._validate_explicit_spec(spec, "random-online", "Qwen/Qwen2.5-14B-Instruct")
+
+
+def test_generate_same_spec_explicit_910b3_binds_910b3(tmp_path: Path) -> None:
+    mod = load_module()
+    spec_path, _ = _write_910b3_spec(tmp_path)
+    with patch.object(mod, "REPO_ROOT", tmp_path):
+        same_spec = mod._generate_same_spec(
+            "random-online", "Qwen/Qwen2.5-14B-Instruct", str(spec_path)
+        )
+    assert same_spec["hardware_chip_model"] == "910B3"
+    assert same_spec["chip_count"] == 1
+    assert "910b3" in same_spec["spec_id"]
+    assert "910b3" in same_spec["spec_source"]
+
+
+def test_submit_artifact_explicit_spec_drives_910b3(tmp_path: Path) -> None:
+    mod = load_module()
+    spec_path, _ = _write_910b3_spec(tmp_path)
+    raw = tmp_path / "raw.json"
+    raw.write_text("{}", encoding="utf-8")
+
+    submit_cmds: list[list[str]] = []
+
+    def _fake_run(cmd, **kwargs):
+        submit_cmds.append(list(cmd))
+        return MagicMock(returncode=0)
+
+    with (
+        patch.object(mod, "REPO_ROOT", tmp_path),
+        patch.object(mod, "STATE_DIR", tmp_path / "state"),
+        patch.object(mod, "_derive_engine_version", return_value="v0.0.0-test"),
+        patch.object(mod.subprocess, "run", side_effect=_fake_run),
+    ):
+        mod.submit_artifact(
+            "random-online",
+            BASE_SHA,
+            PLUGIN_SHA,
+            "run-id",
+            raw,
+            model="Qwen/Qwen2.5-14B-Instruct",
+            spec_path=str(spec_path),
+        )
+
+    assert len(submit_cmds) == 1
+    cmd = submit_cmds[0]
+    assert cmd[cmd.index("--hardware-chip-model") + 1] == "910B3"
+    assert cmd[cmd.index("--chip-count") + 1] == "1"
+    assert cmd[cmd.index("--spec-path") + 1] == str(spec_path.resolve())
+    assert cmd[cmd.index("--model-name") + 1] == "Qwen/Qwen2.5-14B-Instruct"


### PR DESCRIPTION
Fixes #173.

The runner model validation added in #171 tells callers to pass an explicit `--spec-path`, but the CLI did not expose that option, and `submit_artifact()` always derived the spec via `_official_spec_path()` (defaulting to the 910B2 official spec), so a 910B3 specialty rerun could not bind its own spec end-to-end.

Changes:
- Expose `--spec-path` on the backfill runner CLI.
- Thread it through `cmd_run` -> `run_cell` -> `submit_artifact` -> `_generate_same_spec`; the spec becomes authoritative for `hardware_chip_model=910B3`.
- Added 8 tests (22 passed).

Required by the 910B3 clean rerun of #172.
