### PR TITLE
feat: add proposal delivery suite and enterprise replay contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ build/
 coverage.xml
 .benchmarks/
 pytest-results.xml
+
+# Enterprise request bodies remain outside Git. Only manifests and redacted results belong here.
+enterprise-data/
+real_workloads/
+.vllm-hust-enterprise-authorized.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Unreleased entries concise and workflow-focused.
 ## [Unreleased]
 
 ### Added
+- Added a versioned nine-workload delivery suite registry that binds one
+  authoritative benchmark and deployable single-node model to each acceptance
+  class while keeping GLM-5 and Kimi-class models in a multi-node extension tier.
+- Added manifest-only enterprise dataset registration and fail-closed replay
+  loading with explicit data roots, dataset-scoped authorization, full-file
+  checksum/count validation, deterministic sampling, model provenance, and
+  redacted result records.
 - Added quantized Ascend same-spec benchmark support so workflow-dispatch runs
   can override the runtime model, precision, quantization scheme, dtype, and
   hardware chip metadata without mutating the official FP16 spec files.

--- a/docs/AI4SCIENCE_BENCHMARK.md
+++ b/docs/AI4SCIENCE_BENCHMARK.md
@@ -1,0 +1,39 @@
+# HUST Science Serving Benchmark v1 proposal
+
+NatureBench is used as an authoritative design reference, not copied or treated as a cheap serving benchmark. Its paper-sourced tasks, executable environments, hidden evaluators, validity checks, and six-domain coverage motivate a smaller benchmark built specifically for inference-engine acceptance.
+
+## Scope
+
+`hust-science-serving-v1` contains 24 independently licensed task packages: four tasks in each of cellular omics, protein biology, biomedical modeling, physical modeling, molecular design, and relational reasoning.
+
+Each package must include:
+
+- a scientific problem statement and data-description file;
+- a fixed container image digest and data checksums;
+- a bounded compute and wall-clock budget;
+- a deterministic submission schema and hidden evaluator;
+- one primary task-quality metric;
+- validity checks that reject empty, hard-coded, leaked, or malformed submissions;
+- a captured sequence of LLM calls with tool time excluded from engine-service metrics.
+
+Tasks are newly constructed from open, redistribution-compatible scientific assets. NatureBench task bodies, hidden evaluators, and restricted data are not copied without explicit license permission.
+
+## Two-channel evaluation
+
+The quality channel runs the complete agent loop once per admitted stack and scores all 24 tasks. It establishes that the engine still supports successful scientific work.
+
+The performance channel replays the frozen LLM segments extracted from valid quality runs. It fixes prompt bytes, tool schemas, generation parameters, and request order, then compares stock, feature-off, feature-on, and minus-one configurations. External tools, container execution, scientific training, and network time are excluded from inference-engine performance attribution.
+
+## Model and gates
+
+The primary model is the pinned Qwen3-Coder-30B-A3B-Instruct artifact used by the code scenario. Reusing it limits deployment cost and matches the executable coding/verification task form.
+
+Release gates are:
+
+1. six-domain smoke: one task per domain loads, executes, and produces a valid evaluator result;
+2. task-package gate: all 24 packages pass license, checksum, container, determinism, and hidden-evaluator review;
+3. quality gate: task-success count is non-inferior to feature-off by no more than one task;
+4. serving gate: frozen LLM-segment output-token throughput improves by at least 5%, with a paired-bootstrap 95% confidence interval excluding zero;
+5. protocol gate: zero malformed tool calls, parser failures, silent fallbacks, or unclassified engine errors.
+
+The six-task smoke is compatibility evidence only. It is not the final AI4Science quality result.

--- a/docs/DELIVERY_SUITE.md
+++ b/docs/DELIVERY_SUITE.md
@@ -1,0 +1,28 @@
+# vLLM-HUST delivery suite
+
+The package registry `delivery_suite_registry.json` is the machine-readable acceptance contract layered above the existing official leaderboard targets.
+
+It fixes nine non-overlapping workload classes:
+
+| Workload | Benchmark | Fixed single-node model |
+| --- | --- | --- |
+| General QA | ShareGPT serving | Qwen3-32B |
+| Code | LiveCodeBench | Qwen3-Coder-30B-A3B-Instruct |
+| Reasoning | AIME 2025 | DeepSeek-R1-Distill-Qwen-32B |
+| Multimodal | VisionArena serving | Qwen3-VL-30B-A3B-Instruct |
+| KV reuse | vLLM prefix repetition | Qwen3-32B |
+| Structured output | JSONSchemaBench | Qwen3-32B, non-thinking mode |
+| Long context | LongBench v2 | Qwen3.5-27B |
+| Agent | BFCL V4 | GLM-4.5-Air |
+| AI4Science | NatureBench | Qwen3-Coder-30B-A3B-Instruct |
+
+The existing 7B/14B official targets remain unchanged for leaderboard continuity and PR/nightly gates. The delivery suite adds 27B–106B single-node acceptance targets. GLM-4.6 W8A8 is conditional on load and KV-capacity preflight. GLM-5 and Kimi K2/K3 remain customer multi-node extensions and cannot satisfy a fixed single-node target.
+
+Inspect the contract with:
+
+```bash
+PYTHONPATH=src python -m vllm_hust_benchmark.delivery_suite
+PYTHONPATH=src python -m vllm_hust_benchmark.delivery_suite --workload-id long_context
+```
+
+Every formal comparison must keep model, workload, hardware, runtime parameters, and client parameters identical between baseline and candidate. Run status, benchmark quality, throughput, median latency, tail latency, and error rate remain separate gates.

--- a/docs/DELIVERY_SUITE.md
+++ b/docs/DELIVERY_SUITE.md
@@ -1,28 +1,63 @@
-# vLLM-HUST delivery suite
+# Proposed vLLM-HUST delivery suite
 
-The package registry `delivery_suite_registry.json` is the machine-readable acceptance contract layered above the existing official leaderboard targets.
+`delivery_suite_registry.json` is a proposal for the next generation of fixed acceptance targets. It is intentionally additive and does not modify, replace, or inherit identity from the repository's current official targets. Promotion into the official target registry is a later review action after the proposal, adapters, model artifacts, and runners are admitted.
 
-It fixes nine non-overlapping workload classes:
+## Terms
 
-| Workload | Benchmark | Fixed single-node model |
+- **Application scenario**: a user-facing workload class. The suite fixes nine: general QA, code, reasoning, multimodal, KV reuse, structured output, long context, Agent, and AI4Science.
+- **Engine capability target**: an L0 or L1 system behavior such as protocol conformance, overload handling, prefill/decode balance, preemption, KV eviction, OOM boundaries, structured decoding, fault recovery, fairness, or soak stability.
+- **Evaluation asset**: a typed input to evaluation. `quality_benchmark`, `serving_trace`, `serving_harness`, `microbenchmark`, `enterprise_replay`, and `design_reference` are deliberately distinct.
+- **Fixed target**: the resolved model artifact, data revision, runtime profile, client profile, thresholds, and receipt. A scenario name or benchmark name alone is not a fixed target.
+
+The registry keeps nine scenarios but does not require nine unique benchmark frameworks. A scenario can reuse a serving harness or checkpoint when that improves causal attribution.
+
+## Three-layer coverage
+
+| Layer | Purpose | Examples |
 | --- | --- | --- |
-| General QA | ShareGPT serving | Qwen3-32B |
-| Code | LiveCodeBench | Qwen3-Coder-30B-A3B-Instruct |
-| Reasoning | AIME 2025 | DeepSeek-R1-Distill-Qwen-32B |
-| Multimodal | VisionArena serving | Qwen3-VL-30B-A3B-Instruct |
-| KV reuse | vLLM prefix repetition | Qwen3-32B |
-| Structured output | JSONSchemaBench | Qwen3-32B, non-thinking mode |
-| Long context | LongBench v2 | Qwen3.5-27B |
-| Agent | BFCL V4 | GLM-4.5-Air |
-| AI4Science | NatureBench | Qwen3-Coder-30B-A3B-Instruct |
+| L0 | Deployment and protocol conformance | artifact startup, tokenizer/processor/chat template, stream, content parts, tool call, response format, clean restart |
+| L1 | Engine mechanism and boundary | open/closed/burst/overload, prefill/decode mix, preemption, KV reuse/eviction, OOM, TP/EP, cancellation, fairness, two-hour soak |
+| L2 | Application credibility | the nine application scenarios plus public quality assets and enterprise replay |
 
-The existing 7B/14B official targets remain unchanged for leaderboard continuity and PR/nightly gates. The delivery suite adds 27B–106B single-node acceptance targets. GLM-4.6 W8A8 is conditional on load and KV-capacity preflight. GLM-5 and Kimi K2/K3 remain customer multi-node extensions and cannot satisfy a fixed single-node target.
+L0 and L1 close engine coverage. L2 closes scenario credibility. Passing only L2 does not prove mechanism coverage, and passing only L1 does not prove user-facing quality.
 
-Inspect the contract with:
+## Model set
+
+The main suite uses six pinned candidate checkpoints for nine scenarios:
+
+| Checkpoint | Scenarios | Rationale |
+| --- | --- | --- |
+| Qwen3-32B | General QA, KV reuse, structured output | Dense general baseline and clean causal reuse across mechanisms |
+| Qwen3-Coder-30B-A3B-Instruct | Code, AI4Science | Code-specialized MoE with affordable repeated deployment |
+| DeepSeek-R1-Distill-Qwen-32B | Reasoning | Decode-heavy reasoning without a multi-node 671B model |
+| Qwen3-VL-30B-A3B-Instruct | Multimodal | Native image-text pipeline with an official Ascend single-node path |
+| Qwen3.6-27B | Long context | Official Ascend 128K path and sufficient HBM headroom for long KV |
+| GLM-4.5-Air | Agent | Agent-oriented 106B-A12B MoE representing the enterprise GLM class |
+
+GLM-5 and Kimi K2/K3 are model-class extensions, not main single-node targets. They can be promoted only after a customer-accessible exact artifact and production-equivalent multi-node topology are frozen.
+
+Every main model record pins a full repository commit SHA, tokenizer/processor revision, chat-template source, dtype, TP/DP/EP topology, and maximum model length. `pinned_candidate` means identity is fixed but runtime admission is still required; only an actual load and preflight receipt can promote it to `admitted`.
+
+## Acceptance logic
+
+Formal performance uses five paired restart blocks. Each block randomizes A/B or B/A order, warms for 120 seconds, measures for at least 600 seconds, and obtains at least 1,000 successful online requests when the workload is not task-count bounded. The primary endpoint must meet its scenario-specific minimum effect and its paired-bootstrap 95% confidence interval must exclude zero in the beneficial direction.
+
+All nine scenarios must produce valid runs and pass quality non-inferiority. At least seven of nine primary performance endpoints must pass; general QA, KV reuse, structured output, and long context are mandatory. Global guardrails allow at most 5% regression on secondary metrics, 0.1% load error rate, 0.05 percentage-point error-rate increase, zero silent fallbacks, and zero unclassified failures.
+
+Four configurations establish causality:
+
+1. unmodified upstream stock;
+2. vLLM-HUST with target optimizations disabled;
+3. vLLM-HUST with the preregistered optimization set enabled;
+4. feature-on minus one optimization.
+
+The feature-on versus feature-off pair supports the mechanism claim. Feature-off versus stock exposes integration overhead. Feature-on versus stock is the product-level result. Each claimed optimization must also pass one preregistered L1 target and its minus-one ablation.
+
+Inspect the proposal with:
 
 ```bash
 PYTHONPATH=src python -m vllm_hust_benchmark.delivery_suite
 PYTHONPATH=src python -m vllm_hust_benchmark.delivery_suite --workload-id long_context
 ```
 
-Every formal comparison must keep model, workload, hardware, runtime parameters, and client parameters identical between baseline and candidate. Run status, benchmark quality, throughput, median latency, tail latency, and error rate remain separate gates.
+No command in this proposal registers a current official target or changes the existing leaderboard.

--- a/docs/ENTERPRISE_REPLAY.md
+++ b/docs/ENTERPRISE_REPLAY.md
@@ -1,15 +1,35 @@
 # Enterprise replay
 
-Enterprise request assets are external to Git. The package stores only logical relative paths, record counts, SHA-256 digests, source format, aggregate workload-family mapping, and replay case definitions.
+All eight delivered JSONL assets are registered outside Git by logical path, record count, SHA-256, source format, provenance class, and workload-family mapping.
+
+The evidence classes are intentionally different:
+
+- `enterprise_observed_request`: real request bodies supplied by the enterprise. They provide credible API and request-shape evidence.
+- `enterprise_provided_synthetic_or_hybrid`: controlled long-prefill, prefix, conversation-reuse, and semantic-similarity workloads supplied with the enterprise package. They provide useful stress and grouping semantics but are not presented as native production traces.
+
+Neither class alone proves an engine cache hit or performance gain. Those claims require candidate/baseline measurements plus applied/effective engine telemetry.
+
+## Replay modes
+
+The loader preserves prompts and OpenAI request fields. The runner may apply an explicit benchmark normalization overlay for generation parameters such as `max_tokens`, `temperature`, and `seed`; the overlay is stored in the resolved spec and redacted record. It is not silently injected from a filename or global default.
+
+For datasets carrying trace-shape fields, the authorized in-memory object preserves `group_id`, `session_id`, `conversation_id`, `created_at_ms`, `prompt_hash`, `prompt_tokens_est`, and an allowlisted subset of aggregate metadata. Persisted results hash group/session/conversation keys and never store prompts, messages, tools, or complete request bodies.
+
+Sampling is request-based for independent data and group-aware for prefix or conversation data:
+
+- `prefix_shared`: select complete `group_id` groups and replay in group/timestamp order;
+- `reuse_conversation`: select complete `conversation_id` groups and replay in group/timestamp order;
+- `semantic_similar`: select complete semantic groups, but do not treat semantic similarity as exact-prefix evidence;
+- `long_prefill`: select requests deterministically and replay by source timestamp.
 
 ## Mandatory gates
 
 1. Pass `--data-root` or set `VLLM_HUST_ENTERPRISE_DATA_ROOT`; no repository-adjacent path discovery is performed.
-2. Provide a dataset-scoped authorization file, either explicitly or as `.vllm-hust-enterprise-authorized.json` under the data root.
-3. The loader verifies the entire file checksum and non-empty JSONL record count before parsing any request.
-4. Sampling is deterministic over dataset ID, case ID, seed, sampler version, and source index.
-5. The original source model is retained as provenance; the execution model is applied only when creating the OpenAI payload.
-6. Redacted result records contain hashes and request-shape fields, never messages, prompts, tools, or complete request bodies.
+2. Provide a dataset-scoped technical authorization file. This file is a fail-closed runner gate, not a substitute for project-level data authorization, retention, and deletion approval.
+3. Verify the entire checksum and non-empty JSONL record count before parsing requests.
+4. Freeze case ID, sampling unit, seed, selected request/group IDs, replay order, and any generation normalization.
+5. Keep source-model identity as provenance and apply the served model only at submission time.
+6. Persist redacted shape metadata and runtime results only.
 
 Authorization file example:
 
