### PR TITLE
fix(runner): preserve offline cache contract

### DIFF
--- a/src/vllm_hust_benchmark/official_runtime_inputs.py
+++ b/src/vllm_hust_benchmark/official_runtime_inputs.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
-from typing import Mapping
-
 
 SHAREGPT_DATASET_FILENAME = "ShareGPT_V3_unfiltered_cleaned_split.json"
 OFFLINE_SERVER_PARAMETER_KEYS = {
@@ -15,6 +14,7 @@ OFFLINE_SERVER_PARAMETER_KEYS = {
     "max_num_batched_tokens",
     "max_num_seqs",
     "model",
+    "no_enable_prefix_caching",
     "quantization",
     "tensor_parallel_size",
     "tokenizer",

--- a/tests/test_official_runtime_inputs.py
+++ b/tests/test_official_runtime_inputs.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vllm_hust_benchmark.official_runtime_inputs import SHAREGPT_DATASET_FILENAME
-from vllm_hust_benchmark.official_runtime_inputs import normalize_client_parameters
 from vllm_hust_benchmark.official_runtime_inputs import (
+    SHAREGPT_DATASET_FILENAME,
+    normalize_client_parameters,
     normalize_offline_benchmark_parameters,
+    normalize_server_parameters,
+    resolve_runtime_dataset_path,
 )
-from vllm_hust_benchmark.official_runtime_inputs import normalize_server_parameters
-from vllm_hust_benchmark.official_runtime_inputs import resolve_runtime_dataset_path
 
 
 def test_normalize_client_parameters_strips_unsupported_offline_flags(
@@ -122,6 +122,7 @@ def test_normalize_offline_benchmark_parameters_carries_engine_runtime_knobs(
             "trust_remote_code": "",
             "enforce_eager": "",
             "disable_log_stats": "",
+            "no_enable_prefix_caching": True,
         },
         benchmark_type="throughput",
         vllm_worktree=str(worktree),
@@ -132,6 +133,7 @@ def test_normalize_offline_benchmark_parameters_carries_engine_runtime_knobs(
     assert normalized["tensor_parallel_size"] == 1
     assert normalized["trust_remote_code"] == ""
     assert normalized["enforce_eager"] == ""
+    assert normalized["no_enable_prefix_caching"] is True
     assert "host" not in normalized
     assert "port" not in normalized
     assert "disable_log_stats" not in normalized


### PR DESCRIPTION
## What changed

- carry `no_enable_prefix_caching` from the resolved server contract into offline throughput/latency CLI arguments
- add a regression assertion for the normalized offline arguments
- normalize pre-existing imports touched by the focused lint run

## Why

Issue #214 isolation found that `resolved_same_spec.json` recorded `no_enable_prefix_caching: true`, but offline normalization silently dropped the flag before invoking `vllm bench throughput`. That made the artifact claim one cache contract while measuring another and produced a false Sonnet/ShareGPT regression.

## Validation

- `PYTHONPATH=src python3 -m pytest -q tests/test_official_runtime_inputs.py` (7 passed)
- `python3 -m ruff check src/vllm_hust_benchmark/official_runtime_inputs.py tests/test_official_runtime_inputs.py`
- six strict Sonnet reruns verified the flag in the actual process command and removed the false regression

Closes the runner-contract portion of #214.