@@ -37,4 +57,4 @@ PYTHONPATH=src python -m vllm_hust_benchmark.enterprise_replay \
   --limit 100 --seed 0 --output redacted-records.json
 ```
 
-The Python API returns request bodies in memory only to the authorized runner. Call `EnterpriseReplayRequest.to_openai_payload(served_model=...)` immediately before submission and persist only `redacted_record(...)` plus runtime metrics.
+The Python API returns request bodies in memory only to the authorized runner. Call `to_openai_payload(..., generation_overrides=...)` immediately before submission and persist `redacted_record(...)` plus runtime metrics.

--- a/docs/ENTERPRISE_REPLAY.md
+++ b/docs/ENTERPRISE_REPLAY.md
@@ -1,0 +1,40 @@
+# Enterprise replay
+
+Enterprise request assets are external to Git. The package stores only logical relative paths, record counts, SHA-256 digests, source format, aggregate workload-family mapping, and replay case definitions.
+
+## Mandatory gates
+
+1. Pass `--data-root` or set `VLLM_HUST_ENTERPRISE_DATA_ROOT`; no repository-adjacent path discovery is performed.
+2. Provide a dataset-scoped authorization file, either explicitly or as `.vllm-hust-enterprise-authorized.json` under the data root.
+3. The loader verifies the entire file checksum and non-empty JSONL record count before parsing any request.
+4. Sampling is deterministic over dataset ID, case ID, seed, sampler version, and source index.
+5. The original source model is retained as provenance; the execution model is applied only when creating the OpenAI payload.
+6. Redacted result records contain hashes and request-shape fields, never messages, prompts, tools, or complete request bodies.
+
+Authorization file example:
+
+```json
+{
+  "schema_version": "enterprise-data-authorization/v1",
+  "authorized_dataset_ids": ["<dataset-id-from-registry>"]
+}
+```
+
+List cases:
+
+```bash
+PYTHONPATH=src python -m vllm_hust_benchmark.enterprise_replay --list-cases
+```
+
+Validate, sample, and emit redacted records:
+
+```bash
+PYTHONPATH=src python -m vllm_hust_benchmark.enterprise_replay \
+  --case-id <case-id> \
+  --data-root <authorized-data-root> \
+  --authorization-file <authorization.json> \
+  --served-model <model-repo-id> \
+  --limit 100 --seed 0 --output redacted-records.json
+```
+
+The Python API returns request bodies in memory only to the authorized runner. Call `EnterpriseReplayRequest.to_openai_payload(served_model=...)` immediately before submission and persist only `redacted_record(...)` plus runtime metrics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ vllm-hust-benchmark = "vllm_hust_benchmark.cli:main"
 perfgate = "vllm_hust_benchmark.perfgate:main"
 perfgate-baseline = "vllm_hust_benchmark.perfgate_baselines:main"
 official-targets = "vllm_hust_benchmark.official_targets:main"
+delivery-suite = "vllm_hust_benchmark.delivery_suite:main"
+enterprise-replay = "vllm_hust_benchmark.enterprise_replay:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/schemas/delivery_suite_registry_v1.schema.json
+++ b/schemas/delivery_suite_registry_v1.schema.json
@@ -1,13 +1,26 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/vLLM-HUST/vllm-hust-benchmark/schemas/delivery_suite_registry_v1.schema.json",
-  "title": "vLLM-HUST delivery suite registry v1",
+  "title": "vLLM-HUST proposed future delivery suite registry v1",
   "type": "object",
-  "required": ["schema_version", "registry_version", "effective_from", "academic_workload_contract", "acceptance_policy", "entries", "conditional_single_node_extensions", "customer_multinode_extensions"],
+  "required": [
+    "schema_version",
+    "registry_version",
+    "effective_from",
+    "lifecycle_status",
+    "academic_workload_contract",
+    "acceptance_policy",
+    "evaluation_assets",
+    "engine_capability_targets",
+    "entries",
+    "conditional_single_node_extensions",
+    "customer_multinode_extensions"
+  ],
   "properties": {
     "schema_version": {"const": "delivery-suite-registry/v1"},
     "registry_version": {"type": "string", "minLength": 1},
     "effective_from": {"type": "string", "format": "date"},
+    "lifecycle_status": {"const": "proposal_for_future_fixed_targets"},
     "academic_workload_contract": {
       "type": "object",
       "required": ["descriptor_schema_version", "family_generator_version"],
@@ -17,7 +30,49 @@
       },
       "additionalProperties": false
     },
-    "acceptance_policy": {"type": "object"},
+    "acceptance_policy": {
+      "type": "object",
+      "required": ["experimental_design", "causal_baselines", "global_guardrails", "portfolio_gate"],
+      "properties": {
+        "experimental_design": {"type": "object", "required": ["paired_blocks", "bootstrap_resamples", "confidence_level"], "additionalProperties": true},
+        "causal_baselines": {
+          "type": "object",
+          "required": ["upstream_stock", "hust_feature_off", "hust_feature_on", "minus_one_ablation"],
+          "properties": {
+            "upstream_stock": {"type": "string", "minLength": 1},
+            "hust_feature_off": {"type": "string", "minLength": 1},
+            "hust_feature_on": {"type": "string", "minLength": 1},
+            "minus_one_ablation": {"type": "string", "minLength": 1}
+          },
+          "additionalProperties": false
+        },
+        "global_guardrails": {"type": "object", "required": ["protocol_conformance_percent", "maximum_secondary_regression_percent", "silent_fallbacks_allowed"], "additionalProperties": true},
+        "portfolio_gate": {
+          "type": "object",
+          "required": ["required_valid_scenarios", "required_quality_non_inferiority_scenarios", "minimum_primary_pass_count", "mandatory_primary_pass_scenarios", "mechanism_gate"],
+          "properties": {
+            "required_valid_scenarios": {"type": "integer", "minimum": 1, "maximum": 9},
+            "required_quality_non_inferiority_scenarios": {"type": "integer", "minimum": 1, "maximum": 9},
+            "minimum_primary_pass_count": {"type": "integer", "minimum": 1, "maximum": 9},
+            "mandatory_primary_pass_scenarios": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+            "mechanism_gate": {"type": "string", "minLength": 1}
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "evaluation_assets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/evaluation_asset"}
+    },
+    "engine_capability_targets": {
+      "type": "array",
+      "minItems": 12,
+      "maxItems": 12,
+      "items": {"$ref": "#/$defs/capability_target"}
+    },
     "entries": {
       "type": "array",
       "minItems": 9,
@@ -29,39 +84,91 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "evaluation_asset": {
+      "type": "object",
+      "required": ["asset_id", "asset_type", "authority_url", "freeze_rule"],
+      "properties": {
+        "asset_id": {"type": "string", "minLength": 1},
+        "asset_type": {"enum": ["quality_benchmark", "serving_trace", "serving_harness", "microbenchmark", "enterprise_replay", "design_reference"]},
+        "authority_url": {"type": "string", "format": "uri"},
+        "freeze_rule": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "capability_target": {
+      "type": "object",
+      "required": ["capability_id", "layer", "profiles", "pass_gate"],
+      "properties": {
+        "capability_id": {"type": "string", "minLength": 1},
+        "layer": {"enum": ["L0", "L1"]},
+        "profiles": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "pass_gate": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "runtime_profile": {
+      "type": "object",
+      "required": ["dtype", "tensor_parallel_size", "data_parallel_size", "expert_parallel", "max_model_len"],
+      "properties": {
+        "dtype": {"type": "string", "minLength": 1},
+        "tensor_parallel_size": {"type": "integer", "minimum": 1, "maximum": 16},
+        "data_parallel_size": {"type": "integer", "minimum": 1, "maximum": 16},
+        "expert_parallel": {"type": "boolean"},
+        "max_model_len": {"type": "integer", "minimum": 1024}
+      },
+      "additionalProperties": false
+    },
+    "model_artifact": {
+      "type": "object",
+      "required": ["repo_id", "revision", "tokenizer_revision", "processor_revision", "chat_template_source", "artifact_status", "deployment_tier", "runtime_profile", "reason"],
+      "properties": {
+        "repo_id": {"type": "string", "pattern": "^[^/]+/.+$"},
+        "revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "tokenizer_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "processor_revision": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+        "chat_template_source": {"type": "string", "minLength": 1},
+        "artifact_status": {"enum": ["pinned_candidate", "admitted"]},
+        "deployment_tier": {"enum": ["single_node_main", "single_node_conditional"]},
+        "runtime_profile": {"$ref": "#/$defs/runtime_profile"},
+        "reason": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "primary_endpoint": {
+      "type": "object",
+      "required": ["metric", "direction", "minimum_effect_percent"],
+      "properties": {
+        "metric": {"type": "string", "minLength": 1},
+        "direction": {"enum": ["higher", "lower"]},
+        "minimum_effect_percent": {"type": "number", "exclusiveMinimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "quality_gate": {
+      "type": "object",
+      "required": ["metric", "non_inferiority_margin", "unit"],
+      "properties": {
+        "metric": {"type": "string", "minLength": 1},
+        "non_inferiority_margin": {"type": "number", "minimum": 0},
+        "unit": {"type": "string", "minLength": 1},
+        "absolute_minimum_percent": {"type": "number", "minimum": 0, "maximum": 100}
+      },
+      "additionalProperties": false
+    },
     "entry": {
       "type": "object",
-      "required": ["workload_id", "label", "workload_family_ids", "benchmark", "model", "enterprise_case_ids", "engine_pressure", "acceptance_metrics"],
+      "required": ["application_scenario_id", "label", "workload_family_ids", "public_asset_ids", "enterprise_case_ids", "engine_capability_ids", "model_artifact", "primary_endpoint", "quality_gate"],
       "properties": {
-        "workload_id": {"enum": ["general_qa", "code", "reasoning", "multimodal", "kv_reuse", "structured_output", "long_context", "agent", "ai4science"]},
+        "application_scenario_id": {"enum": ["general_qa", "code", "reasoning", "multimodal", "kv_reuse", "structured_output", "long_context", "agent", "ai4science"]},
         "label": {"type": "string", "minLength": 1},
         "workload_family_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
-        "benchmark": {
-          "type": "object",
-          "required": ["id", "authority_url", "dataset"],
-          "properties": {
-            "id": {"type": "string", "minLength": 1},
-            "authority_url": {"type": "string", "format": "uri"},
-            "dataset": {"type": "string", "minLength": 1},
-            "arrival_profile": {"type": "string"}
-          },
-          "additionalProperties": false
-        },
-        "model": {
-          "type": "object",
-          "required": ["id", "deployment_tier", "precision", "tensor_parallel_size", "reason"],
-          "properties": {
-            "id": {"type": "string", "pattern": "^[^/]+/.+$"},
-            "deployment_tier": {"enum": ["single_node_main", "single_node_conditional"]},
-            "precision": {"type": "string", "minLength": 1},
-            "tensor_parallel_size": {"type": "integer", "minimum": 1, "maximum": 8},
-            "reason": {"type": "string", "minLength": 1}
-          },
-          "additionalProperties": false
-        },
+        "public_asset_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "enterprise_case_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
-        "engine_pressure": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
-        "acceptance_metrics": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+        "engine_capability_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "model_artifact": {"$ref": "#/$defs/model_artifact"},
+        "primary_endpoint": {"$ref": "#/$defs/primary_endpoint"},
+        "quality_gate": {"$ref": "#/$defs/quality_gate"},
+        "mechanism_guardrails": {"type": "object"}
       },
       "additionalProperties": false
     }

--- a/schemas/delivery_suite_registry_v1.schema.json
+++ b/schemas/delivery_suite_registry_v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/vLLM-HUST/vllm-hust-benchmark/schemas/delivery_suite_registry_v1.schema.json",
+  "title": "vLLM-HUST delivery suite registry v1",
+  "type": "object",
+  "required": ["schema_version", "registry_version", "effective_from", "academic_workload_contract", "acceptance_policy", "entries", "conditional_single_node_extensions", "customer_multinode_extensions"],
+  "properties": {
+    "schema_version": {"const": "delivery-suite-registry/v1"},
+    "registry_version": {"type": "string", "minLength": 1},
+    "effective_from": {"type": "string", "format": "date"},
+    "academic_workload_contract": {
+      "type": "object",
+      "required": ["descriptor_schema_version", "family_generator_version"],
+      "properties": {
+        "descriptor_schema_version": {"const": "workload-descriptor/v1"},
+        "family_generator_version": {"const": "family-generator/v1"}
+      },
+      "additionalProperties": false
+    },
+    "acceptance_policy": {"type": "object"},
+    "entries": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "items": {"$ref": "#/$defs/entry"}
+    },
+    "conditional_single_node_extensions": {"type": "array", "items": {"type": "object"}},
+    "customer_multinode_extensions": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "required": ["workload_id", "label", "workload_family_ids", "benchmark", "model", "enterprise_case_ids", "engine_pressure", "acceptance_metrics"],
+      "properties": {
+        "workload_id": {"enum": ["general_qa", "code", "reasoning", "multimodal", "kv_reuse", "structured_output", "long_context", "agent", "ai4science"]},
+        "label": {"type": "string", "minLength": 1},
+        "workload_family_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "benchmark": {
+          "type": "object",
+          "required": ["id", "authority_url", "dataset"],
+          "properties": {
+            "id": {"type": "string", "minLength": 1},
+            "authority_url": {"type": "string", "format": "uri"},
+            "dataset": {"type": "string", "minLength": 1},
+            "arrival_profile": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "model": {
+          "type": "object",
+          "required": ["id", "deployment_tier", "precision", "tensor_parallel_size", "reason"],
+          "properties": {
+            "id": {"type": "string", "pattern": "^[^/]+/.+$"},
+            "deployment_tier": {"enum": ["single_node_main", "single_node_conditional"]},
+            "precision": {"type": "string", "minLength": 1},
+            "tensor_parallel_size": {"type": "integer", "minimum": 1, "maximum": 8},
+            "reason": {"type": "string", "minLength": 1}
+          },
+          "additionalProperties": false
+        },
+        "enterprise_case_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "engine_pressure": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "acceptance_metrics": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/enterprise_dataset_registry_v1.schema.json
+++ b/schemas/enterprise_dataset_registry_v1.schema.json
@@ -16,7 +16,7 @@
   "$defs": {
     "dataset": {
       "type": "object",
-      "required": ["dataset_id", "relative_path", "source_format", "source_model_name", "record_count", "sha256", "workload_family_id"],
+      "required": ["dataset_id", "relative_path", "source_format", "source_model_name", "record_count", "sha256", "workload_family_id", "provenance_class", "preserved_source_fields"],
       "properties": {
         "dataset_id": {"type": "string", "minLength": 1},
         "relative_path": {"type": "string", "minLength": 1},
@@ -24,17 +24,21 @@
         "source_model_name": {"type": "string", "minLength": 1},
         "record_count": {"type": "integer", "minimum": 1},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
-        "workload_family_id": {"type": "string", "minLength": 1}
+        "workload_family_id": {"type": "string", "minLength": 1},
+        "provenance_class": {"enum": ["enterprise_observed_request", "enterprise_provided_synthetic_or_hybrid"]},
+        "preserved_source_fields": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
       },
       "additionalProperties": false
     },
     "case": {
       "type": "object",
-      "required": ["case_id", "dataset_id", "filter_id"],
+      "required": ["case_id", "dataset_id", "filter_id", "sampling_unit", "replay_order"],
       "properties": {
         "case_id": {"type": "string", "minLength": 1},
         "dataset_id": {"type": "string", "minLength": 1},
-        "filter_id": {"type": ["string", "null"]}
+        "filter_id": {"type": ["string", "null"]},
+        "sampling_unit": {"enum": ["request", "group", "session", "conversation"]},
+        "replay_order": {"enum": ["source_order", "timestamp", "group_then_timestamp"]}
       },
       "additionalProperties": false
     }

--- a/schemas/enterprise_dataset_registry_v1.schema.json
+++ b/schemas/enterprise_dataset_registry_v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/vLLM-HUST/vllm-hust-benchmark/schemas/enterprise_dataset_registry_v1.schema.json",
+  "title": "vLLM-HUST enterprise dataset registry v1",
+  "type": "object",
+  "required": ["schema_version", "registry_version", "effective_from", "data_policy", "datasets", "cases"],
+  "properties": {
+    "schema_version": {"const": "enterprise-dataset-registry/v1"},
+    "registry_version": {"type": "string", "minLength": 1},
+    "effective_from": {"type": "string", "format": "date"},
+    "data_policy": {"type": "object"},
+    "datasets": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/dataset"}},
+    "cases": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/case"}}
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "dataset": {
+      "type": "object",
+      "required": ["dataset_id", "relative_path", "source_format", "source_model_name", "record_count", "sha256", "workload_family_id"],
+      "properties": {
+        "dataset_id": {"type": "string", "minLength": 1},
+        "relative_path": {"type": "string", "minLength": 1},
+        "source_format": {"enum": ["wrapped_openai_request_jsonl", "direct_messages_jsonl"]},
+        "source_model_name": {"type": "string", "minLength": 1},
+        "record_count": {"type": "integer", "minimum": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "workload_family_id": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": false
+    },
+    "case": {
+      "type": "object",
+      "required": ["case_id", "dataset_id", "filter_id"],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "dataset_id": {"type": "string", "minLength": 1},
+        "filter_id": {"type": ["string", "null"]}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/vllm_hust_benchmark/__init__.py
+++ b/src/vllm_hust_benchmark/__init__.py
@@ -1,3 +1,15 @@
 from vllm_hust_benchmark._version import __version__
+from vllm_hust_benchmark.delivery_suite import delivery_suite_entries
+from vllm_hust_benchmark.delivery_suite import load_delivery_suite_registry
+from vllm_hust_benchmark.enterprise_replay import enterprise_case_rows
+from vllm_hust_benchmark.enterprise_replay import enterprise_dataset_rows
+from vllm_hust_benchmark.enterprise_replay import load_enterprise_replay_requests
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "delivery_suite_entries",
+    "enterprise_case_rows",
+    "enterprise_dataset_rows",
+    "load_delivery_suite_registry",
+    "load_enterprise_replay_requests",
+]

--- a/src/vllm_hust_benchmark/data/delivery_suite_registry.json
+++ b/src/vllm_hust_benchmark/data/delivery_suite_registry.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": "delivery-suite-registry/v1",
+  "registry_version": "1.0.0",
+  "effective_from": "2026-08-13",
+  "academic_workload_contract": {
+    "descriptor_schema_version": "workload-descriptor/v1",
+    "family_generator_version": "family-generator/v1"
+  },
+  "acceptance_policy": {
+    "comparison": "same-spec baseline versus candidate with identical model, workload, hardware, server and client parameters",
+    "repetitions": 3,
+    "required_run_status": "valid",
+    "quality_gate": "benchmark-specific quality must not regress outside its declared tolerance",
+    "performance_gate": "report median plus tail latency and throughput; no single composite score may hide a failed metric"
+  },
+  "entries": [
+    {
+      "workload_id": "general_qa",
+      "label": "通用问答与短对话",
+      "workload_family_ids": ["session-affine-multi-turn", "session-affine-bursty", "multi-turn-support-chat"],
+      "benchmark": {
+        "id": "sharegpt-serving",
+        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+        "dataset": "ShareGPT",
+        "arrival_profile": "BurstGPT trace is an optional arrival-process overlay, not a second benchmark"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-32B",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "high-quality general instruction model with enough headroom for concurrency and KV cache on 8x64GB 910B2"
+      },
+      "enterprise_case_ids": ["enterprise_normal_chat_all", "enterprise_normal_chat_support_multi_turn", "enterprise_normal_chat_single_turn"],
+      "engine_pressure": ["short_prefill", "mixed_decode", "online_arrival", "continuous_batching"],
+      "acceptance_metrics": ["request_throughput", "output_token_throughput", "ttft_p50_p95_p99", "tpot_p50_p95_p99", "e2el_p95_p99", "error_rate"]
+    },
+    {
+      "workload_id": "code",
+      "label": "代码生成与代码判定",
+      "workload_family_ids": ["code-eval-judge", "repo-aware-coding-assistant"],
+      "benchmark": {
+        "id": "livecodebench",
+        "authority_url": "https://github.com/LiveCodeBench/LiveCodeBench",
+        "dataset": "LiveCodeBench"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "code-specialized MoE exposes both code quality and serving scheduling/dispatch behavior at deployable total weight"
+      },
+      "enterprise_case_ids": ["enterprise_code_eval_all", "enterprise_code_reward_hack_judge", "enterprise_code_correctness_judge"],
+      "engine_pressure": ["long_prefill", "long_decode", "moe_dispatch", "ttft_sensitive"],
+      "acceptance_metrics": ["pass_at_1", "request_throughput", "ttft_p95_p99", "tpot_p95", "error_rate"]
+    },
+    {
+      "workload_id": "reasoning",
+      "label": "长思维链推理",
+      "workload_family_ids": ["preemption-resume-long-decode"],
+      "benchmark": {
+        "id": "aime-2025",
+        "authority_url": "https://artofproblemsolving.com/wiki/index.php/AIME_Problems_and_Solutions",
+        "dataset": "AIME 2025"
+      },
+      "model": {
+        "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "reasoning-specialized dense 32B model produces the long decode sequences needed to test scheduler stability without multi-node dependence"
+      },
+      "enterprise_case_ids": [],
+      "engine_pressure": ["very_long_decode", "decode_bound", "preemption", "tail_latency"],
+      "acceptance_metrics": ["accuracy", "output_token_throughput", "tpot_p50_p95_p99", "e2el_p95_p99", "error_rate"]
+    },
+    {
+      "workload_id": "multimodal",
+      "label": "图文多模态请求",
+      "workload_family_ids": ["realtime-voice-assistant"],
+      "benchmark": {
+        "id": "visionarena-serving",
+        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+        "dataset": "VisionArena"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "current deployable Qwen vision-language MoE exercises vision preprocessing, multimodal batching and decoder serving"
+      },
+      "enterprise_case_ids": [],
+      "engine_pressure": ["vision_encoder", "variable_image_tokens", "multimodal_batching", "mixed_prefill"],
+      "acceptance_metrics": ["request_throughput", "ttft_p50_p95_p99", "tpot_p95", "e2el_p95_p99", "error_rate"]
+    },
+    {
+      "workload_id": "kv_reuse",
+      "label": "前缀与会话 KV 复用",
+      "workload_family_ids": ["shared-prefix-multi-tenant-assistant", "session-affine-multi-turn", "memory-write-then-reuse"],
+      "benchmark": {
+        "id": "vllm-prefix-repetition",
+        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+        "dataset": "prefix_repetition"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-32B",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "same general checkpoint isolates KV reuse benefit from model-quality changes"
+      },
+      "enterprise_case_ids": ["enterprise_prefix_shared", "enterprise_reuse_conversation", "enterprise_semantic_similar"],
+      "engine_pressure": ["prefix_cache", "kv_lookup", "kv_capacity", "cache_hit_miss_mix"],
+      "acceptance_metrics": ["prefix_cache_hit_rate", "ttft_hit_miss_delta", "request_throughput", "kv_cache_utilization", "error_rate"]
+    },
+    {
+      "workload_id": "structured_output",
+      "label": "JSON 与 Schema 约束输出",
+      "workload_family_ids": ["structured-json-generation"],
+      "benchmark": {
+        "id": "jsonschemabench",
+        "authority_url": "https://github.com/guidance-ai/jsonschemabench",
+        "dataset": "JSONSchemaBench"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-32B",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "general model in non-thinking mode isolates constrained-decoding overhead and schema compliance"
+      },
+      "enterprise_case_ids": ["enterprise_json_all", "enterprise_json_extraction", "enterprise_json_planning"],
+      "engine_pressure": ["guided_decoding", "grammar_state", "small_batch_overhead", "format_validation"],
+      "acceptance_metrics": ["schema_compliance_rate", "valid_json_rate", "request_throughput", "ttft_p95", "tpot_p95", "error_rate"]
+    },
+    {
+      "workload_id": "long_context",
+      "label": "长上下文理解与长 Prefill",
+      "workload_family_ids": ["long-context-doc-analysis"],
+      "benchmark": {
+        "id": "longbench-v2",
+        "authority_url": "https://github.com/THUDM/LongBench",
+        "dataset": "LongBench v2"
+      },
+      "model": {
+        "id": "Qwen/Qwen3.5-27B",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "strong 27B long-context checkpoint leaves HBM for long prompts and concurrency on a single 8-card node"
+      },
+      "enterprise_case_ids": ["enterprise_long_text", "enterprise_long_prefill"],
+      "engine_pressure": ["long_prefill", "attention_memory", "chunked_prefill", "kv_capacity"],
+      "acceptance_metrics": ["longbench_v2_score", "ttft_by_context_bucket", "prefill_token_throughput", "peak_hbm", "oom_rate", "error_rate"]
+    },
+    {
+      "workload_id": "agent",
+      "label": "Agent 工具调用",
+      "workload_family_ids": ["tool-scaffold-agent", "experiment-planning-assistant"],
+      "benchmark": {
+        "id": "bfcl-v4",
+        "authority_url": "https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard",
+        "dataset": "Berkeley Function Calling Leaderboard V4"
+      },
+      "model": {
+        "id": "zai-org/GLM-4.5-Air",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 8,
+        "reason": "106B-A12B agent-oriented MoE represents the enterprise GLM class while remaining a single-node target"
+      },
+      "enterprise_case_ids": ["enterprise_json_planning"],
+      "engine_pressure": ["tool_schema_prefill", "multi_turn", "structured_arguments", "long_lived_session"],
+      "acceptance_metrics": ["bfcl_accuracy", "valid_tool_call_rate", "request_throughput", "ttft_p95_p99", "e2el_p95_p99", "error_rate"]
+    },
+    {
+      "workload_id": "ai4science",
+      "label": "AI4Science 科学问题求解",
+      "workload_family_ids": ["simulation-analysis-verification"],
+      "benchmark": {
+        "id": "naturebench",
+        "authority_url": "https://arxiv.org/pdf/2606.24530",
+        "dataset": "NatureBench"
+      },
+      "model": {
+        "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "deployment_tier": "single_node_main",
+        "precision": "BF16",
+        "tensor_parallel_size": 4,
+        "reason": "scientific problem solving frequently requires code and tool-like reasoning; reusing the deployable code MoE avoids another heavyweight checkpoint"
+      },
+      "enterprise_case_ids": [],
+      "engine_pressure": ["heterogeneous_prompt", "reasoning_decode", "code_generation", "long_tail_output"],
+      "acceptance_metrics": ["naturebench_score", "request_throughput", "ttft_p95", "tpot_p95_p99", "error_rate"]
+    }
+  ],
+  "conditional_single_node_extensions": [
+    {
+      "model_id": "zai-org/GLM-4.6-W8A8",
+      "deployment_tier": "single_node_conditional",
+      "gate": "load and 32k-context KV-capacity preflight must pass before campaign admission"
+    }
+  ],
+  "customer_multinode_extensions": [
+    {"model_id": "zai-org/GLM-5", "deployment_tier": "customer_multinode_extension"},
+    {"model_id": "moonshotai/Kimi-K2", "deployment_tier": "customer_multinode_extension"},
+    {"model_id": "moonshotai/Kimi-K3", "deployment_tier": "customer_multinode_extension"}
+  ]
+}

--- a/src/vllm_hust_benchmark/data/delivery_suite_registry.json
+++ b/src/vllm_hust_benchmark/data/delivery_suite_registry.json
@@ -1,211 +1,411 @@
 {
   "schema_version": "delivery-suite-registry/v1",
-  "registry_version": "1.0.0",
-  "effective_from": "2026-08-13",
+  "registry_version": "1.1.0-proposal",
+  "effective_from": "2026-08-14",
+  "lifecycle_status": "proposal_for_future_fixed_targets",
   "academic_workload_contract": {
     "descriptor_schema_version": "workload-descriptor/v1",
     "family_generator_version": "family-generator/v1"
   },
   "acceptance_policy": {
-    "comparison": "same-spec baseline versus candidate with identical model, workload, hardware, server and client parameters",
-    "repetitions": 3,
-    "required_run_status": "valid",
-    "quality_gate": "benchmark-specific quality must not regress outside its declared tolerance",
-    "performance_gate": "report median plus tail latency and throughput; no single composite score may hide a failed metric"
+    "experimental_design": {
+      "paired_blocks": 5,
+      "block_order": "seeded_AB_or_BA_after_server_restart",
+      "warmup_seconds": 120,
+      "minimum_measured_seconds": 600,
+      "minimum_successful_requests_per_online_run": 1000,
+      "bootstrap_resamples": 10000,
+      "confidence_level": 0.95,
+      "performance_pass_rule": "median paired effect meets the target and the paired-bootstrap confidence interval excludes zero in the beneficial direction",
+      "quality_pass_rule": "paired or stratified-bootstrap lower confidence bound stays above the declared non-inferiority margin",
+      "invalid_run_rule": "only predeclared environment, checksum, protocol, timeout or receipt failures invalidate a block; rerun both sides of the pair"
+    },
+    "causal_baselines": {
+      "upstream_stock": "unmodified upstream vLLM plus the matched upstream vLLM-Ascend backend",
+      "hust_feature_off": "vLLM-HUST with the target optimization disabled, used to expose integration overhead",
+      "hust_feature_on": "vLLM-HUST with the preregistered optimization set enabled",
+      "minus_one_ablation": "feature-on configuration with one optimization removed, required for each claimed mechanism"
+    },
+    "global_guardrails": {
+      "protocol_conformance_percent": 100.0,
+      "maximum_load_error_rate_percent": 0.1,
+      "maximum_error_rate_increase_percentage_points": 0.05,
+      "maximum_secondary_regression_percent": 5.0,
+      "maximum_peak_hbm_regression_percent": 5.0,
+      "silent_fallbacks_allowed": 0,
+      "unclassified_failures_allowed": 0
+    },
+    "portfolio_gate": {
+      "required_valid_scenarios": 9,
+      "required_quality_non_inferiority_scenarios": 9,
+      "minimum_primary_pass_count": 7,
+      "mandatory_primary_pass_scenarios": [
+        "general_qa",
+        "kv_reuse",
+        "structured_output",
+        "long_context"
+      ],
+      "mechanism_gate": "every claimed engine optimization must pass at least one preregistered L1 target and its minus-one ablation"
+    }
   },
+  "evaluation_assets": [
+    {
+      "asset_id": "sharegpt-serving",
+      "asset_type": "serving_harness",
+      "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+      "freeze_rule": "dataset revision, filtered sample IDs, tokenizer and serving parameters"
+    },
+    {
+      "asset_id": "burstgpt-arrival-trace",
+      "asset_type": "serving_trace",
+      "authority_url": "https://github.com/HPMLL/BurstGPT",
+      "freeze_rule": "trace revision, time window, time scale and request-length mapping"
+    },
+    {
+      "asset_id": "livecodebench",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://github.com/LiveCodeBench/LiveCodeBench",
+      "freeze_rule": "release, contamination-safe time window, evaluator image and problem IDs"
+    },
+    {
+      "asset_id": "aime-2025",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://artofproblemsolving.com/wiki/index.php/AIME_Problems_and_Solutions",
+      "freeze_rule": "all 30 problems, prompt, answer parser and generation parameters"
+    },
+    {
+      "asset_id": "visionarena-serving",
+      "asset_type": "serving_harness",
+      "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+      "freeze_rule": "dataset revision, image bytes or checksums, processor revision and pixel policy"
+    },
+    {
+      "asset_id": "vllm-prefix-repetition",
+      "asset_type": "microbenchmark",
+      "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
+      "freeze_rule": "prefix lengths, exact byte prefixes, reuse ratio, request order and cold/warm state"
+    },
+    {
+      "asset_id": "jsonschemabench",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://github.com/guidance-ai/jsonschemabench",
+      "freeze_rule": "schema IDs, backend, compile-cache state, prompts and sampling"
+    },
+    {
+      "asset_id": "longbench-v2",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://github.com/THUDM/LongBench",
+      "freeze_rule": "revision, task IDs, evaluator and target-tokenizer length buckets"
+    },
+    {
+      "asset_id": "bfcl-v4",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard",
+      "freeze_rule": "V4 release, AST evaluator, tool schemas, parser and external-service fixtures"
+    },
+    {
+      "asset_id": "naturebench-design-reference",
+      "asset_type": "design_reference",
+      "authority_url": "https://arxiv.org/pdf/2606.24530",
+      "freeze_rule": "paper and released task-package revision; not used directly as the primary performance gate"
+    },
+    {
+      "asset_id": "hust-science-serving-v1",
+      "asset_type": "quality_benchmark",
+      "authority_url": "https://github.com/vLLM-HUST/vllm-hust-benchmark/blob/main/docs/AI4SCIENCE_BENCHMARK.md",
+      "freeze_rule": "24 task packages, hidden evaluator image, data checksums, budget and frozen LLM segment traces"
+    },
+    {
+      "asset_id": "enterprise-request-replay",
+      "asset_type": "enterprise_replay",
+      "authority_url": "https://github.com/vLLM-HUST/vllm-hust-benchmark/blob/main/docs/ENTERPRISE_REPLAY.md",
+      "freeze_rule": "private dataset checksum, authorization, deterministic sample or group IDs and normalization policy"
+    }
+  ],
+  "engine_capability_targets": [
+    {
+      "capability_id": "api_protocol",
+      "layer": "L0",
+      "profiles": ["chat", "completion", "stream", "content_parts", "tool_call", "response_format"],
+      "pass_gate": "100% conformance on the frozen valid-case suite and zero unclassified failures"
+    },
+    {
+      "capability_id": "artifact_startup",
+      "layer": "L0",
+      "profiles": ["weight_hash", "tokenizer", "processor", "chat_template", "parser", "clean_restart"],
+      "pass_gate": "all pinned artifacts load and pass one deterministic request before performance admission"
+    },
+    {
+      "capability_id": "open_loop_overload",
+      "layer": "L1",
+      "profiles": ["closed_loop", "open_loop", "burst", "saturation", "overload"],
+      "pass_gate": "stable backpressure, bounded error rate and complete tail-latency reporting"
+    },
+    {
+      "capability_id": "prefill_decode_balance",
+      "layer": "L1",
+      "profiles": ["prefill_heavy", "decode_heavy", "balanced", "mixed_interference"],
+      "pass_gate": "separate prefill/decode telemetry and no hidden queueing collapse"
+    },
+    {
+      "capability_id": "scheduler_preemption",
+      "layer": "L1",
+      "profiles": ["continuous_batching", "priority", "preemption", "resume"],
+      "pass_gate": "no request loss, duplication or starvation; resume evidence is emitted"
+    },
+    {
+      "capability_id": "kv_reuse_eviction",
+      "layer": "L1",
+      "profiles": ["cold", "warm", "exact_prefix", "conversation_growth", "eviction"],
+      "pass_gate": "workload expectation, applied mechanism, effective hit and token reduction are all distinguishable"
+    },
+    {
+      "capability_id": "memory_oom_boundary",
+      "layer": "L1",
+      "profiles": ["context_buckets", "kv_pressure", "eviction", "preemption", "oom_boundary"],
+      "pass_gate": "no silent truncation and failure boundary is reproducible"
+    },
+    {
+      "capability_id": "structured_decode",
+      "layer": "L1",
+      "profiles": ["compile_cold", "compile_warm", "grammar_state", "streaming_json", "fallback"],
+      "pass_gate": "schema compliance is preserved and fallback is observable"
+    },
+    {
+      "capability_id": "multimodal_pipeline",
+      "layer": "L1",
+      "profiles": ["image_decode", "processor", "vision_tokens", "mixed_batch", "stream"],
+      "pass_gate": "preprocess and model-service time are reported separately"
+    },
+    {
+      "capability_id": "parallelism_topology",
+      "layer": "L1",
+      "profiles": ["TP2", "TP4", "TP8", "EP_on", "EP_off", "DP_when_applicable"],
+      "pass_gate": "only preflight-admitted topologies become fixed targets"
+    },
+    {
+      "capability_id": "fault_cancellation_restart",
+      "layer": "L1",
+      "profiles": ["client_cancel", "timeout", "worker_failure", "service_restart", "queue_drain"],
+      "pass_gate": "bounded recovery time, no orphan requests and post-restart correctness"
+    },
+    {
+      "capability_id": "fairness_soak",
+      "layer": "L1",
+      "profiles": ["tenant_mix", "short_long_mix", "two_hour_soak", "memory_leak", "starvation"],
+      "pass_gate": "fairness ratio, resource drift and starvation remain within frozen limits"
+    }
+  ],
   "entries": [
     {
-      "workload_id": "general_qa",
-      "label": "通用问答与短对话",
-      "workload_family_ids": ["session-affine-multi-turn", "session-affine-bursty", "multi-turn-support-chat"],
-      "benchmark": {
-        "id": "sharegpt-serving",
-        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
-        "dataset": "ShareGPT",
-        "arrival_profile": "BurstGPT trace is an optional arrival-process overlay, not a second benchmark"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-32B",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "high-quality general instruction model with enough headroom for concurrency and KV cache on 8x64GB 910B2"
-      },
+      "application_scenario_id": "general_qa",
+      "label": "通用问答与真实突发流量",
+      "workload_family_ids": ["session-affine-multi-turn", "session-affine-bursty", "multi-turn-support-chat", "overload-backpressure"],
+      "public_asset_ids": ["sharegpt-serving", "burstgpt-arrival-trace"],
       "enterprise_case_ids": ["enterprise_normal_chat_all", "enterprise_normal_chat_support_multi_turn", "enterprise_normal_chat_single_turn"],
-      "engine_pressure": ["short_prefill", "mixed_decode", "online_arrival", "continuous_batching"],
-      "acceptance_metrics": ["request_throughput", "output_token_throughput", "ttft_p50_p95_p99", "tpot_p50_p95_p99", "e2el_p95_p99", "error_rate"]
+      "engine_capability_ids": ["api_protocol", "open_loop_overload", "prefill_decode_balance", "fairness_soak"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-32B",
+        "revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "tokenizer_revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": false, "max_model_len": 32768},
+        "reason": "32B dense general model balances task quality, cache pressure and repeatable single-node capacity"
+      },
+      "primary_endpoint": {"metric": "maximum_sustainable_rps_at_frozen_slo", "direction": "higher", "minimum_effect_percent": 10.0},
+      "quality_gate": {"metric": "protocol_and_deterministic_case_pass_rate", "non_inferiority_margin": 0.0, "unit": "percentage_points"}
     },
     {
-      "workload_id": "code",
+      "application_scenario_id": "code",
       "label": "代码生成与代码判定",
       "workload_family_ids": ["code-eval-judge", "repo-aware-coding-assistant"],
-      "benchmark": {
-        "id": "livecodebench",
-        "authority_url": "https://github.com/LiveCodeBench/LiveCodeBench",
-        "dataset": "LiveCodeBench"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "code-specialized MoE exposes both code quality and serving scheduling/dispatch behavior at deployable total weight"
-      },
+      "public_asset_ids": ["livecodebench"],
       "enterprise_case_ids": ["enterprise_code_eval_all", "enterprise_code_reward_hack_judge", "enterprise_code_correctness_judge"],
-      "engine_pressure": ["long_prefill", "long_decode", "moe_dispatch", "ttft_sensitive"],
-      "acceptance_metrics": ["pass_at_1", "request_throughput", "ttft_p95_p99", "tpot_p95", "error_rate"]
+      "engine_capability_ids": ["api_protocol", "prefill_decode_balance", "scheduler_preemption", "parallelism_topology"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "revision": "b2cff646eb4bb1d68355c01b18ae02e7cf42d120",
+        "tokenizer_revision": "b2cff646eb4bb1d68355c01b18ae02e7cf42d120",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": true, "max_model_len": 65536},
+        "reason": "30.5B total and 3.3B active code-specialized MoE gives credible quality with affordable repeated serving runs"
+      },
+      "primary_endpoint": {"metric": "request_throughput_at_frozen_slo", "direction": "higher", "minimum_effect_percent": 5.0},
+      "quality_gate": {"metric": "livecodebench_pass_at_1", "non_inferiority_margin": 1.0, "unit": "percentage_points"}
     },
     {
-      "workload_id": "reasoning",
-      "label": "长思维链推理",
-      "workload_family_ids": ["preemption-resume-long-decode"],
-      "benchmark": {
-        "id": "aime-2025",
-        "authority_url": "https://artofproblemsolving.com/wiki/index.php/AIME_Problems_and_Solutions",
-        "dataset": "AIME 2025"
-      },
-      "model": {
-        "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "reasoning-specialized dense 32B model produces the long decode sequences needed to test scheduler stability without multi-node dependence"
-      },
+      "application_scenario_id": "reasoning",
+      "label": "长思维链推理与长输出",
+      "workload_family_ids": ["preemption-resume-long-decode", "mixed-prefill-decode-interference"],
+      "public_asset_ids": ["aime-2025"],
       "enterprise_case_ids": [],
-      "engine_pressure": ["very_long_decode", "decode_bound", "preemption", "tail_latency"],
-      "acceptance_metrics": ["accuracy", "output_token_throughput", "tpot_p50_p95_p99", "e2el_p95_p99", "error_rate"]
+      "engine_capability_ids": ["prefill_decode_balance", "scheduler_preemption", "fault_cancellation_restart"],
+      "model_artifact": {
+        "repo_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+        "revision": "711ad2ea6aa40cfca18895e8aca02ab92df1a746",
+        "tokenizer_revision": "711ad2ea6aa40cfca18895e8aca02ab92df1a746",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": false, "max_model_len": 32768},
+        "reason": "reasoning-specialized 32B model creates repeatable decode-heavy pressure without a multi-node 671B checkpoint"
+      },
+      "primary_endpoint": {"metric": "output_token_throughput", "direction": "higher", "minimum_effect_percent": 8.0},
+      "quality_gate": {"metric": "aime_2025_accuracy", "non_inferiority_margin": 1.0, "unit": "problem_count"}
     },
     {
-      "workload_id": "multimodal",
-      "label": "图文多模态请求",
-      "workload_family_ids": ["realtime-voice-assistant"],
-      "benchmark": {
-        "id": "visionarena-serving",
-        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
-        "dataset": "VisionArena"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "current deployable Qwen vision-language MoE exercises vision preprocessing, multimodal batching and decoder serving"
-      },
+      "application_scenario_id": "multimodal",
+      "label": "图文多模态在线服务",
+      "workload_family_ids": ["multimodal-online-serving"],
+      "public_asset_ids": ["visionarena-serving"],
       "enterprise_case_ids": [],
-      "engine_pressure": ["vision_encoder", "variable_image_tokens", "multimodal_batching", "mixed_prefill"],
-      "acceptance_metrics": ["request_throughput", "ttft_p50_p95_p99", "tpot_p95", "e2el_p95_p99", "error_rate"]
+      "engine_capability_ids": ["api_protocol", "multimodal_pipeline", "parallelism_topology", "fairness_soak"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+        "revision": "9c4b90e1e4ba969fd3b5378b57d966d725f1b86c",
+        "tokenizer_revision": "9c4b90e1e4ba969fd3b5378b57d966d725f1b86c",
+        "processor_revision": "9c4b90e1e4ba969fd3b5378b57d966d725f1b86c",
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 2, "data_parallel_size": 1, "expert_parallel": true, "max_model_len": 32768},
+        "reason": "official Ascend single-node path and native image-text pipeline; TP2 follows the documented A2 starting point"
+      },
+      "primary_endpoint": {"metric": "request_throughput_at_frozen_slo", "direction": "higher", "minimum_effect_percent": 5.0},
+      "quality_gate": {"metric": "multimodal_protocol_and_fixed_case_score", "non_inferiority_margin": 1.0, "unit": "percentage_points"}
     },
     {
-      "workload_id": "kv_reuse",
-      "label": "前缀与会话 KV 复用",
-      "workload_family_ids": ["shared-prefix-multi-tenant-assistant", "session-affine-multi-turn", "memory-write-then-reuse"],
-      "benchmark": {
-        "id": "vllm-prefix-repetition",
-        "authority_url": "https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py",
-        "dataset": "prefix_repetition"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-32B",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "same general checkpoint isolates KV reuse benefit from model-quality changes"
-      },
+      "application_scenario_id": "kv_reuse",
+      "label": "前缀、会话与 KV 复用",
+      "workload_family_ids": ["shared-prefix-multi-tenant-assistant", "session-affine-multi-turn", "memory-write-then-reuse", "kv-eviction-recompute"],
+      "public_asset_ids": ["vllm-prefix-repetition"],
       "enterprise_case_ids": ["enterprise_prefix_shared", "enterprise_reuse_conversation", "enterprise_semantic_similar"],
-      "engine_pressure": ["prefix_cache", "kv_lookup", "kv_capacity", "cache_hit_miss_mix"],
-      "acceptance_metrics": ["prefix_cache_hit_rate", "ttft_hit_miss_delta", "request_throughput", "kv_cache_utilization", "error_rate"]
+      "engine_capability_ids": ["kv_reuse_eviction", "memory_oom_boundary", "fairness_soak"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-32B",
+        "revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "tokenizer_revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": false, "max_model_len": 65536},
+        "reason": "reuses the general dense checkpoint so cache effects are not confounded by a model change"
+      },
+      "primary_endpoint": {"metric": "warm_ttft_p50", "direction": "lower", "minimum_effect_percent": 20.0},
+      "quality_gate": {"metric": "deterministic_output_equivalence_rate", "non_inferiority_margin": 0.0, "unit": "percentage_points"},
+      "mechanism_guardrails": {"minimum_prefill_token_reduction_percent": 30.0, "minimum_end_to_end_latency_reduction_percent": 10.0, "semantic_similarity_is_exact_prefix_evidence": false}
     },
     {
-      "workload_id": "structured_output",
+      "application_scenario_id": "structured_output",
       "label": "JSON 与 Schema 约束输出",
       "workload_family_ids": ["structured-json-generation"],
-      "benchmark": {
-        "id": "jsonschemabench",
-        "authority_url": "https://github.com/guidance-ai/jsonschemabench",
-        "dataset": "JSONSchemaBench"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-32B",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "general model in non-thinking mode isolates constrained-decoding overhead and schema compliance"
-      },
+      "public_asset_ids": ["jsonschemabench"],
       "enterprise_case_ids": ["enterprise_json_all", "enterprise_json_extraction", "enterprise_json_planning"],
-      "engine_pressure": ["guided_decoding", "grammar_state", "small_batch_overhead", "format_validation"],
-      "acceptance_metrics": ["schema_compliance_rate", "valid_json_rate", "request_throughput", "ttft_p95", "tpot_p95", "error_rate"]
+      "engine_capability_ids": ["api_protocol", "structured_decode", "prefill_decode_balance"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-32B",
+        "revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "tokenizer_revision": "9216db5781bf21249d130ec9da846c4624c16137",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": false, "max_model_len": 32768},
+        "reason": "non-thinking general model isolates grammar compilation and constrained decoding from model specialization"
+      },
+      "primary_endpoint": {"metric": "constrained_output_token_throughput", "direction": "higher", "minimum_effect_percent": 5.0},
+      "quality_gate": {"metric": "schema_compliance_rate", "non_inferiority_margin": 0.0, "unit": "percentage_points", "absolute_minimum_percent": 100.0}
     },
     {
-      "workload_id": "long_context",
+      "application_scenario_id": "long_context",
       "label": "长上下文理解与长 Prefill",
-      "workload_family_ids": ["long-context-doc-analysis"],
-      "benchmark": {
-        "id": "longbench-v2",
-        "authority_url": "https://github.com/THUDM/LongBench",
-        "dataset": "LongBench v2"
-      },
-      "model": {
-        "id": "Qwen/Qwen3.5-27B",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "strong 27B long-context checkpoint leaves HBM for long prompts and concurrency on a single 8-card node"
-      },
+      "workload_family_ids": ["long-context-doc-analysis", "mixed-prefill-decode-interference", "kv-eviction-recompute"],
+      "public_asset_ids": ["longbench-v2"],
       "enterprise_case_ids": ["enterprise_long_text", "enterprise_long_prefill"],
-      "engine_pressure": ["long_prefill", "attention_memory", "chunked_prefill", "kv_capacity"],
-      "acceptance_metrics": ["longbench_v2_score", "ttft_by_context_bucket", "prefill_token_throughput", "peak_hbm", "oom_rate", "error_rate"]
+      "engine_capability_ids": ["prefill_decode_balance", "memory_oom_boundary", "parallelism_topology", "fairness_soak"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3.6-27B",
+        "revision": "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9",
+        "tokenizer_revision": "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9",
+        "processor_revision": "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9",
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 2, "data_parallel_size": 1, "expert_parallel": false, "max_model_len": 133000},
+        "reason": "27B dense hybrid model has an official Ascend 128K single-node path and leaves capacity for long KV"
+      },
+      "primary_endpoint": {"metric": "prefill_token_throughput_64k_128k", "direction": "higher", "minimum_effect_percent": 10.0},
+      "quality_gate": {"metric": "longbench_v2_score", "non_inferiority_margin": 1.0, "unit": "score_points"}
     },
     {
-      "workload_id": "agent",
-      "label": "Agent 工具调用",
-      "workload_family_ids": ["tool-scaffold-agent", "experiment-planning-assistant"],
-      "benchmark": {
-        "id": "bfcl-v4",
-        "authority_url": "https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard",
-        "dataset": "Berkeley Function Calling Leaderboard V4"
-      },
-      "model": {
-        "id": "zai-org/GLM-4.5-Air",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 8,
-        "reason": "106B-A12B agent-oriented MoE represents the enterprise GLM class while remaining a single-node target"
-      },
+      "application_scenario_id": "agent",
+      "label": "Agent 工具调用与长会话",
+      "workload_family_ids": ["tool-scaffold-agent", "experiment-planning-assistant", "cancellation-timeout-churn"],
+      "public_asset_ids": ["bfcl-v4"],
       "enterprise_case_ids": ["enterprise_json_planning"],
-      "engine_pressure": ["tool_schema_prefill", "multi_turn", "structured_arguments", "long_lived_session"],
-      "acceptance_metrics": ["bfcl_accuracy", "valid_tool_call_rate", "request_throughput", "ttft_p95_p99", "e2el_p95_p99", "error_rate"]
+      "engine_capability_ids": ["api_protocol", "scheduler_preemption", "fault_cancellation_restart", "parallelism_topology"],
+      "model_artifact": {
+        "repo_id": "zai-org/GLM-4.5-Air",
+        "revision": "a24ceef6ce4f3536971efe9b778bdaa1bab18daa",
+        "tokenizer_revision": "a24ceef6ce4f3536971efe9b778bdaa1bab18daa",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 8, "data_parallel_size": 1, "expert_parallel": true, "max_model_len": 32768},
+        "reason": "106B total and 12B active agent-oriented MoE represents the enterprise GLM class while remaining a single-node candidate"
+      },
+      "primary_endpoint": {"metric": "frozen_llm_segment_e2e_p95", "direction": "lower", "minimum_effect_percent": 5.0},
+      "quality_gate": {"metric": "bfcl_v4_accuracy", "non_inferiority_margin": 1.0, "unit": "percentage_points"}
     },
     {
-      "workload_id": "ai4science",
-      "label": "AI4Science 科学问题求解",
-      "workload_family_ids": ["simulation-analysis-verification"],
-      "benchmark": {
-        "id": "naturebench",
-        "authority_url": "https://arxiv.org/pdf/2606.24530",
-        "dataset": "NatureBench"
-      },
-      "model": {
-        "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "deployment_tier": "single_node_main",
-        "precision": "BF16",
-        "tensor_parallel_size": 4,
-        "reason": "scientific problem solving frequently requires code and tool-like reasoning; reusing the deployable code MoE avoids another heavyweight checkpoint"
-      },
+      "application_scenario_id": "ai4science",
+      "label": "AI4Science 科学代码与验证",
+      "workload_family_ids": ["simulation-analysis-verification", "scientific-code-agent"],
+      "public_asset_ids": ["naturebench-design-reference", "hust-science-serving-v1"],
       "enterprise_case_ids": [],
-      "engine_pressure": ["heterogeneous_prompt", "reasoning_decode", "code_generation", "long_tail_output"],
-      "acceptance_metrics": ["naturebench_score", "request_throughput", "ttft_p95", "tpot_p95_p99", "error_rate"]
+      "engine_capability_ids": ["prefill_decode_balance", "scheduler_preemption", "fault_cancellation_restart", "fairness_soak"],
+      "model_artifact": {
+        "repo_id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "revision": "b2cff646eb4bb1d68355c01b18ae02e7cf42d120",
+        "tokenizer_revision": "b2cff646eb4bb1d68355c01b18ae02e7cf42d120",
+        "processor_revision": null,
+        "chat_template_source": "tokenizer_config.json@model_revision",
+        "artifact_status": "pinned_candidate",
+        "deployment_tier": "single_node_main",
+        "runtime_profile": {"dtype": "BF16", "tensor_parallel_size": 4, "data_parallel_size": 1, "expert_parallel": true, "max_model_len": 65536},
+        "reason": "scientific tasks are executable coding and verification workloads; the code MoE avoids a seventh heavyweight checkpoint"
+      },
+      "primary_endpoint": {"metric": "frozen_llm_segment_output_token_throughput", "direction": "higher", "minimum_effect_percent": 5.0},
+      "quality_gate": {"metric": "hust_science_serving_task_success", "non_inferiority_margin": 1.0, "unit": "task_count"}
     }
   ],
   "conditional_single_node_extensions": [
     {
-      "model_id": "zai-org/GLM-4.6-W8A8",
+      "model_class": "GLM-4.6-W8A8",
       "deployment_tier": "single_node_conditional",
-      "gate": "load and 32k-context KV-capacity preflight must pass before campaign admission"
+      "artifact_status": "unresolved_until_accessible_revision_and_weight_hash_are_supplied",
+      "gate": "load, parser, 32K KV capacity and 20% free-HBM preflight"
     }
   ],
   "customer_multinode_extensions": [
-    {"model_id": "zai-org/GLM-5", "deployment_tier": "customer_multinode_extension"},
-    {"model_id": "moonshotai/Kimi-K2", "deployment_tier": "customer_multinode_extension"},
-    {"model_id": "moonshotai/Kimi-K3", "deployment_tier": "customer_multinode_extension"}
+    {
+      "model_class": "GLM-5-class",
+      "deployment_tier": "customer_multinode_extension",
+      "gate": "customer-accessible artifact and production-equivalent multi-node topology"
+    },
+    {
+      "model_class": "Kimi-K2-or-K3-class",
+      "deployment_tier": "customer_multinode_extension",
+      "gate": "customer-accessible artifact and production-equivalent multi-node topology"
+    }
   ]
 }

--- a/src/vllm_hust_benchmark/data/enterprise_dataset_registry.json
+++ b/src/vllm_hust_benchmark/data/enterprise_dataset_registry.json
@@ -6,7 +6,8 @@
     "raw_data_in_git": false,
     "data_root_resolution": "explicit_argument_or_VLLM_HUST_ENTERPRISE_DATA_ROOT_only",
     "authorization": "dataset-scoped authorization file required",
-    "result_redaction": "request bodies are excluded; canonical hashes and shape metadata only"
+    "result_redaction": "request bodies are excluded; canonical hashes and allowlisted shape metadata only",
+    "evidence_model": "observed requests prove request-shape realism; synthetic or hybrid sets prove controlled stress coverage; runtime cache hits and gains require engine telemetry"
   },
   "datasets": [
     {
@@ -16,7 +17,9 @@
       "source_model_name": "qwen3",
       "record_count": 1000,
       "sha256": "dc22bd65cbea0fa61d436282178a30d728d2e3a0ed3f4269361601b43177bbc8",
-      "workload_family_id": "code-eval-judge"
+      "workload_family_id": "code-eval-judge",
+      "provenance_class": "enterprise_observed_request",
+      "preserved_source_fields": []
     },
     {
       "dataset_id": "enterprise_structured_json_v1",
@@ -25,7 +28,9 @@
       "source_model_name": "qwen3",
       "record_count": 500,
       "sha256": "7090c161d155be77af77f96a22900643145dd583944a2df959a94f362dba4640",
-      "workload_family_id": "structured-json-generation"
+      "workload_family_id": "structured-json-generation",
+      "provenance_class": "enterprise_observed_request",
+      "preserved_source_fields": []
     },
     {
       "dataset_id": "enterprise_normal_chat_v1",
@@ -34,7 +39,9 @@
       "source_model_name": "qwen3",
       "record_count": 1000,
       "sha256": "1097f4c57d3f958e726c4c671edafc301cd6152a1f9ce04231fd83e9531086bd",
-      "workload_family_id": "multi-turn-support-chat"
+      "workload_family_id": "multi-turn-support-chat",
+      "provenance_class": "enterprise_observed_request",
+      "preserved_source_fields": []
     },
     {
       "dataset_id": "enterprise_long_text_v1",
@@ -43,7 +50,9 @@
       "source_model_name": "enterprise-unspecified",
       "record_count": 4000,
       "sha256": "97d40d4f66eb184ea13e24397b57614c70aedf2c9dea0d0f970c5b3547d6779c",
-      "workload_family_id": "long-context-doc-analysis"
+      "workload_family_id": "long-context-doc-analysis",
+      "provenance_class": "enterprise_observed_request",
+      "preserved_source_fields": ["id", "request_id", "workload_type", "prompt_hash"]
     },
     {
       "dataset_id": "enterprise_prefix_shared_v2",
@@ -52,7 +61,9 @@
       "source_model_name": "enterprise-unspecified",
       "record_count": 5000,
       "sha256": "355ed42e0050bd178bee74f616d16c6036117f2eea338bb30eff0f941b86027e",
-      "workload_family_id": "shared-prefix-multi-tenant-assistant"
+      "workload_family_id": "shared-prefix-multi-tenant-assistant",
+      "provenance_class": "enterprise_provided_synthetic_or_hybrid",
+      "preserved_source_fields": ["id", "workload_type", "group_id", "session_id", "created_at_ms", "prompt_hash", "prompt_tokens_est", "metadata"]
     },
     {
       "dataset_id": "enterprise_reuse_conversation_v2",
@@ -61,7 +72,9 @@
       "source_model_name": "enterprise-unspecified",
       "record_count": 5000,
       "sha256": "3b69ef16266945121df6d752367c9d132f3a21de2dea0158fcd03f2014649a77",
-      "workload_family_id": "session-affine-multi-turn"
+      "workload_family_id": "session-affine-multi-turn",
+      "provenance_class": "enterprise_provided_synthetic_or_hybrid",
+      "preserved_source_fields": ["id", "workload_type", "group_id", "session_id", "conversation_id", "created_at_ms", "prompt_hash", "prompt_tokens_est", "metadata"]
     },
     {
       "dataset_id": "enterprise_semantic_similar_v2",
@@ -70,7 +83,9 @@
       "source_model_name": "enterprise-unspecified",
       "record_count": 5000,
       "sha256": "eecb069a51af828f3388525fcaf84f82cb15a56116fdffc293a69dd77bc9a746",
-      "workload_family_id": "dynamic-rag-corpus-update"
+      "workload_family_id": "dynamic-rag-corpus-update",
+      "provenance_class": "enterprise_provided_synthetic_or_hybrid",
+      "preserved_source_fields": ["id", "workload_type", "group_id", "session_id", "created_at_ms", "prompt_hash", "prompt_tokens_est", "metadata"]
     },
     {
       "dataset_id": "enterprise_long_prefill_v2",
@@ -79,23 +94,25 @@
       "source_model_name": "enterprise-unspecified",
       "record_count": 5000,
       "sha256": "11baa5e4b25fc760a14517b734c5ce0ceb1abf8e0361697fbeef66e0f48e14c1",
-      "workload_family_id": "long-context-doc-analysis"
+      "workload_family_id": "long-context-doc-analysis",
+      "provenance_class": "enterprise_provided_synthetic_or_hybrid",
+      "preserved_source_fields": ["id", "workload_type", "group_id", "session_id", "created_at_ms", "prompt_hash", "prompt_tokens_est", "metadata"]
     }
   ],
   "cases": [
-    {"case_id": "enterprise_code_eval_all", "dataset_id": "enterprise_code_eval_v1", "filter_id": null},
-    {"case_id": "enterprise_code_reward_hack_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_reward_hack_judge"},
-    {"case_id": "enterprise_code_correctness_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_answer_correctness_judge"},
-    {"case_id": "enterprise_json_all", "dataset_id": "enterprise_structured_json_v1", "filter_id": null},
-    {"case_id": "enterprise_json_extraction", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_structured_extraction"},
-    {"case_id": "enterprise_json_planning", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_planning_orchestration"},
-    {"case_id": "enterprise_normal_chat_all", "dataset_id": "enterprise_normal_chat_v1", "filter_id": null},
-    {"case_id": "enterprise_normal_chat_support_multi_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_support_multi_turn"},
-    {"case_id": "enterprise_normal_chat_single_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_single_turn_general"},
-    {"case_id": "enterprise_long_text", "dataset_id": "enterprise_long_text_v1", "filter_id": null},
-    {"case_id": "enterprise_prefix_shared", "dataset_id": "enterprise_prefix_shared_v2", "filter_id": null},
-    {"case_id": "enterprise_reuse_conversation", "dataset_id": "enterprise_reuse_conversation_v2", "filter_id": null},
-    {"case_id": "enterprise_semantic_similar", "dataset_id": "enterprise_semantic_similar_v2", "filter_id": null},
-    {"case_id": "enterprise_long_prefill", "dataset_id": "enterprise_long_prefill_v2", "filter_id": null}
+    {"case_id": "enterprise_code_eval_all", "dataset_id": "enterprise_code_eval_v1", "filter_id": null, "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_code_reward_hack_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_reward_hack_judge", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_code_correctness_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_answer_correctness_judge", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_json_all", "dataset_id": "enterprise_structured_json_v1", "filter_id": null, "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_json_extraction", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_structured_extraction", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_json_planning", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_planning_orchestration", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_normal_chat_all", "dataset_id": "enterprise_normal_chat_v1", "filter_id": null, "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_normal_chat_support_multi_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_support_multi_turn", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_normal_chat_single_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_single_turn_general", "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_long_text", "dataset_id": "enterprise_long_text_v1", "filter_id": null, "sampling_unit": "request", "replay_order": "source_order"},
+    {"case_id": "enterprise_prefix_shared", "dataset_id": "enterprise_prefix_shared_v2", "filter_id": null, "sampling_unit": "group", "replay_order": "group_then_timestamp"},
+    {"case_id": "enterprise_reuse_conversation", "dataset_id": "enterprise_reuse_conversation_v2", "filter_id": null, "sampling_unit": "conversation", "replay_order": "group_then_timestamp"},
+    {"case_id": "enterprise_semantic_similar", "dataset_id": "enterprise_semantic_similar_v2", "filter_id": null, "sampling_unit": "group", "replay_order": "group_then_timestamp"},
+    {"case_id": "enterprise_long_prefill", "dataset_id": "enterprise_long_prefill_v2", "filter_id": null, "sampling_unit": "request", "replay_order": "timestamp"}
   ]
 }

--- a/src/vllm_hust_benchmark/data/enterprise_dataset_registry.json
+++ b/src/vllm_hust_benchmark/data/enterprise_dataset_registry.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "enterprise-dataset-registry/v1",
+  "registry_version": "1.0.0",
+  "effective_from": "2026-08-13",
+  "data_policy": {
+    "raw_data_in_git": false,
+    "data_root_resolution": "explicit_argument_or_VLLM_HUST_ENTERPRISE_DATA_ROOT_only",
+    "authorization": "dataset-scoped authorization file required",
+    "result_redaction": "request bodies are excluded; canonical hashes and shape metadata only"
+  },
+  "datasets": [
+    {
+      "dataset_id": "enterprise_code_eval_v1",
+      "relative_path": "benchmark_test_datasdet_v1/可交付客户/code_eval_ttft_1000.jsonl",
+      "source_format": "wrapped_openai_request_jsonl",
+      "source_model_name": "qwen3",
+      "record_count": 1000,
+      "sha256": "dc22bd65cbea0fa61d436282178a30d728d2e3a0ed3f4269361601b43177bbc8",
+      "workload_family_id": "code-eval-judge"
+    },
+    {
+      "dataset_id": "enterprise_structured_json_v1",
+      "relative_path": "benchmark_test_datasdet_v1/可交付客户/json_requests_500.jsonl",
+      "source_format": "wrapped_openai_request_jsonl",
+      "source_model_name": "qwen3",
+      "record_count": 500,
+      "sha256": "7090c161d155be77af77f96a22900643145dd583944a2df959a94f362dba4640",
+      "workload_family_id": "structured-json-generation"
+    },
+    {
+      "dataset_id": "enterprise_normal_chat_v1",
+      "relative_path": "benchmark_test_datasdet_v1/可交付客户/normal_chat_1000.jsonl",
+      "source_format": "wrapped_openai_request_jsonl",
+      "source_model_name": "qwen3",
+      "record_count": 1000,
+      "sha256": "1097f4c57d3f958e726c4c671edafc301cd6152a1f9ce04231fd83e9531086bd",
+      "workload_family_id": "multi-turn-support-chat"
+    },
+    {
+      "dataset_id": "enterprise_long_text_v1",
+      "relative_path": "long_text_dataset/超长文本数据集/api_long_text_merged_4000.jsonl",
+      "source_format": "direct_messages_jsonl",
+      "source_model_name": "enterprise-unspecified",
+      "record_count": 4000,
+      "sha256": "97d40d4f66eb184ea13e24397b57614c70aedf2c9dea0d0f970c5b3547d6779c",
+      "workload_family_id": "long-context-doc-analysis"
+    },
+    {
+      "dataset_id": "enterprise_prefix_shared_v2",
+      "relative_path": "final_workloaddata_v2/final_workloaddata_v2/prefix_shared.jsonl",
+      "source_format": "direct_messages_jsonl",
+      "source_model_name": "enterprise-unspecified",
+      "record_count": 5000,
+      "sha256": "355ed42e0050bd178bee74f616d16c6036117f2eea338bb30eff0f941b86027e",
+      "workload_family_id": "shared-prefix-multi-tenant-assistant"
+    },
+    {
+      "dataset_id": "enterprise_reuse_conversation_v2",
+      "relative_path": "final_workloaddata_v2/final_workloaddata_v2/reuse_conversation.jsonl",
+      "source_format": "direct_messages_jsonl",
+      "source_model_name": "enterprise-unspecified",
+      "record_count": 5000,
+      "sha256": "3b69ef16266945121df6d752367c9d132f3a21de2dea0158fcd03f2014649a77",
+      "workload_family_id": "session-affine-multi-turn"
+    },
+    {
+      "dataset_id": "enterprise_semantic_similar_v2",
+      "relative_path": "final_workloaddata_v2/final_workloaddata_v2/semantic_similar.jsonl",
+      "source_format": "direct_messages_jsonl",
+      "source_model_name": "enterprise-unspecified",
+      "record_count": 5000,
+      "sha256": "eecb069a51af828f3388525fcaf84f82cb15a56116fdffc293a69dd77bc9a746",
+      "workload_family_id": "dynamic-rag-corpus-update"
+    },
+    {
+      "dataset_id": "enterprise_long_prefill_v2",
+      "relative_path": "final_workloaddata_v2/final_workloaddata_v2/long_prefill.jsonl",
+      "source_format": "direct_messages_jsonl",
+      "source_model_name": "enterprise-unspecified",
+      "record_count": 5000,
+      "sha256": "11baa5e4b25fc760a14517b734c5ce0ceb1abf8e0361697fbeef66e0f48e14c1",
+      "workload_family_id": "long-context-doc-analysis"
+    }
+  ],
+  "cases": [
+    {"case_id": "enterprise_code_eval_all", "dataset_id": "enterprise_code_eval_v1", "filter_id": null},
+    {"case_id": "enterprise_code_reward_hack_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_reward_hack_judge"},
+    {"case_id": "enterprise_code_correctness_judge", "dataset_id": "enterprise_code_eval_v1", "filter_id": "code_answer_correctness_judge"},
+    {"case_id": "enterprise_json_all", "dataset_id": "enterprise_structured_json_v1", "filter_id": null},
+    {"case_id": "enterprise_json_extraction", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_structured_extraction"},
+    {"case_id": "enterprise_json_planning", "dataset_id": "enterprise_structured_json_v1", "filter_id": "json_planning_orchestration"},
+    {"case_id": "enterprise_normal_chat_all", "dataset_id": "enterprise_normal_chat_v1", "filter_id": null},
+    {"case_id": "enterprise_normal_chat_support_multi_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_support_multi_turn"},
+    {"case_id": "enterprise_normal_chat_single_turn", "dataset_id": "enterprise_normal_chat_v1", "filter_id": "normal_chat_single_turn_general"},
+    {"case_id": "enterprise_long_text", "dataset_id": "enterprise_long_text_v1", "filter_id": null},
+    {"case_id": "enterprise_prefix_shared", "dataset_id": "enterprise_prefix_shared_v2", "filter_id": null},
+    {"case_id": "enterprise_reuse_conversation", "dataset_id": "enterprise_reuse_conversation_v2", "filter_id": null},
+    {"case_id": "enterprise_semantic_similar", "dataset_id": "enterprise_semantic_similar_v2", "filter_id": null},
+    {"case_id": "enterprise_long_prefill", "dataset_id": "enterprise_long_prefill_v2", "filter_id": null}
+  ]
+}

--- a/src/vllm_hust_benchmark/delivery_suite.py
+++ b/src/vllm_hust_benchmark/delivery_suite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib import resources
@@ -10,7 +11,7 @@ from typing import Any
 
 
 SCHEMA_VERSION = "delivery-suite-registry/v1"
-REQUIRED_WORKLOAD_IDS = frozenset(
+REQUIRED_APPLICATION_SCENARIO_IDS = frozenset(
     {
         "general_qa",
         "code",
@@ -23,21 +24,52 @@ REQUIRED_WORKLOAD_IDS = frozenset(
         "ai4science",
     }
 )
+# Kept as an import-compatible alias for the unmerged v1 branch API.
+REQUIRED_WORKLOAD_IDS = REQUIRED_APPLICATION_SCENARIO_IDS
+REQUIRED_CAPABILITY_TARGET_IDS = frozenset(
+    {
+        "api_protocol",
+        "artifact_startup",
+        "open_loop_overload",
+        "prefill_decode_balance",
+        "scheduler_preemption",
+        "kv_reuse_eviction",
+        "memory_oom_boundary",
+        "structured_decode",
+        "multimodal_pipeline",
+        "parallelism_topology",
+        "fault_cancellation_restart",
+        "fairness_soak",
+    }
+)
 VALID_DEPLOYMENT_TIERS = frozenset(
     {"single_node_main", "single_node_conditional", "customer_multinode_extension"}
 )
+VALID_ASSET_TYPES = frozenset(
+    {
+        "quality_benchmark",
+        "serving_trace",
+        "serving_harness",
+        "microbenchmark",
+        "enterprise_replay",
+        "design_reference",
+    }
+)
+PINNED_ARTIFACT_STATUSES = frozenset({"pinned_candidate", "admitted"})
 
 
 @dataclass(frozen=True)
 class DeliverySuiteEntry:
     workload_id: str
     workload_family_ids: tuple[str, ...]
-    benchmark_id: str
+    public_asset_ids: tuple[str, ...]
     model_id: str
+    model_revision: str
     deployment_tier: str
     enterprise_case_ids: tuple[str, ...]
-    engine_pressure: tuple[str, ...]
-    acceptance_metrics: tuple[str, ...]
+    engine_capability_ids: tuple[str, ...]
+    primary_metric: str
+    minimum_effect_percent: float
 
 
 def _registry_resource() -> Any:
@@ -53,13 +85,81 @@ def _require_non_empty_string(value: object, *, field: str) -> str:
     return normalized
 
 
-def _require_string_list(value: object, *, field: str) -> list[str]:
-    if not isinstance(value, list) or not value:
-        raise ValueError(f"delivery suite {field} must be a non-empty array")
+def _require_string_list(
+    value: object, *, field: str, allow_empty: bool = False
+) -> list[str]:
+    if not isinstance(value, list) or (not value and not allow_empty):
+        qualifier = "an array" if allow_empty else "a non-empty array"
+        raise ValueError(f"delivery suite {field} must be {qualifier}")
     normalized = [_require_non_empty_string(item, field=field) for item in value]
     if len(normalized) != len(set(normalized)):
         raise ValueError(f"delivery suite {field} must not contain duplicates")
     return normalized
+
+
+def _validate_model_artifact(model: dict[str, Any], *, scenario_id: str) -> None:
+    model_id = _require_non_empty_string(model.get("repo_id"), field=f"{scenario_id}.model_artifact.repo_id")
+    if "/" not in model_id:
+        raise ValueError(f"{scenario_id}: model repo_id must be a namespaced repository ID")
+    revision = _require_non_empty_string(
+        model.get("revision"), field=f"{scenario_id}.model_artifact.revision"
+    )
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ValueError(f"{scenario_id}: model revision must be a full 40-character commit SHA")
+    for field in ("tokenizer_revision", "processor_revision"):
+        value = model.get(field)
+        if value is not None and not re.fullmatch(r"[0-9a-f]{40}", str(value)):
+            raise ValueError(f"{scenario_id}: {field} must be null or a full commit SHA")
+    deployment_tier = _require_non_empty_string(
+        model.get("deployment_tier"), field=f"{scenario_id}.model_artifact.deployment_tier"
+    )
+    if deployment_tier not in VALID_DEPLOYMENT_TIERS:
+        raise ValueError(f"{scenario_id}: unsupported deployment tier {deployment_tier!r}")
+    if deployment_tier == "customer_multinode_extension":
+        raise ValueError(f"{scenario_id}: customer multi-node models cannot be main acceptance targets")
+    status = _require_non_empty_string(
+        model.get("artifact_status"), field=f"{scenario_id}.model_artifact.artifact_status"
+    )
+    if status not in PINNED_ARTIFACT_STATUSES:
+        raise ValueError(f"{scenario_id}: main target artifact must be pinned")
+    runtime = model.get("runtime_profile")
+    if not isinstance(runtime, dict):
+        raise ValueError(f"{scenario_id}: runtime_profile must be an object")
+    for field in ("dtype", "tensor_parallel_size", "data_parallel_size", "max_model_len"):
+        if field not in runtime:
+            raise ValueError(f"{scenario_id}: runtime_profile is missing {field}")
+    _require_non_empty_string(model.get("chat_template_source"), field=f"{scenario_id}.model_artifact.chat_template_source")
+
+
+def _validate_acceptance_policy(policy: object) -> None:
+    if not isinstance(policy, dict):
+        raise ValueError("delivery suite acceptance_policy must be an object")
+    design = policy.get("experimental_design")
+    portfolio = policy.get("portfolio_gate")
+    baselines = policy.get("causal_baselines")
+    guardrails = policy.get("global_guardrails")
+    if not all(isinstance(item, dict) for item in (design, portfolio, baselines, guardrails)):
+        raise ValueError("acceptance policy sections must be objects")
+    if int(design.get("paired_blocks") or 0) < 5:
+        raise ValueError("formal acceptance requires at least five paired restart blocks")
+    if int(design.get("bootstrap_resamples") or 0) < 1000:
+        raise ValueError("formal acceptance requires at least 1000 bootstrap resamples")
+    required_baselines = {"upstream_stock", "hust_feature_off", "hust_feature_on", "minus_one_ablation"}
+    if set(baselines) != required_baselines:
+        raise ValueError("causal_baselines must define stock, feature-off, feature-on and minus-one ablation")
+    mandatory = set(
+        _require_string_list(
+            portfolio.get("mandatory_primary_pass_scenarios"),
+            field="acceptance_policy.portfolio_gate.mandatory_primary_pass_scenarios",
+        )
+    )
+    if not mandatory <= REQUIRED_APPLICATION_SCENARIO_IDS:
+        raise ValueError("portfolio mandatory scenarios must be application scenarios")
+    minimum = int(portfolio.get("minimum_primary_pass_count") or 0)
+    if minimum < len(mandatory) or minimum > len(REQUIRED_APPLICATION_SCENARIO_IDS):
+        raise ValueError("portfolio minimum_primary_pass_count is inconsistent")
+    if float(guardrails.get("maximum_secondary_regression_percent") or 0) <= 0:
+        raise ValueError("global guardrail regression allowance must be positive")
 
 
 def validate_delivery_suite_registry(payload: dict[str, Any]) -> None:
@@ -73,75 +173,87 @@ def validate_delivery_suite_registry(payload: dict[str, Any]) -> None:
         raise ValueError("delivery suite workload descriptor schema version mismatch")
     if academic_contract.get("family_generator_version") != "family-generator/v1":
         raise ValueError("delivery suite family generator version mismatch")
+
+    _validate_acceptance_policy(payload.get("acceptance_policy"))
+
+    assets = payload.get("evaluation_assets")
+    if not isinstance(assets, list) or not assets:
+        raise ValueError("delivery suite evaluation_assets must be a non-empty array")
+    asset_ids: set[str] = set()
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise ValueError("evaluation asset entries must be objects")
+        asset_id = _require_non_empty_string(asset.get("asset_id"), field="evaluation_asset.asset_id")
+        if asset_id in asset_ids:
+            raise ValueError(f"duplicate evaluation asset: {asset_id}")
+        if asset.get("asset_type") not in VALID_ASSET_TYPES:
+            raise ValueError(f"{asset_id}: unsupported asset_type")
+        _require_non_empty_string(asset.get("authority_url"), field=f"{asset_id}.authority_url")
+        asset_ids.add(asset_id)
+
+    capability_targets = payload.get("engine_capability_targets")
+    if not isinstance(capability_targets, list):
+        raise ValueError("engine_capability_targets must be an array")
+    capability_ids = {
+        _require_non_empty_string(item.get("capability_id"), field="capability_id")
+        for item in capability_targets
+        if isinstance(item, dict)
+    }
+    if capability_ids != REQUIRED_CAPABILITY_TARGET_IDS:
+        missing = sorted(REQUIRED_CAPABILITY_TARGET_IDS - capability_ids)
+        extra = sorted(capability_ids - REQUIRED_CAPABILITY_TARGET_IDS)
+        raise ValueError(f"engine capability coverage mismatch; missing={missing}, extra={extra}")
+
     entries = payload.get("entries")
     if not isinstance(entries, list):
         raise ValueError("delivery suite entries must be an array")
-
-    workload_ids: list[str] = []
-    benchmark_ids: list[str] = []
+    scenario_ids: list[str] = []
     for entry in entries:
         if not isinstance(entry, dict):
             raise ValueError("delivery suite entries must be objects")
-        workload_id = _require_non_empty_string(
-            entry.get("workload_id"), field="workload_id"
+        scenario_id = _require_non_empty_string(
+            entry.get("application_scenario_id"), field="application_scenario_id"
         )
-        benchmark = entry.get("benchmark")
-        model = entry.get("model")
-        if not isinstance(benchmark, dict) or not isinstance(model, dict):
-            raise ValueError(f"{workload_id}: benchmark and model must be objects")
-        benchmark_id = _require_non_empty_string(
-            benchmark.get("id"), field=f"{workload_id}.benchmark.id"
+        _require_string_list(entry.get("workload_family_ids"), field=f"{scenario_id}.workload_family_ids")
+        public_asset_ids = _require_string_list(
+            entry.get("public_asset_ids"), field=f"{scenario_id}.public_asset_ids"
         )
-        _require_string_list(
-            entry.get("workload_family_ids"),
-            field=f"{workload_id}.workload_family_ids",
+        if not set(public_asset_ids) <= asset_ids:
+            raise ValueError(f"{scenario_id}: unknown public asset ID")
+        enterprise_case_ids = _require_string_list(
+            entry.get("enterprise_case_ids"),
+            field=f"{scenario_id}.enterprise_case_ids",
+            allow_empty=True,
         )
-        _require_non_empty_string(
-            benchmark.get("authority_url"),
-            field=f"{workload_id}.benchmark.authority_url",
+        del enterprise_case_ids
+        entry_capabilities = _require_string_list(
+            entry.get("engine_capability_ids"), field=f"{scenario_id}.engine_capability_ids"
         )
-        _require_non_empty_string(model.get("id"), field=f"{workload_id}.model.id")
-        deployment_tier = _require_non_empty_string(
-            model.get("deployment_tier"),
-            field=f"{workload_id}.model.deployment_tier",
-        )
-        if deployment_tier not in VALID_DEPLOYMENT_TIERS:
-            raise ValueError(
-                f"{workload_id}: unsupported deployment tier {deployment_tier!r}"
-            )
-        if deployment_tier == "customer_multinode_extension":
-            raise ValueError(
-                f"{workload_id}: customer multi-node models cannot be fixed acceptance targets"
-            )
-        _require_string_list(
-            entry.get("engine_pressure"), field=f"{workload_id}.engine_pressure"
-        )
-        _require_string_list(
-            entry.get("acceptance_metrics"),
-            field=f"{workload_id}.acceptance_metrics",
-        )
-        enterprise_case_ids = entry.get("enterprise_case_ids")
-        if not isinstance(enterprise_case_ids, list):
-            raise ValueError(f"{workload_id}.enterprise_case_ids must be an array")
-        for case_id in enterprise_case_ids:
-            _require_non_empty_string(
-                case_id, field=f"{workload_id}.enterprise_case_ids"
-            )
-        workload_ids.append(workload_id)
-        benchmark_ids.append(benchmark_id)
+        if not set(entry_capabilities) <= capability_ids:
+            raise ValueError(f"{scenario_id}: unknown engine capability ID")
+        model = entry.get("model_artifact")
+        if not isinstance(model, dict):
+            raise ValueError(f"{scenario_id}: model_artifact must be an object")
+        _validate_model_artifact(model, scenario_id=scenario_id)
+        primary = entry.get("primary_endpoint")
+        quality = entry.get("quality_gate")
+        if not isinstance(primary, dict) or not isinstance(quality, dict):
+            raise ValueError(f"{scenario_id}: primary_endpoint and quality_gate must be objects")
+        _require_non_empty_string(primary.get("metric"), field=f"{scenario_id}.primary_endpoint.metric")
+        if float(primary.get("minimum_effect_percent") or 0) <= 0:
+            raise ValueError(f"{scenario_id}: primary endpoint effect must be positive")
+        margin = quality.get("non_inferiority_margin")
+        if margin is None or float(margin) < 0:
+            raise ValueError(f"{scenario_id}: quality margin must be non-negative")
+        scenario_ids.append(scenario_id)
 
-    if len(workload_ids) != len(set(workload_ids)):
-        raise ValueError("delivery suite workload_id values must be unique")
-    if set(workload_ids) != REQUIRED_WORKLOAD_IDS:
-        missing = sorted(REQUIRED_WORKLOAD_IDS.difference(workload_ids))
-        extra = sorted(set(workload_ids).difference(REQUIRED_WORKLOAD_IDS))
+    if len(scenario_ids) != len(set(scenario_ids)):
+        raise ValueError("delivery suite application_scenario_id values must be unique")
+    if set(scenario_ids) != REQUIRED_APPLICATION_SCENARIO_IDS:
+        missing = sorted(REQUIRED_APPLICATION_SCENARIO_IDS.difference(scenario_ids))
+        extra = sorted(set(scenario_ids).difference(REQUIRED_APPLICATION_SCENARIO_IDS))
         raise ValueError(
-            f"delivery suite must cover exactly nine workloads; missing={missing}, extra={extra}"
-        )
-    if len(benchmark_ids) != len(set(benchmark_ids)):
-        raise ValueError(
-            "each workload must own one distinct fixed benchmark; arrival traces and "
-            "enterprise cases are workload inputs, not additional benchmark identities"
+            f"delivery suite must cover exactly nine application scenarios; missing={missing}, extra={extra}"
         )
 
     extensions = payload.get("customer_multinode_extensions")
@@ -150,7 +262,7 @@ def validate_delivery_suite_registry(payload: dict[str, Any]) -> None:
     for extension in extensions:
         if not isinstance(extension, dict):
             raise ValueError("customer multi-node extensions must be objects")
-        _require_non_empty_string(extension.get("model_id"), field="extension.model_id")
+        _require_non_empty_string(extension.get("model_class"), field="extension.model_class")
         if extension.get("deployment_tier") != "customer_multinode_extension":
             raise ValueError("customer extension must use customer_multinode_extension tier")
 
@@ -168,16 +280,20 @@ def load_delivery_suite_registry() -> dict[str, Any]:
 def delivery_suite_entries() -> tuple[DeliverySuiteEntry, ...]:
     records: list[DeliverySuiteEntry] = []
     for entry in load_delivery_suite_registry()["entries"]:
+        model = entry["model_artifact"]
+        primary = entry["primary_endpoint"]
         records.append(
             DeliverySuiteEntry(
-                workload_id=entry["workload_id"],
+                workload_id=entry["application_scenario_id"],
                 workload_family_ids=tuple(entry["workload_family_ids"]),
-                benchmark_id=entry["benchmark"]["id"],
-                model_id=entry["model"]["id"],
-                deployment_tier=entry["model"]["deployment_tier"],
+                public_asset_ids=tuple(entry["public_asset_ids"]),
+                model_id=model["repo_id"],
+                model_revision=model["revision"],
+                deployment_tier=model["deployment_tier"],
                 enterprise_case_ids=tuple(entry["enterprise_case_ids"]),
-                engine_pressure=tuple(entry["engine_pressure"]),
-                acceptance_metrics=tuple(entry["acceptance_metrics"]),
+                engine_capability_ids=tuple(entry["engine_capability_ids"]),
+                primary_metric=primary["metric"],
+                minimum_effect_percent=float(primary["minimum_effect_percent"]),
             )
         )
     return tuple(records)
@@ -185,14 +301,14 @@ def delivery_suite_entries() -> tuple[DeliverySuiteEntry, ...]:
 
 def resolve_delivery_workload(workload_id: str) -> dict[str, Any]:
     for entry in load_delivery_suite_registry()["entries"]:
-        if entry["workload_id"] == workload_id:
+        if entry["application_scenario_id"] == workload_id:
             return dict(entry)
     raise ValueError(f"unknown delivery workload: {workload_id}")
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Inspect the fixed delivery suite")
-    parser.add_argument("--workload-id", choices=sorted(REQUIRED_WORKLOAD_IDS))
+    parser = argparse.ArgumentParser(description="Inspect the proposed future delivery suite")
+    parser.add_argument("--workload-id", choices=sorted(REQUIRED_APPLICATION_SCENARIO_IDS))
     parser.add_argument("--output", type=Path)
     args = parser.parse_args(argv)
     payload = (

--- a/src/vllm_hust_benchmark/delivery_suite.py
+++ b/src/vllm_hust_benchmark/delivery_suite.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "delivery-suite-registry/v1"
+REQUIRED_WORKLOAD_IDS = frozenset(
+    {
+        "general_qa",
+        "code",
+        "reasoning",
+        "multimodal",
+        "kv_reuse",
+        "structured_output",
+        "long_context",
+        "agent",
+        "ai4science",
+    }
+)
+VALID_DEPLOYMENT_TIERS = frozenset(
+    {"single_node_main", "single_node_conditional", "customer_multinode_extension"}
+)
+
+
+@dataclass(frozen=True)
+class DeliverySuiteEntry:
+    workload_id: str
+    workload_family_ids: tuple[str, ...]
+    benchmark_id: str
+    model_id: str
+    deployment_tier: str
+    enterprise_case_ids: tuple[str, ...]
+    engine_pressure: tuple[str, ...]
+    acceptance_metrics: tuple[str, ...]
+
+
+def _registry_resource() -> Any:
+    return resources.files("vllm_hust_benchmark.data").joinpath(
+        "delivery_suite_registry.json"
+    )
+
+
+def _require_non_empty_string(value: object, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"delivery suite {field} must be a non-empty string")
+    return normalized
+
+
+def _require_string_list(value: object, *, field: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"delivery suite {field} must be a non-empty array")
+    normalized = [_require_non_empty_string(item, field=field) for item in value]
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"delivery suite {field} must not contain duplicates")
+    return normalized
+
+
+def validate_delivery_suite_registry(payload: dict[str, Any]) -> None:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"delivery suite schema_version must be {SCHEMA_VERSION!r}")
+    _require_non_empty_string(payload.get("registry_version"), field="registry_version")
+    academic_contract = payload.get("academic_workload_contract")
+    if not isinstance(academic_contract, dict):
+        raise ValueError("delivery suite academic_workload_contract must be an object")
+    if academic_contract.get("descriptor_schema_version") != "workload-descriptor/v1":
+        raise ValueError("delivery suite workload descriptor schema version mismatch")
+    if academic_contract.get("family_generator_version") != "family-generator/v1":
+        raise ValueError("delivery suite family generator version mismatch")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("delivery suite entries must be an array")
+
+    workload_ids: list[str] = []
+    benchmark_ids: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("delivery suite entries must be objects")
+        workload_id = _require_non_empty_string(
+            entry.get("workload_id"), field="workload_id"
+        )
+        benchmark = entry.get("benchmark")
+        model = entry.get("model")
+        if not isinstance(benchmark, dict) or not isinstance(model, dict):
+            raise ValueError(f"{workload_id}: benchmark and model must be objects")
+        benchmark_id = _require_non_empty_string(
+            benchmark.get("id"), field=f"{workload_id}.benchmark.id"
+        )
+        _require_string_list(
+            entry.get("workload_family_ids"),
+            field=f"{workload_id}.workload_family_ids",
+        )
+        _require_non_empty_string(
+            benchmark.get("authority_url"),
+            field=f"{workload_id}.benchmark.authority_url",
+        )
+        _require_non_empty_string(model.get("id"), field=f"{workload_id}.model.id")
+        deployment_tier = _require_non_empty_string(
+            model.get("deployment_tier"),
+            field=f"{workload_id}.model.deployment_tier",
+        )
+        if deployment_tier not in VALID_DEPLOYMENT_TIERS:
+            raise ValueError(
+                f"{workload_id}: unsupported deployment tier {deployment_tier!r}"
+            )
+        if deployment_tier == "customer_multinode_extension":
+            raise ValueError(
+                f"{workload_id}: customer multi-node models cannot be fixed acceptance targets"
+            )
+        _require_string_list(
+            entry.get("engine_pressure"), field=f"{workload_id}.engine_pressure"
+        )
+        _require_string_list(
+            entry.get("acceptance_metrics"),
+            field=f"{workload_id}.acceptance_metrics",
+        )
+        enterprise_case_ids = entry.get("enterprise_case_ids")
+        if not isinstance(enterprise_case_ids, list):
+            raise ValueError(f"{workload_id}.enterprise_case_ids must be an array")
+        for case_id in enterprise_case_ids:
+            _require_non_empty_string(
+                case_id, field=f"{workload_id}.enterprise_case_ids"
+            )
+        workload_ids.append(workload_id)
+        benchmark_ids.append(benchmark_id)
+
+    if len(workload_ids) != len(set(workload_ids)):
+        raise ValueError("delivery suite workload_id values must be unique")
+    if set(workload_ids) != REQUIRED_WORKLOAD_IDS:
+        missing = sorted(REQUIRED_WORKLOAD_IDS.difference(workload_ids))
+        extra = sorted(set(workload_ids).difference(REQUIRED_WORKLOAD_IDS))
+        raise ValueError(
+            f"delivery suite must cover exactly nine workloads; missing={missing}, extra={extra}"
+        )
+    if len(benchmark_ids) != len(set(benchmark_ids)):
+        raise ValueError(
+            "each workload must own one distinct fixed benchmark; arrival traces and "
+            "enterprise cases are workload inputs, not additional benchmark identities"
+        )
+
+    extensions = payload.get("customer_multinode_extensions")
+    if not isinstance(extensions, list) or not extensions:
+        raise ValueError("customer_multinode_extensions must be a non-empty array")
+    for extension in extensions:
+        if not isinstance(extension, dict):
+            raise ValueError("customer multi-node extensions must be objects")
+        _require_non_empty_string(extension.get("model_id"), field="extension.model_id")
+        if extension.get("deployment_tier") != "customer_multinode_extension":
+            raise ValueError("customer extension must use customer_multinode_extension tier")
+
+
+@lru_cache(maxsize=1)
+def load_delivery_suite_registry() -> dict[str, Any]:
+    with _registry_resource().open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("delivery suite registry must be a JSON object")
+    validate_delivery_suite_registry(payload)
+    return payload
+
+
+def delivery_suite_entries() -> tuple[DeliverySuiteEntry, ...]:
+    records: list[DeliverySuiteEntry] = []
+    for entry in load_delivery_suite_registry()["entries"]:
+        records.append(
+            DeliverySuiteEntry(
+                workload_id=entry["workload_id"],
+                workload_family_ids=tuple(entry["workload_family_ids"]),
+                benchmark_id=entry["benchmark"]["id"],
+                model_id=entry["model"]["id"],
+                deployment_tier=entry["model"]["deployment_tier"],
+                enterprise_case_ids=tuple(entry["enterprise_case_ids"]),
+                engine_pressure=tuple(entry["engine_pressure"]),
+                acceptance_metrics=tuple(entry["acceptance_metrics"]),
+            )
+        )
+    return tuple(records)
+
+
+def resolve_delivery_workload(workload_id: str) -> dict[str, Any]:
+    for entry in load_delivery_suite_registry()["entries"]:
+        if entry["workload_id"] == workload_id:
+            return dict(entry)
+    raise ValueError(f"unknown delivery workload: {workload_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Inspect the fixed delivery suite")
+    parser.add_argument("--workload-id", choices=sorted(REQUIRED_WORKLOAD_IDS))
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    payload = (
+        resolve_delivery_workload(args.workload_id)
+        if args.workload_id
+        else load_delivery_suite_registry()
+    )
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vllm_hust_benchmark/enterprise_replay.py
+++ b/src/vllm_hust_benchmark/enterprise_replay.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import heapq
+import json
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "enterprise-dataset-registry/v1"
+AUTHORIZATION_SCHEMA_VERSION = "enterprise-data-authorization/v1"
+DATA_ROOT_ENV = "VLLM_HUST_ENTERPRISE_DATA_ROOT"
+AUTHORIZATION_FILE_ENV = "VLLM_HUST_ENTERPRISE_AUTHORIZATION_FILE"
+DEFAULT_AUTHORIZATION_FILENAME = ".vllm-hust-enterprise-authorized.json"
+SAMPLER_VERSION = "enterprise-replay-sampler/v1"
+
+
+class EnterpriseReplayError(RuntimeError):
+    """Raised when enterprise replay cannot proceed without weakening a gate."""
+
+
+@dataclass(frozen=True)
+class EnterpriseReplayRequest:
+    case_id: str
+    dataset_id: str
+    request_id: str
+    source_index: int
+    source_model_name: str
+    request_type: str
+    request_body: dict[str, Any]
+    workload_family_id: str
+
+    def to_openai_payload(self, *, served_model: str) -> dict[str, Any]:
+        payload = dict(self.request_body)
+        payload["model"] = served_model
+        return payload
+
+    def redacted_record(self, *, served_model: str) -> dict[str, Any]:
+        payload = self.to_openai_payload(served_model=served_model)
+        canonical = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        prompt_text = _request_prompt_text(payload)
+        return {
+            "schema_version": "enterprise-replay-redacted/v1",
+            "case_id": self.case_id,
+            "dataset_id": self.dataset_id,
+            "request_id": self.request_id,
+            "source_index": self.source_index,
+            "source_model_name": self.source_model_name,
+            "served_model": served_model,
+            "request_type": self.request_type,
+            "workload_family_id": self.workload_family_id,
+            "request_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+            "prompt_chars": len(prompt_text),
+            "prompt_tokens_est": _fallback_token_count(prompt_text),
+            "max_output_tokens": _request_output_len(payload),
+            "message_count": len(payload.get("messages") or []),
+            "stream": bool(payload.get("stream", False)),
+            "tool_count": len(payload.get("tools") or []),
+            "has_response_format": isinstance(payload.get("response_format"), dict),
+        }
+
+
+def _registry_resource() -> Any:
+    return resources.files("vllm_hust_benchmark.data").joinpath(
+        "enterprise_dataset_registry.json"
+    )
+
+
+def validate_enterprise_dataset_registry(payload: Mapping[str, Any]) -> None:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"enterprise registry schema_version must be {SCHEMA_VERSION!r}")
+    datasets = payload.get("datasets")
+    cases = payload.get("cases")
+    if not isinstance(datasets, list) or not datasets:
+        raise ValueError("enterprise registry datasets must be a non-empty array")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("enterprise registry cases must be a non-empty array")
+
+    dataset_ids: set[str] = set()
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            raise ValueError("enterprise registry dataset entries must be objects")
+        dataset_id = str(dataset.get("dataset_id") or "").strip()
+        relative_path = str(dataset.get("relative_path") or "").strip()
+        if not dataset_id or dataset_id in dataset_ids:
+            raise ValueError(f"invalid or duplicate enterprise dataset_id: {dataset_id!r}")
+        if not relative_path or Path(relative_path).is_absolute() or ".." in Path(relative_path).parts:
+            raise ValueError(f"{dataset_id}: relative_path must stay below the explicit data root")
+        if "__MACOSX" in Path(relative_path).parts or Path(relative_path).name.startswith("._"):
+            raise ValueError(f"{dataset_id}: macOS metadata files are not replay assets")
+        if dataset.get("source_format") not in {
+            "wrapped_openai_request_jsonl",
+            "direct_messages_jsonl",
+        }:
+            raise ValueError(f"{dataset_id}: unsupported source_format")
+        if int(dataset.get("record_count") or 0) < 1:
+            raise ValueError(f"{dataset_id}: record_count must be positive")
+        if not re.fullmatch(r"[0-9a-f]{64}", str(dataset.get("sha256") or "")):
+            raise ValueError(f"{dataset_id}: sha256 must be lowercase hex")
+        dataset_ids.add(dataset_id)
+
+    case_ids: set[str] = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            raise ValueError("enterprise registry case entries must be objects")
+        case_id = str(case.get("case_id") or "").strip()
+        if not case_id or case_id in case_ids:
+            raise ValueError(f"invalid or duplicate enterprise case_id: {case_id!r}")
+        if case.get("dataset_id") not in dataset_ids:
+            raise ValueError(f"{case_id}: unknown dataset_id {case.get('dataset_id')!r}")
+        case_ids.add(case_id)
+
+
+@lru_cache(maxsize=1)
+def load_enterprise_dataset_registry() -> dict[str, Any]:
+    with _registry_resource().open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("enterprise registry must be a JSON object")
+    validate_enterprise_dataset_registry(payload)
+    return payload
+
+
+def enterprise_dataset_rows() -> list[dict[str, Any]]:
+    return [dict(row) for row in load_enterprise_dataset_registry()["datasets"]]
+
+
+def enterprise_case_rows() -> list[dict[str, Any]]:
+    return [dict(row) for row in load_enterprise_dataset_registry()["cases"]]
+
+
+def resolve_enterprise_data_root(root: str | os.PathLike[str] | None = None) -> Path:
+    raw = str(root) if root is not None else os.environ.get(DATA_ROOT_ENV)
+    if not raw:
+        raise EnterpriseReplayError(
+            f"enterprise data root is required; pass --data-root or set {DATA_ROOT_ENV}"
+        )
+    resolved = Path(raw).expanduser().resolve()
+    if not resolved.is_dir():
+        raise EnterpriseReplayError(f"enterprise data root is not a directory: {resolved}")
+    return resolved
+
+
+def _resolve_authorization_file(
+    data_root: Path, authorization_file: str | os.PathLike[str] | None
+) -> Path:
+    raw = (
+        str(authorization_file)
+        if authorization_file is not None
+        else os.environ.get(AUTHORIZATION_FILE_ENV)
+    )
+    return Path(raw).expanduser().resolve() if raw else data_root / DEFAULT_AUTHORIZATION_FILENAME
+
+
+def _require_dataset_authorization(
+    *,
+    dataset_id: str,
+    data_root: Path,
+    authorization_file: str | os.PathLike[str] | None,
+) -> None:
+    path = _resolve_authorization_file(data_root, authorization_file)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EnterpriseReplayError(
+            f"valid enterprise authorization file is required: {path}"
+        ) from exc
+    if payload.get("schema_version") != AUTHORIZATION_SCHEMA_VERSION:
+        raise EnterpriseReplayError("enterprise authorization schema version mismatch")
+    authorized = payload.get("authorized_dataset_ids")
+    if not isinstance(authorized, list) or dataset_id not in authorized:
+        raise EnterpriseReplayError(f"dataset is not authorized for replay: {dataset_id}")
+
+
+def _find_registry_row(
+    registry: Mapping[str, Any], *, key: str, value: str, section: str
+) -> dict[str, Any]:
+    for row in registry[section]:
+        if row.get(key) == value:
+            return dict(row)
+    raise EnterpriseReplayError(f"unknown enterprise {key}: {value}")
+
+
+def _asset_path(data_root: Path, relative_path: str) -> Path:
+    candidate = (data_root / relative_path).resolve()
+    if not candidate.is_relative_to(data_root):
+        raise EnterpriseReplayError("enterprise asset escaped the explicit data root")
+    return candidate
+
+
+def verify_enterprise_dataset_asset(dataset: Mapping[str, Any], *, data_root: Path) -> Path:
+    path = _asset_path(data_root, str(dataset["relative_path"]))
+    if not path.is_file():
+        raise EnterpriseReplayError(f"enterprise dataset asset is missing: {path}")
+    digest = hashlib.sha256()
+    record_count = 0
+    with path.open("rb") as handle:
+        for line in handle:
+            digest.update(line)
+            if line.strip():
+                record_count += 1
+    if digest.hexdigest() != dataset["sha256"]:
+        raise EnterpriseReplayError(f"enterprise dataset checksum mismatch: {dataset['dataset_id']}")
+    if record_count != int(dataset["record_count"]):
+        raise EnterpriseReplayError(
+            f"enterprise dataset record count mismatch: expected {dataset['record_count']}, got {record_count}"
+        )
+    return path
+
+
+def _render_message_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Mapping):
+        return str(content.get("text") or "")
+    if isinstance(content, list):
+        return "\n".join(filter(None, (_render_message_content(item) for item in content)))
+    return str(content or "")
+
+
+def _request_prompt_text(request_body: Mapping[str, Any]) -> str:
+    messages = request_body.get("messages") or []
+    if messages:
+        return "\n\n".join(
+            f"{str(message.get('role') or '').strip()}: {_render_message_content(message.get('content'))}".strip()
+            for message in messages
+            if isinstance(message, Mapping)
+        )
+    return str(request_body.get("prompt") or "")
+
+
+def _fallback_token_count(text: str) -> int:
+    return len(re.findall(r"[\u4e00-\u9fff]|[A-Za-z0-9_]+|[^\w\s]", text, re.UNICODE))
+
+
+def _request_output_len(request_body: Mapping[str, Any]) -> int:
+    raw = request_body.get("max_tokens", request_body.get("max_completion_tokens", 0))
+    try:
+        return max(0, int(raw or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _validate_request_body(request_body: Mapping[str, Any]) -> None:
+    messages = request_body.get("messages")
+    prompt = request_body.get("prompt")
+    if not isinstance(messages, list) and not isinstance(prompt, str):
+        raise EnterpriseReplayError("request must contain messages or prompt")
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict) or not str(message.get("role") or "").strip():
+                raise EnterpriseReplayError("request messages must contain a role")
+            content = message.get("content")
+            if not isinstance(content, (str, list, dict)):
+                raise EnterpriseReplayError("request message content has an unsupported shape")
+    if "stream" in request_body and not isinstance(request_body["stream"], bool):
+        raise EnterpriseReplayError("request stream field must be boolean")
+    if "tools" in request_body and not isinstance(request_body["tools"], list):
+        raise EnterpriseReplayError("request tools field must be an array")
+    if "response_format" in request_body and not isinstance(request_body["response_format"], dict):
+        raise EnterpriseReplayError("request response_format field must be an object")
+
+
+def _parse_source_row(
+    row: Mapping[str, Any], *, source_format: str, fallback_source_model: str
+) -> tuple[str, str, dict[str, Any]]:
+    if source_format == "wrapped_openai_request_jsonl":
+        raw_body = row.get("request_body")
+        if isinstance(raw_body, str):
+            try:
+                body = json.loads(raw_body)
+            except json.JSONDecodeError as exc:
+                raise EnterpriseReplayError("wrapped request_body is not valid JSON") from exc
+        elif isinstance(raw_body, dict):
+            body = dict(raw_body)
+        else:
+            raise EnterpriseReplayError("wrapped request_body must be an object or JSON string")
+        source_model = str(row.get("model_name") or body.get("model") or fallback_source_model)
+        request_type = str(row.get("request_type") or "ChatCompletion")
+    else:
+        allowed = {
+            "messages", "prompt", "stream", "tools", "tool_choice", "response_format",
+            "temperature", "top_p", "max_tokens", "max_completion_tokens", "stop", "seed", "n"
+        }
+        body = {key: row[key] for key in allowed if key in row}
+        if not isinstance(body.get("messages"), list) and isinstance(row.get("prompt"), str):
+            body["messages"] = [{"role": "user", "content": row["prompt"]}]
+        source_model = str(row.get("model_name") or row.get("model") or fallback_source_model)
+        request_type = str(row.get("request_type") or "ChatCompletion")
+    if not isinstance(body, dict):
+        raise EnterpriseReplayError("request body must decode to an object")
+    _validate_request_body(body)
+    return source_model, request_type, body
+
+
+def _combined_request_text(request_body: Mapping[str, Any]) -> str:
+    return _request_prompt_text(request_body).lower()
+
+
+def _matches_filter(filter_id: str | None, request_body: Mapping[str, Any]) -> bool:
+    if filter_id is None:
+        return True
+    messages = request_body.get("messages") or []
+    text = _combined_request_text(request_body)
+    if filter_id == "normal_chat_support_multi_turn":
+        return len(messages) >= 4 and "user simulation guidelines" in text and "support representative" in text
+    if filter_id == "normal_chat_single_turn_general":
+        excluded = (
+            "act as an impartial judge", "reference answer", "output only one valid json object",
+            "expert document analyzer", "collection order analysis expert", "trajectory-reading assistant"
+        )
+        return len(messages) == 1 and not any(phrase in text for phrase in excluded)
+    if filter_id == "json_structured_extraction":
+        return any(
+            phrase in text
+            for phrase in (
+                "extract structured", "extract information", "analyze the chat history",
+                "named entity recognition", "relation extraction", "canonical product search query"
+            )
+        )
+    if filter_id == "json_planning_orchestration":
+        return any(
+            phrase in text
+            for phrase in (
+                "orchestration planner", "tool schemas", "tool-powered analysis",
+                "return only valid json that defines depth iteration goals"
+            )
+        )
+    if filter_id == "code_reward_hack_judge":
+        return "strict code-integrity reviewer" in text or "reward hack" in text
+    if filter_id == "code_answer_correctness_judge":
+        return "judging answer correctness" in text or "answer correctness" in text
+    raise EnterpriseReplayError(f"unknown enterprise replay filter: {filter_id}")
+
+
+def _sample_score(*, dataset_id: str, case_id: str, seed: int, source_index: int) -> int:
+    material = f"{SAMPLER_VERSION}\0{dataset_id}\0{case_id}\0{seed}\0{source_index}"
+    return int(hashlib.sha256(material.encode("utf-8")).hexdigest(), 16)
+
+
+def load_enterprise_replay_requests(
+    case_id: str,
+    *,
+    data_root: str | os.PathLike[str] | None,
+    authorization_file: str | os.PathLike[str] | None = None,
+    limit: int = 100,
+    seed: int = 0,
+    registry: Mapping[str, Any] | None = None,
+) -> list[EnterpriseReplayRequest]:
+    if limit < 1:
+        raise ValueError("enterprise replay limit must be positive")
+    active_registry = dict(registry or load_enterprise_dataset_registry())
+    validate_enterprise_dataset_registry(active_registry)
+    case = _find_registry_row(active_registry, key="case_id", value=case_id, section="cases")
+    dataset = _find_registry_row(
+        active_registry, key="dataset_id", value=case["dataset_id"], section="datasets"
+    )
+    root = resolve_enterprise_data_root(data_root)
+    _require_dataset_authorization(
+        dataset_id=dataset["dataset_id"],
+        data_root=root,
+        authorization_file=authorization_file,
+    )
+    path = verify_enterprise_dataset_asset(dataset, data_root=root)
+
+    heap: list[tuple[int, int, EnterpriseReplayRequest]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for source_index, line in enumerate(handle):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise EnterpriseReplayError(
+                    f"invalid JSONL record at source index {source_index}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise EnterpriseReplayError("enterprise JSONL records must be objects")
+            source_model, request_type, request_body = _parse_source_row(
+                row,
+                source_format=dataset["source_format"],
+                fallback_source_model=dataset["source_model_name"],
+            )
+            if not _matches_filter(case.get("filter_id"), request_body):
+                continue
+            raw_request_id = row.get("request_id") or row.get("id") or source_index
+            source_identity = f"{dataset['dataset_id']}\0{raw_request_id}\0{source_index}"
+            request_id = (
+                f"{dataset['dataset_id']}::"
+                f"{hashlib.sha256(source_identity.encode('utf-8')).hexdigest()[:24]}"
+            )
+            request = EnterpriseReplayRequest(
+                case_id=case_id,
+                dataset_id=dataset["dataset_id"],
+                request_id=request_id,
+                source_index=source_index,
+                source_model_name=source_model,
+                request_type=request_type,
+                request_body=request_body,
+                workload_family_id=dataset["workload_family_id"],
+            )
+            score = _sample_score(
+                dataset_id=dataset["dataset_id"],
+                case_id=case_id,
+                seed=seed,
+                source_index=source_index,
+            )
+            item = (-score, -source_index, request)
+            if len(heap) < limit:
+                heapq.heappush(heap, item)
+            elif score < -heap[0][0]:
+                heapq.heapreplace(heap, item)
+
+    selected = [(-neg_score, -neg_index, request) for neg_score, neg_index, request in heap]
+    selected.sort(key=lambda item: (item[0], item[1]))
+    return [request for _, _, request in selected]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate and sample enterprise replay data")
+    parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument("--case-id")
+    parser.add_argument("--data-root")
+    parser.add_argument("--authorization-file")
+    parser.add_argument("--served-model", default="Qwen/Qwen3-32B")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    if args.list_cases:
+        payload: Any = enterprise_case_rows()
+    else:
+        if not args.case_id:
+            parser.error("--case-id is required unless --list-cases is used")
+        requests = load_enterprise_replay_requests(
+            args.case_id,
+            data_root=args.data_root,
+            authorization_file=args.authorization_file,
+            limit=args.limit,
+            seed=args.seed,
+        )
+        payload = [
+            request.redacted_record(served_model=args.served_model) for request in requests
+        ]
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vllm_hust_benchmark/enterprise_replay.py
+++ b/src/vllm_hust_benchmark/enterprise_replay.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import heapq
 import json
 import os
 import re
@@ -35,14 +34,47 @@ class EnterpriseReplayRequest:
     request_type: str
     request_body: dict[str, Any]
     workload_family_id: str
+    source_group_id: str | None
+    source_session_id: str | None
+    source_conversation_id: str | None
+    source_created_at_ms: int | None
+    source_prompt_hash: str | None
+    source_prompt_tokens_est: int | None
+    source_shape_metadata: dict[str, Any]
 
-    def to_openai_payload(self, *, served_model: str) -> dict[str, Any]:
+    def to_openai_payload(
+        self,
+        *,
+        served_model: str,
+        generation_overrides: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
         payload = dict(self.request_body)
         payload["model"] = served_model
+        for key, value in dict(generation_overrides or {}).items():
+            if key not in {
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "max_completion_tokens",
+                "stop",
+                "seed",
+                "n",
+            }:
+                raise EnterpriseReplayError(
+                    f"unsupported benchmark normalization override: {key}"
+                )
+            payload[key] = value
         return payload
 
-    def redacted_record(self, *, served_model: str) -> dict[str, Any]:
-        payload = self.to_openai_payload(served_model=served_model)
+    def redacted_record(
+        self,
+        *,
+        served_model: str,
+        generation_overrides: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload = self.to_openai_payload(
+            served_model=served_model, generation_overrides=generation_overrides
+        )
         canonical = json.dumps(
             payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
         )
@@ -60,12 +92,50 @@ class EnterpriseReplayRequest:
             "request_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
             "prompt_chars": len(prompt_text),
             "prompt_tokens_est": _fallback_token_count(prompt_text),
+            "source_prompt_tokens_est": self.source_prompt_tokens_est,
             "max_output_tokens": _request_output_len(payload),
             "message_count": len(payload.get("messages") or []),
             "stream": bool(payload.get("stream", False)),
             "tool_count": len(payload.get("tools") or []),
             "has_response_format": isinstance(payload.get("response_format"), dict),
+            "source_group_key_sha256": _optional_identity_hash(self.source_group_id),
+            "source_session_key_sha256": _optional_identity_hash(self.source_session_id),
+            "source_conversation_key_sha256": _optional_identity_hash(
+                self.source_conversation_id
+            ),
+            "source_created_at_ms": self.source_created_at_ms,
+            "source_prompt_hash": self.source_prompt_hash,
+            "source_shape_metadata": dict(self.source_shape_metadata),
         }
+
+
+SAFE_SOURCE_METADATA_FIELDS = frozenset(
+    {
+        "workload_type",
+        "topic",
+        "batch_group_id",
+        "batch_size",
+        "batch_mix_type",
+        "reuse_tier",
+        "target_matched_ratio",
+        "matched_flag",
+        "length_bucket",
+        "output_bucket",
+        "output_tokens_target",
+        "topic_family",
+        "reuse_type",
+        "prefix_strength",
+        "conversation_strength",
+        "request_variation",
+        "timestamp_bucket_ms",
+    }
+)
+
+
+def _optional_identity_hash(value: str | None) -> str | None:
+    if not value:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _registry_resource() -> Any:
@@ -105,6 +175,13 @@ def validate_enterprise_dataset_registry(payload: Mapping[str, Any]) -> None:
             raise ValueError(f"{dataset_id}: record_count must be positive")
         if not re.fullmatch(r"[0-9a-f]{64}", str(dataset.get("sha256") or "")):
             raise ValueError(f"{dataset_id}: sha256 must be lowercase hex")
+        if dataset.get("provenance_class") not in {
+            "enterprise_observed_request",
+            "enterprise_provided_synthetic_or_hybrid",
+        }:
+            raise ValueError(f"{dataset_id}: unsupported provenance_class")
+        if not isinstance(dataset.get("preserved_source_fields"), list):
+            raise ValueError(f"{dataset_id}: preserved_source_fields must be an array")
         dataset_ids.add(dataset_id)
 
     case_ids: set[str] = set()
@@ -116,6 +193,19 @@ def validate_enterprise_dataset_registry(payload: Mapping[str, Any]) -> None:
             raise ValueError(f"invalid or duplicate enterprise case_id: {case_id!r}")
         if case.get("dataset_id") not in dataset_ids:
             raise ValueError(f"{case_id}: unknown dataset_id {case.get('dataset_id')!r}")
+        if case.get("sampling_unit") not in {
+            "request",
+            "group",
+            "session",
+            "conversation",
+        }:
+            raise ValueError(f"{case_id}: unsupported sampling_unit")
+        if case.get("replay_order") not in {
+            "source_order",
+            "timestamp",
+            "group_then_timestamp",
+        }:
+            raise ValueError(f"{case_id}: unsupported replay_order")
         case_ids.add(case_id)
 
 
@@ -271,7 +361,7 @@ def _validate_request_body(request_body: Mapping[str, Any]) -> None:
 
 def _parse_source_row(
     row: Mapping[str, Any], *, source_format: str, fallback_source_model: str
-) -> tuple[str, str, dict[str, Any]]:
+) -> tuple[str, str, dict[str, Any], dict[str, Any]]:
     if source_format == "wrapped_openai_request_jsonl":
         raw_body = row.get("request_body")
         if isinstance(raw_body, str):
@@ -285,6 +375,7 @@ def _parse_source_row(
             raise EnterpriseReplayError("wrapped request_body must be an object or JSON string")
         source_model = str(row.get("model_name") or body.get("model") or fallback_source_model)
         request_type = str(row.get("request_type") or "ChatCompletion")
+        source_metadata: dict[str, Any] = {}
     else:
         allowed = {
             "messages", "prompt", "stream", "tools", "tool_choice", "response_format",
@@ -295,10 +386,18 @@ def _parse_source_row(
             body["messages"] = [{"role": "user", "content": row["prompt"]}]
         source_model = str(row.get("model_name") or row.get("model") or fallback_source_model)
         request_type = str(row.get("request_type") or "ChatCompletion")
+        nested_metadata = row.get("metadata")
+        nested_metadata = nested_metadata if isinstance(nested_metadata, Mapping) else {}
+        combined_metadata = {**nested_metadata, **row}
+        source_metadata = {
+            key: combined_metadata[key]
+            for key in SAFE_SOURCE_METADATA_FIELDS
+            if key in combined_metadata
+        }
     if not isinstance(body, dict):
         raise EnterpriseReplayError("request body must decode to an object")
     _validate_request_body(body)
-    return source_model, request_type, body
+    return source_model, request_type, body, source_metadata
 
 
 def _combined_request_text(request_body: Mapping[str, Any]) -> str:
@@ -346,6 +445,68 @@ def _sample_score(*, dataset_id: str, case_id: str, seed: int, source_index: int
     return int(hashlib.sha256(material.encode("utf-8")).hexdigest(), 16)
 
 
+def _sample_group_score(*, dataset_id: str, case_id: str, seed: int, group_key: str) -> int:
+    material = f"{SAMPLER_VERSION}\0{dataset_id}\0{case_id}\0{seed}\0{group_key}"
+    return int(hashlib.sha256(material.encode("utf-8")).hexdigest(), 16)
+
+
+def _optional_string(value: object) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _optional_integer(value: object) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _sampling_key(request: EnterpriseReplayRequest, sampling_unit: str) -> str:
+    if sampling_unit == "request":
+        return request.request_id
+    candidates = {
+        "group": request.source_group_id,
+        "session": request.source_session_id,
+        "conversation": request.source_conversation_id,
+    }
+    if sampling_unit not in candidates:
+        raise EnterpriseReplayError(f"unsupported enterprise sampling_unit: {sampling_unit}")
+    value = candidates[sampling_unit]
+    if not value:
+        raise EnterpriseReplayError(
+            f"{request.dataset_id}: sampling_unit={sampling_unit!r} requires source metadata"
+        )
+    return value
+
+
+def _order_selected_requests(
+    requests: list[EnterpriseReplayRequest], *, replay_order: str
+) -> list[EnterpriseReplayRequest]:
+    if replay_order == "source_order":
+        return sorted(requests, key=lambda item: item.source_index)
+    if replay_order == "timestamp":
+        return sorted(
+            requests,
+            key=lambda item: (
+                item.source_created_at_ms is None,
+                item.source_created_at_ms or 0,
+                item.source_index,
+            ),
+        )
+    if replay_order == "group_then_timestamp":
+        return sorted(
+            requests,
+            key=lambda item: (
+                item.source_group_id or item.source_session_id or item.source_conversation_id or "",
+                item.source_created_at_ms is None,
+                item.source_created_at_ms or 0,
+                item.source_index,
+            ),
+        )
+    raise EnterpriseReplayError(f"unsupported enterprise replay_order: {replay_order}")
+
+
 def load_enterprise_replay_requests(
     case_id: str,
     *,
@@ -371,7 +532,7 @@ def load_enterprise_replay_requests(
     )
     path = verify_enterprise_dataset_asset(dataset, data_root=root)
 
-    heap: list[tuple[int, int, EnterpriseReplayRequest]] = []
+    eligible: list[EnterpriseReplayRequest] = []
     with path.open("r", encoding="utf-8") as handle:
         for source_index, line in enumerate(handle):
             if not line.strip():
@@ -384,7 +545,7 @@ def load_enterprise_replay_requests(
                 ) from exc
             if not isinstance(row, dict):
                 raise EnterpriseReplayError("enterprise JSONL records must be objects")
-            source_model, request_type, request_body = _parse_source_row(
+            source_model, request_type, request_body, source_shape_metadata = _parse_source_row(
                 row,
                 source_format=dataset["source_format"],
                 fallback_source_model=dataset["source_model_name"],
@@ -406,22 +567,50 @@ def load_enterprise_replay_requests(
                 request_type=request_type,
                 request_body=request_body,
                 workload_family_id=dataset["workload_family_id"],
+                source_group_id=_optional_string(row.get("group_id")),
+                source_session_id=_optional_string(row.get("session_id")),
+                source_conversation_id=_optional_string(row.get("conversation_id")),
+                source_created_at_ms=_optional_integer(row.get("created_at_ms")),
+                source_prompt_hash=_optional_string(row.get("prompt_hash")),
+                source_prompt_tokens_est=_optional_integer(row.get("prompt_tokens_est")),
+                source_shape_metadata=source_shape_metadata,
             )
-            score = _sample_score(
+            eligible.append(request)
+
+    sampling_unit = str(case.get("sampling_unit") or "request")
+    replay_order = str(case.get("replay_order") or "source_order")
+    grouped: dict[str, list[EnterpriseReplayRequest]] = {}
+    for request in eligible:
+        grouped.setdefault(_sampling_key(request, sampling_unit), []).append(request)
+    ranked_groups = sorted(
+        grouped.items(),
+        key=lambda item: (
+            _sample_group_score(
                 dataset_id=dataset["dataset_id"],
                 case_id=case_id,
                 seed=seed,
-                source_index=source_index,
+                group_key=item[0],
+            ),
+            item[0],
+        ),
+    )
+    selected_requests: list[EnterpriseReplayRequest] = []
+    for _, group_requests in ranked_groups:
+        if sampling_unit == "request" and len(selected_requests) >= limit:
+            break
+        if sampling_unit != "request" and selected_requests and len(selected_requests) + len(group_requests) > limit:
+            continue
+        selected_requests.extend(group_requests)
+        if len(selected_requests) >= limit:
+            break
+    if not selected_requests and ranked_groups:
+        first_group = ranked_groups[0][1]
+        if len(first_group) > limit:
+            raise EnterpriseReplayError(
+                f"limit={limit} cannot preserve the first {sampling_unit} group of {len(first_group)} requests"
             )
-            item = (-score, -source_index, request)
-            if len(heap) < limit:
-                heapq.heappush(heap, item)
-            elif score < -heap[0][0]:
-                heapq.heapreplace(heap, item)
-
-    selected = [(-neg_score, -neg_index, request) for neg_score, neg_index, request in heap]
-    selected.sort(key=lambda item: (item[0], item[1]))
-    return [request for _, _, request in selected]
+        selected_requests.extend(first_group)
+    return _order_selected_requests(selected_requests, replay_order=replay_order)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_delivery_suite.py
+++ b/tests/test_delivery_suite.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from vllm_hust_benchmark.delivery_suite import REQUIRED_WORKLOAD_IDS
+from vllm_hust_benchmark.delivery_suite import delivery_suite_entries
+from vllm_hust_benchmark.delivery_suite import load_delivery_suite_registry
+from vllm_hust_benchmark.delivery_suite import resolve_delivery_workload
+from vllm_hust_benchmark.delivery_suite import validate_delivery_suite_registry
+from vllm_hust_benchmark.enterprise_replay import enterprise_case_rows
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_delivery_suite_registry_matches_json_schema() -> None:
+    schema = json.loads(
+        (REPO_ROOT / "schemas" / "delivery_suite_registry_v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    jsonschema.Draft202012Validator(schema, format_checker=jsonschema.FormatChecker()).validate(
+        load_delivery_suite_registry()
+    )
+
+
+def test_delivery_suite_covers_exactly_nine_distinct_workloads_and_benchmarks() -> None:
+    entries = delivery_suite_entries()
+
+    assert {entry.workload_id for entry in entries} == REQUIRED_WORKLOAD_IDS
+    assert len(entries) == 9
+    assert len({entry.benchmark_id for entry in entries}) == 9
+
+
+def test_delivery_suite_enterprise_cases_exist_in_enterprise_registry() -> None:
+    known_cases = {row["case_id"] for row in enterprise_case_rows()}
+
+    for entry in delivery_suite_entries():
+        assert set(entry.enterprise_case_ids) <= known_cases
+
+
+def test_delivery_suite_pins_academic_descriptor_contract() -> None:
+    contract = load_delivery_suite_registry()["academic_workload_contract"]
+
+    assert contract == {
+        "descriptor_schema_version": "workload-descriptor/v1",
+        "family_generator_version": "family-generator/v1",
+    }
+    assert all(entry.workload_family_ids for entry in delivery_suite_entries())
+
+
+def test_main_suite_excludes_customer_multinode_models() -> None:
+    payload = load_delivery_suite_registry()
+
+    assert all(
+        entry["model"]["deployment_tier"] != "customer_multinode_extension"
+        for entry in payload["entries"]
+    )
+    assert {row["model_id"] for row in payload["customer_multinode_extensions"]} == {
+        "zai-org/GLM-5",
+        "moonshotai/Kimi-K2",
+        "moonshotai/Kimi-K3",
+    }
+
+
+def test_workload_bindings_preserve_key_model_choices() -> None:
+    assert resolve_delivery_workload("reasoning")["model"]["id"] == (
+        "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
+    )
+    assert resolve_delivery_workload("agent")["model"]["id"] == "zai-org/GLM-4.5-Air"
+    assert resolve_delivery_workload("long_context")["model"]["id"] == "Qwen/Qwen3.5-27B"
+
+
+def test_validator_rejects_customer_multinode_fixed_target() -> None:
+    payload = json.loads(json.dumps(load_delivery_suite_registry()))
+    payload["entries"][0]["model"]["deployment_tier"] = "customer_multinode_extension"
+
+    with pytest.raises(ValueError, match="cannot be fixed acceptance targets"):
+        validate_delivery_suite_registry(payload)

--- a/tests/test_delivery_suite.py
+++ b/tests/test_delivery_suite.py
@@ -28,12 +28,12 @@ def test_delivery_suite_registry_matches_json_schema() -> None:
     )
 
 
-def test_delivery_suite_covers_exactly_nine_distinct_workloads_and_benchmarks() -> None:
+def test_delivery_suite_covers_exactly_nine_application_scenarios() -> None:
     entries = delivery_suite_entries()
 
     assert {entry.workload_id for entry in entries} == REQUIRED_WORKLOAD_IDS
     assert len(entries) == 9
-    assert len({entry.benchmark_id for entry in entries}) == 9
+    assert all(entry.public_asset_ids for entry in entries)
 
 
 def test_delivery_suite_enterprise_cases_exist_in_enterprise_registry() -> None:
@@ -57,27 +57,51 @@ def test_main_suite_excludes_customer_multinode_models() -> None:
     payload = load_delivery_suite_registry()
 
     assert all(
-        entry["model"]["deployment_tier"] != "customer_multinode_extension"
+        entry["model_artifact"]["deployment_tier"] != "customer_multinode_extension"
         for entry in payload["entries"]
     )
-    assert {row["model_id"] for row in payload["customer_multinode_extensions"]} == {
-        "zai-org/GLM-5",
-        "moonshotai/Kimi-K2",
-        "moonshotai/Kimi-K3",
+    assert {row["model_class"] for row in payload["customer_multinode_extensions"]} == {
+        "GLM-5-class",
+        "Kimi-K2-or-K3-class",
     }
 
 
 def test_workload_bindings_preserve_key_model_choices() -> None:
-    assert resolve_delivery_workload("reasoning")["model"]["id"] == (
+    assert resolve_delivery_workload("reasoning")["model_artifact"]["repo_id"] == (
         "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
     )
-    assert resolve_delivery_workload("agent")["model"]["id"] == "zai-org/GLM-4.5-Air"
-    assert resolve_delivery_workload("long_context")["model"]["id"] == "Qwen/Qwen3.5-27B"
+    assert resolve_delivery_workload("agent")["model_artifact"]["repo_id"] == "zai-org/GLM-4.5-Air"
+    assert resolve_delivery_workload("long_context")["model_artifact"]["repo_id"] == "Qwen/Qwen3.6-27B"
+    assert all(len(entry.model_revision) == 40 for entry in delivery_suite_entries())
 
 
 def test_validator_rejects_customer_multinode_fixed_target() -> None:
     payload = json.loads(json.dumps(load_delivery_suite_registry()))
-    payload["entries"][0]["model"]["deployment_tier"] = "customer_multinode_extension"
+    payload["entries"][0]["model_artifact"]["deployment_tier"] = "customer_multinode_extension"
 
-    with pytest.raises(ValueError, match="cannot be fixed acceptance targets"):
+    with pytest.raises(ValueError, match="cannot be main acceptance targets"):
         validate_delivery_suite_registry(payload)
+
+
+def test_acceptance_policy_has_numeric_statistics_and_causal_baselines() -> None:
+    policy = load_delivery_suite_registry()["acceptance_policy"]
+
+    assert policy["experimental_design"]["paired_blocks"] >= 5
+    assert policy["experimental_design"]["bootstrap_resamples"] >= 10000
+    assert set(policy["causal_baselines"]) == {
+        "upstream_stock",
+        "hust_feature_off",
+        "hust_feature_on",
+        "minus_one_ablation",
+    }
+    assert policy["portfolio_gate"]["minimum_primary_pass_count"] == 7
+
+
+def test_evaluation_asset_types_are_not_conflated() -> None:
+    assets = {row["asset_id"]: row["asset_type"] for row in load_delivery_suite_registry()["evaluation_assets"]}
+
+    assert assets["livecodebench"] == "quality_benchmark"
+    assert assets["burstgpt-arrival-trace"] == "serving_trace"
+    assert assets["vllm-prefix-repetition"] == "microbenchmark"
+    assert assets["enterprise-request-replay"] == "enterprise_replay"
+    assert assets["naturebench-design-reference"] == "design_reference"

--- a/tests/test_enterprise_replay.py
+++ b/tests/test_enterprise_replay.py
@@ -37,10 +37,18 @@ def _fixture_registry(path: Path, rows: list[dict[str, object]]) -> dict[str, ob
                 "record_count": len(rows),
                 "sha256": hashlib.sha256(asset_bytes).hexdigest(),
                 "workload_family_id": "fixture-family",
+                "provenance_class": "enterprise_observed_request",
+                "preserved_source_fields": [],
             }
         ],
         "cases": [
-            {"case_id": "fixture_all", "dataset_id": "fixture_dataset", "filter_id": None}
+            {
+                "case_id": "fixture_all",
+                "dataset_id": "fixture_dataset",
+                "filter_id": None,
+                "sampling_unit": "request",
+                "replay_order": "source_order",
+            }
         ],
     }
 
@@ -193,3 +201,79 @@ def test_redacted_record_keeps_shape_but_not_request_body(tmp_path: Path) -> Non
     assert record["tool_count"] == 1
     assert record["has_response_format"] is True
     assert len(record["request_sha256"]) == 64
+
+
+def test_group_sampling_preserves_group_order_and_allowlisted_shape_metadata(
+    tmp_path: Path,
+) -> None:
+    rows = []
+    for group_id in ("group-a", "group-b", "group-c"):
+        for turn in range(2):
+            rows.append(
+                {
+                    "id": f"{group_id}-{turn}",
+                    "messages": [{"role": "user", "content": f"question {turn}"}],
+                    "group_id": group_id,
+                    "session_id": f"session-{group_id}",
+                    "created_at_ms": 100 + turn,
+                    "prompt_hash": f"hash-{group_id}-{turn}",
+                    "prompt_tokens_est": 1000 + turn,
+                    "metadata": {
+                        "length_bucket": "1k-2k",
+                        "output_tokens_target": 64,
+                        "private_note": "must-not-leak",
+                    },
+                }
+            )
+    asset = tmp_path / "fixture.jsonl"
+    rendered = "".join(json.dumps(row) + "\n" for row in rows)
+    asset.write_text(rendered, encoding="utf-8")
+    registry = {
+        "schema_version": "enterprise-dataset-registry/v1",
+        "registry_version": "test",
+        "effective_from": "2026-08-14",
+        "data_policy": {},
+        "datasets": [
+            {
+                "dataset_id": "grouped_fixture",
+                "relative_path": asset.name,
+                "source_format": "direct_messages_jsonl",
+                "source_model_name": "source",
+                "record_count": len(rows),
+                "sha256": hashlib.sha256(asset.read_bytes()).hexdigest(),
+                "workload_family_id": "grouped-family",
+                "provenance_class": "enterprise_provided_synthetic_or_hybrid",
+                "preserved_source_fields": ["group_id", "session_id", "metadata"],
+            }
+        ],
+        "cases": [
+            {
+                "case_id": "grouped_case",
+                "dataset_id": "grouped_fixture",
+                "filter_id": None,
+                "sampling_unit": "group",
+                "replay_order": "group_then_timestamp",
+            }
+        ],
+    }
+    authorization = _authorization_file(tmp_path, "grouped_fixture")
+
+    selected = load_enterprise_replay_requests(
+        "grouped_case",
+        data_root=tmp_path,
+        authorization_file=authorization,
+        registry=registry,
+        limit=4,
+        seed=7,
+    )
+
+    assert len(selected) == 4
+    assert all(selected[index].source_group_id == selected[index + 1].source_group_id for index in (0, 2))
+    assert selected[0].source_created_at_ms < selected[1].source_created_at_ms
+    record = selected[0].redacted_record(
+        served_model="Qwen/Qwen3-32B", generation_overrides={"max_tokens": 64}
+    )
+    assert record["max_output_tokens"] == 64
+    assert record["source_shape_metadata"]["length_bucket"] == "1k-2k"
+    assert "private_note" not in record["source_shape_metadata"]
+    assert record["source_group_key_sha256"] != selected[0].source_group_id

--- a/tests/test_enterprise_replay.py
+++ b/tests/test_enterprise_replay.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from vllm_hust_benchmark.enterprise_replay import AUTHORIZATION_SCHEMA_VERSION
+from vllm_hust_benchmark.enterprise_replay import EnterpriseReplayError
+from vllm_hust_benchmark.enterprise_replay import enterprise_case_rows
+from vllm_hust_benchmark.enterprise_replay import enterprise_dataset_rows
+from vllm_hust_benchmark.enterprise_replay import load_enterprise_dataset_registry
+from vllm_hust_benchmark.enterprise_replay import load_enterprise_replay_requests
+from vllm_hust_benchmark.enterprise_replay import resolve_enterprise_data_root
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fixture_registry(path: Path, rows: list[dict[str, object]]) -> dict[str, object]:
+    rendered = "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows)
+    path.write_text(rendered, encoding="utf-8")
+    asset_bytes = path.read_bytes()
+    return {
+        "schema_version": "enterprise-dataset-registry/v1",
+        "registry_version": "test",
+        "effective_from": "2026-08-13",
+        "data_policy": {},
+        "datasets": [
+            {
+                "dataset_id": "fixture_dataset",
+                "relative_path": path.name,
+                "source_format": "wrapped_openai_request_jsonl",
+                "source_model_name": "qwen3",
+                "record_count": len(rows),
+                "sha256": hashlib.sha256(asset_bytes).hexdigest(),
+                "workload_family_id": "fixture-family",
+            }
+        ],
+        "cases": [
+            {"case_id": "fixture_all", "dataset_id": "fixture_dataset", "filter_id": None}
+        ],
+    }
+
+
+def _authorization_file(root: Path, *dataset_ids: str) -> Path:
+    path = root / "authorization.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": AUTHORIZATION_SCHEMA_VERSION,
+                "authorized_dataset_ids": list(dataset_ids),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _wrapped_row(index: int) -> dict[str, object]:
+    body = {
+        "model": "qwen3",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": f"question {index}"},
+                    {"type": "text", "text": "return json"},
+                ],
+            }
+        ],
+        "stream": True,
+        "tools": [{"type": "function", "function": {"name": "lookup"}}],
+        "response_format": {"type": "json_schema", "json_schema": {"name": "answer"}},
+        "max_tokens": 32,
+    }
+    return {
+        "model_name": "qwen3",
+        "request_type": "ChatCompletionStream",
+        "request_body": json.dumps(body),
+    }
+
+
+def test_enterprise_registry_matches_json_schema() -> None:
+    schema = json.loads(
+        (REPO_ROOT / "schemas" / "enterprise_dataset_registry_v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    jsonschema.Draft202012Validator(schema, format_checker=jsonschema.FormatChecker()).validate(
+        load_enterprise_dataset_registry()
+    )
+
+
+def test_enterprise_registry_covers_all_delivered_assets_and_migrated_cases() -> None:
+    datasets = enterprise_dataset_rows()
+    cases = {row["case_id"] for row in enterprise_case_rows()}
+
+    assert len(datasets) == 8
+    assert sum(row["record_count"] for row in datasets) == 26500
+    assert {
+        "enterprise_code_eval_all",
+        "enterprise_json_all",
+        "enterprise_normal_chat_all",
+        "enterprise_long_text",
+        "enterprise_prefix_shared",
+        "enterprise_reuse_conversation",
+        "enterprise_semantic_similar",
+        "enterprise_long_prefill",
+    } <= cases
+
+
+def test_data_root_is_never_discovered_implicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VLLM_HUST_ENTERPRISE_DATA_ROOT", raising=False)
+
+    with pytest.raises(EnterpriseReplayError, match="data root is required"):
+        resolve_enterprise_data_root()
+
+
+def test_replay_fails_closed_without_dataset_authorization(tmp_path: Path) -> None:
+    asset = tmp_path / "fixture.jsonl"
+    registry = _fixture_registry(asset, [_wrapped_row(0)])
+
+    with pytest.raises(EnterpriseReplayError, match="authorization file"):
+        load_enterprise_replay_requests(
+            "fixture_all", data_root=tmp_path, registry=registry
+        )
+
+
+def test_replay_fails_closed_on_checksum_mismatch(tmp_path: Path) -> None:
+    asset = tmp_path / "fixture.jsonl"
+    registry = _fixture_registry(asset, [_wrapped_row(0)])
+    authorization = _authorization_file(tmp_path, "fixture_dataset")
+    asset.write_text(asset.read_text(encoding="utf-8") + "{}\n", encoding="utf-8")
+
+    with pytest.raises(EnterpriseReplayError, match="checksum mismatch"):
+        load_enterprise_replay_requests(
+            "fixture_all",
+            data_root=tmp_path,
+            authorization_file=authorization,
+            registry=registry,
+        )
+
+
+def test_replay_is_deterministic_and_preserves_source_model_separately(tmp_path: Path) -> None:
+    asset = tmp_path / "fixture.jsonl"
+    registry = _fixture_registry(asset, [_wrapped_row(index) for index in range(20)])
+    authorization = _authorization_file(tmp_path, "fixture_dataset")
+
+    first = load_enterprise_replay_requests(
+        "fixture_all",
+        data_root=tmp_path,
+        authorization_file=authorization,
+        limit=5,
+        seed=17,
+        registry=registry,
+    )
+    second = load_enterprise_replay_requests(
+        "fixture_all",
+        data_root=tmp_path,
+        authorization_file=authorization,
+        limit=5,
+        seed=17,
+        registry=registry,
+    )
+
+    assert [row.request_id for row in first] == [row.request_id for row in second]
+    assert len(first) == 5
+    assert all(row.source_model_name == "qwen3" for row in first)
+    assert all("question" not in row.request_id for row in first)
+    assert all(row.to_openai_payload(served_model="Qwen/Qwen3-32B")["model"] == "Qwen/Qwen3-32B" for row in first)
+
+
+def test_redacted_record_keeps_shape_but_not_request_body(tmp_path: Path) -> None:
+    asset = tmp_path / "fixture.jsonl"
+    registry = _fixture_registry(asset, [_wrapped_row(0)])
+    authorization = _authorization_file(tmp_path, "fixture_dataset")
+    request = load_enterprise_replay_requests(
+        "fixture_all",
+        data_root=tmp_path,
+        authorization_file=authorization,
+        registry=registry,
+    )[0]
+
+    record = request.redacted_record(served_model="Qwen/Qwen3-32B")
+
+    assert "request_body" not in record
+    assert "messages" not in record
+    assert record["source_model_name"] == "qwen3"
+    assert record["served_model"] == "Qwen/Qwen3-32B"
+    assert record["tool_count"] == 1
+    assert record["has_response_format"] is True
+    assert len(record["request_sha256"]) == 64


### PR DESCRIPTION
﻿## Summary

This PR establishes the **reviewable contract and implementation foundation** for the next vLLM-HUST delivery suite. It does **not** claim that the final runnable acceptance benchmark or the 21rc experiment campaign is complete.

## Implemented in this PR

- three-layer contract: L0 deployability, 12 L1 engine-capability targets, and 9 L2 application scenarios;
- six exact-revision single-node model candidates with `pinned_candidate` lifecycle status;
- paired causal-baseline policy for U (`upstream_stock`), F0 (`hust_feature_off`), F1 (`hust_feature_on`), and A-i minus-one ablations;
- numeric performance thresholds, quality non-inferiority margins, statistical policy, portfolio gate, and global guardrails;
- registry/schema validation for the delivery suite and all eight enterprise datasets;
- provenance-aware, group/session/conversation-preserving enterprise replay with deterministic sampling and redaction;
- HUST Science Serving v1 design for a dedicated 24-task AI4Science benchmark;
- proposal namespace that leaves existing official targets, historical results, and leaderboard behavior unchanged.

## Explicitly not implemented yet

Merging this PR does **not** mean the following are complete:

- runnable adapters for LiveCodeBench, AIME 2025, VisionArena serving, JSONSchemaBench, LongBench v2, BFCL V4, ShareGPT, or BurstGPT;
- a registry-driven runner that executes U/F0/F1/A-i with paired restart blocks;
- the 12 L1 runtime probes and applied/effective engine telemetry;
- official quality evaluators, bootstrap aggregation, result cards, receipts, or admission decisions;
- the 24 licensed HUST Science Serving task packages, containers, and hidden evaluators;
- authorized runtime mounting and checksum freezing of enterprise raw JSONL assets;
- download/preflight/admission of the six model artifacts on 21rc;
- formal 21rc experiments or evidence that the declared thresholds already pass.

The current implementation therefore corresponds to the **P0 contract plus part of the P1 data/replay foundation**, not P2-P4 completion.

## Follow-up handoff

- #187 tracks the runnable adapters, model/data admission, causal runner, evaluators, AI4Science task packages, 21rc campaign, evidence artifacts, and final definition of done.

## Validation of this PR's implemented scope

- `PYTHONPATH=.;src uv run --extra test pytest -q tests/test_delivery_suite.py tests/test_enterprise_replay.py` ? 17 passed.
- Ruff checks for the changed Python modules and tests passed.

These tests validate registry/schema/replay contracts only; they are not end-to-end benchmark results.

## Compatibility

This PR must not replace current official targets before #187 is implemented, reviewed, and admitted. Missing runtime evidence remains `pinned_candidate`/`blocked`; it must never be reported as accepted performance.
