### PR TITLE
fix(target-registry): preserve per-target contract versions

### DIFF
--- a/docs/OFFICIAL_TARGETS.md
+++ b/docs/OFFICIAL_TARGETS.md
@@ -5,6 +5,11 @@
 - Registry version: `1.3.5`
 - Effective from: `2026-08-16`
 
+`registry_version` identifies this generated registry snapshot. Each target's `target_version` is
+the immutable execution-contract version for that target; an unrelated target update must not change
+it. Producers should record the canonical `target_contract_id` and `target_contract_version`
+metadata fields.
+
 Public leaderboard targets and 3B perfgate profiles are separate contracts. Provisional entries are
 not valid public-result comparison targets.
 

--- a/docs/OFFICIAL_TARGETS.zh-CN.md
+++ b/docs/OFFICIAL_TARGETS.zh-CN.md
@@ -5,6 +5,9 @@
 - Registry version: `1.3.5`
 - Effective from: `2026-08-16`
 
+`registry_version` 表示本次生成的 registry 快照版本；每个 target 的 `target_version` 表示该 target 不可变的执行契约版本。无关
+target 的更新不应 改变它。生产端应记录 canonical 的 `target_contract_id` 和 `target_contract_version` 字段。
+
 公开排行榜固定靶与 3B 快速门禁是不同契约；provisional 记录不得作为公开成果对比。
 
 | 用途 | 状态 | Profile | Workload | 模型 | 硬件 | 精度 | 显存比例 | 最大长度 | Spec | | --- | --- | --- | --- | --- |

--- a/leaderboard-data/official-targets.json
+++ b/leaderboard-data/official-targets.json
@@ -1,5 +1,10 @@
 {
   "effective_from": "2026-08-16",
+  "registry_generation": {
+    "effective_from": "2026-08-16",
+    "source_set_sha256": "3f4d3f8be663095014e40d900cb8e675b41b2e2f35b4081ca0f0597c54362e6f",
+    "version": "1.3.5"
+  },
   "registry_version": "1.3.5",
   "schema_version": "official-target-registry/v1",
   "source_set_sha256": "3f4d3f8be663095014e40d900cb8e675b41b2e2f35b4081ca0f0597c54362e6f",

--- a/leaderboard-data/official-targets.sha256
+++ b/leaderboard-data/official-targets.sha256
@@ -1,1 +1,1 @@
-d9fd84148a9a28c67ab2d50f63d8a31416f7deb14d27b918a31d2a5affdb466a  official-targets.json
+a1002308cff2d91147f23a3ec3e8ba74aae1dd9daeedbfb355c24e612cb00d7c  official-targets.json

--- a/schemas/official_target_registry_v1.schema.json
+++ b/schemas/official_target_registry_v1.schema.json
@@ -3,12 +3,22 @@
   "$id": "https://github.com/vLLM-HUST/vllm-hust-benchmark/schemas/official_target_registry_v1.schema.json",
   "title": "vLLM-HUST official target registry v1",
   "type": "object",
-  "required": ["schema_version", "registry_version", "effective_from", "source_set_sha256", "targets"],
+  "required": ["schema_version", "registry_version", "effective_from", "source_set_sha256", "registry_generation", "targets"],
   "properties": {
     "schema_version": {"const": "official-target-registry/v1"},
     "registry_version": {"type": "string", "minLength": 1},
     "effective_from": {"type": "string", "format": "date"},
     "source_set_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "registry_generation": {
+      "type": "object",
+      "required": ["version", "effective_from", "source_set_sha256"],
+      "properties": {
+        "version": {"type": "string", "minLength": 1},
+        "effective_from": {"type": "string", "format": "date"},
+        "source_set_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      },
+      "additionalProperties": false
+    },
     "targets": {
       "type": "array",
       "minItems": 1,

--- a/src/vllm_hust_benchmark/data/official_target_versions.json
+++ b/src/vllm_hust_benchmark/data/official_target_versions.json
@@ -62,6 +62,13 @@
       "effective_from": "2026-08-16",
       "source_set_sha256": "3f4d3f8be663095014e40d900cb8e675b41b2e2f35b4081ca0f0597c54362e6f",
       "supersedes": "1.3.4",
+      "target_contracts": {
+        "default": {
+          "version": "1.3.5",
+          "effective_from": "2026-08-16",
+          "supersedes": []
+        }
+      },
       "summary_en": "Freeze the executable prefix-repetition contract, including fixed-length generation and the required 0.9 memory utilization, prefix caching, chunked prefill, scheduler concurrency, and batched-token limits, so milestones do not inherit version-dependent defaults.",
       "summary_zh": "为公开 prefix-repetition workload 显式冻结可执行契约，包括固定长度生成、必需的 0.9 显存比例、前缀缓存、分块预填充、调度并发数和批处理 token 上限，避免不同 milestone 继承版本相关的默认值。"
     }

--- a/src/vllm_hust_benchmark/data/official_targets.json
+++ b/src/vllm_hust_benchmark/data/official_targets.json
@@ -1,5 +1,10 @@
 {
   "effective_from": "2026-08-16",
+  "registry_generation": {
+    "effective_from": "2026-08-16",
+    "source_set_sha256": "3f4d3f8be663095014e40d900cb8e675b41b2e2f35b4081ca0f0597c54362e6f",
+    "version": "1.3.5"
+  },
   "registry_version": "1.3.5",
   "schema_version": "official-target-registry/v1",
   "source_set_sha256": "3f4d3f8be663095014e40d900cb8e675b41b2e2f35b4081ca0f0597c54362e6f",

--- a/src/vllm_hust_benchmark/leaderboard_export.py
+++ b/src/vllm_hust_benchmark/leaderboard_export.py
@@ -14,6 +14,7 @@ from vllm_hust_benchmark.model_registry import normalize_model_identity_payload
 from vllm_hust_benchmark.model_registry import resolve_model_identity
 from vllm_hust_benchmark.model_registry import validate_model_identity_payload
 from vllm_hust_benchmark.models import ScenarioDefinition
+from vllm_hust_benchmark.official_targets import load_packaged_registry
 from vllm_hust_benchmark.workload_config_contract import (
     WORKLOAD_CONFIG_CONTRACT_VERSION,
     is_official_workload_contract_entry,
@@ -753,6 +754,29 @@ def export_leaderboard_artifacts(
             )
         artifact["metadata"]["target_id"] = target_id
         artifact["metadata"]["target_version"] = target_version
+        canonical_target_id = str(spec_payload.get("id") or "").strip()
+        official_registry = load_packaged_registry()
+        canonical_targets = [
+            target
+            for target in official_registry.get("targets", [])
+            if isinstance(target, dict)
+            and target.get("target_id") == canonical_target_id
+        ]
+        if not canonical_targets:
+            raise ValueError(
+                f"spec_path {spec_path} target id {canonical_target_id!r} is not "
+                "present in the packaged official target registry"
+            )
+        canonical_versions = {
+            str(target.get("target_version")) for target in canonical_targets
+        }
+        if len(canonical_versions) != 1:
+            raise ValueError(
+                f"official target {canonical_target_id!r} has ambiguous contract versions: "
+                f"{sorted(canonical_versions)}"
+            )
+        artifact["metadata"]["target_contract_id"] = canonical_target_id
+        artifact["metadata"]["target_contract_version"] = canonical_versions.pop()
         artifact["metadata"]["workload_config_contract"] = (
             WORKLOAD_CONFIG_CONTRACT_VERSION
         )

--- a/src/vllm_hust_benchmark/official_targets.py
+++ b/src/vllm_hust_benchmark/official_targets.py
@@ -210,6 +210,44 @@ def _validate_version_history(
     return history
 
 
+def _target_contract_metadata(
+    history: dict[str, Any], target_id: str
+) -> dict[str, Any]:
+    """Resolve the immutable contract metadata for one target.
+
+    ``official_target_versions.json`` historically versioned the whole source
+    set.  New entries may add a ``target_contracts`` mapping containing only
+    changed targets plus an optional ``default`` migration entry. Walking the
+    history backwards lets unchanged targets inherit their previous contract
+    while a changed target records its own version and supersession.
+    """
+    for version in reversed(history["versions"]):
+        contracts = version.get("target_contracts")
+        if not isinstance(contracts, dict):
+            continue
+        metadata = contracts.get(target_id) or contracts.get("default")
+        if not isinstance(metadata, dict):
+            continue
+        resolved = dict(metadata)
+        resolved.setdefault("version", version["version"])
+        resolved.setdefault("effective_from", version["effective_from"])
+        supersedes = resolved.get("supersedes")
+        if supersedes is None:
+            resolved["supersedes"] = []
+        elif isinstance(supersedes, str):
+            resolved["supersedes"] = [supersedes]
+        elif not isinstance(supersedes, list) or not all(
+            isinstance(item, str) for item in supersedes
+        ):
+            raise ValueError(f"invalid supersedes metadata for target {target_id!r}")
+        return resolved
+    return {
+        "version": REGISTRY_VERSION,
+        "effective_from": EFFECTIVE_FROM,
+        "supersedes": [],
+    }
+
+
 def build_registry(repo_root: Path) -> dict[str, Any]:
     spec_root = repo_root / "docs" / "official-baselines"
     spec_paths = sorted(
@@ -221,6 +259,10 @@ def build_registry(repo_root: Path) -> dict[str, Any]:
         raise ValueError(f"no official target specs found under {spec_root}")
 
     targets: list[dict[str, Any]] = []
+    history_path = repo_root / VERSION_HISTORY_RELATIVE_PATH
+    history = (
+        _load_version_history(repo_root) if history_path.exists() else {"versions": []}
+    )
     for path in spec_paths:
         spec = _load_spec(path)
         _validate_prefix_repetition_workload(spec, path)
@@ -231,13 +273,15 @@ def build_registry(repo_root: Path) -> dict[str, Any]:
         baseline = spec["baseline_target"]
         export = spec["export"]
         relative_path = path.relative_to(repo_root).as_posix()
+        source_sha256 = _sha256_bytes(path.read_bytes())
+        contract = _target_contract_metadata(history, str(spec["id"]))
         targets.append(
             {
                 "target_id": spec["id"],
-                "target_version": REGISTRY_VERSION,
+                "target_version": str(contract["version"]),
                 "status": status,
-                "effective_from": EFFECTIVE_FROM,
-                "supersedes": [],
+                "effective_from": str(contract["effective_from"]),
+                "supersedes": contract["supersedes"],
                 "profile": profile,
                 "intended_use": intended_use,
                 "baseline_runtime": {
@@ -266,7 +310,7 @@ def build_registry(repo_root: Path) -> dict[str, Any]:
                 },
                 "source_spec": {
                     "path": relative_path,
-                    "sha256": _sha256_bytes(path.read_bytes()),
+                    "sha256": source_sha256,
                 },
                 "compatibility_policy": {
                     "model": "exact",
@@ -294,6 +338,11 @@ def build_registry(repo_root: Path) -> dict[str, Any]:
         "registry_version": REGISTRY_VERSION,
         "effective_from": EFFECTIVE_FROM,
         "source_set_sha256": source_set_sha256,
+        "registry_generation": {
+            "version": REGISTRY_VERSION,
+            "effective_from": EFFECTIVE_FROM,
+            "source_set_sha256": source_set_sha256,
+        },
         "targets": targets,
     }
 
@@ -356,6 +405,18 @@ def render_document(registry: dict[str, Any], *, language: str) -> str:
         "",
         f"- Registry version: `{registry['registry_version']}`",
         f"- Effective from: `{registry['effective_from']}`",
+        "",
+        (
+            "`registry_version` identifies this generated registry snapshot. Each target's "
+            "`target_version` is the immutable execution-contract version for that target; "
+            "an unrelated target update must not change it. Producers should record the "
+            "canonical `target_contract_id` and `target_contract_version` metadata fields."
+            if not chinese
+            else "`registry_version` 表示本次生成的 registry 快照版本；每个 target 的 "
+            "`target_version` 表示该 target 不可变的执行契约版本。无关 target 的更新不应 "
+            "改变它。生产端应记录 canonical 的 `target_contract_id` 和 "
+            "`target_contract_version` 字段。"
+        ),
         "",
         public_note,
         "",

--- a/src/vllm_hust_benchmark/workload_config_contract.py
+++ b/src/vllm_hust_benchmark/workload_config_contract.py
@@ -237,6 +237,57 @@ def _validate_target_metadata(metadata: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_target_contract_metadata(metadata: Mapping[str, Any]) -> list[str]:
+    """Validate the canonical per-profile target contract binding.
+
+    ``target_id``/``target_version`` remain the legacy baseline label used by
+    existing producers.  The canonical fields resolve against the generated
+    official-target registry and therefore remain stable when the registry
+    generation itself is bumped for an unrelated profile.
+    """
+    contract_id = str(metadata.get("target_contract_id") or "").strip()
+    contract_version = str(metadata.get("target_contract_version") or "").strip()
+    if not contract_id and not contract_version:
+        return []
+    errors: list[str] = []
+    if not contract_id:
+        errors.append(
+            "metadata.target_contract_id must be recorded with target_contract_version"
+        )
+        return errors
+    if not contract_version:
+        errors.append(
+            "metadata.target_contract_version must be recorded with target_contract_id"
+        )
+        return errors
+
+    from vllm_hust_benchmark.official_targets import load_packaged_registry
+
+    try:
+        registry = load_packaged_registry()
+    except (OSError, TypeError, ValueError) as exc:
+        return [f"metadata target contract validation failed to load registry: {exc}"]
+
+    matching = [
+        target
+        for target in registry.get("targets", [])
+        if isinstance(target, Mapping) and target.get("target_id") == contract_id
+    ]
+    if not matching:
+        errors.append(
+            f"metadata.target_contract_id {contract_id!r} does not match the official target registry"
+        )
+        return errors
+    valid_versions = {str(target.get("target_version")) for target in matching}
+    if contract_version not in valid_versions:
+        errors.append(
+            f"metadata.target_contract_version {contract_version!r} does not match "
+            f"the official target contract for {contract_id!r} "
+            f"(expected one of {sorted(valid_versions)})"
+        )
+    return errors
+
+
 def validate_explicit_workload_config(
     entry: Mapping[str, Any], *, validate_target_metadata: bool = True
 ) -> list[str]:
@@ -257,6 +308,7 @@ def validate_explicit_workload_config(
         errors.append("metadata.submitted_at must be explicitly recorded")
     elif validate_target_metadata and submitted_at >= TARGET_ID_REQUIRED_AFTER:
         errors.extend(_validate_target_metadata(metadata))
+        errors.extend(_validate_target_contract_metadata(metadata))
 
     workload = entry.get("workload")
     if not isinstance(workload, Mapping):

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -154,6 +154,11 @@ def test_official_entry_records_target_id_and_target_version(tmp_path: Path) -> 
     metadata = artifact["metadata"]
     assert metadata["target_id"] == "official-ascend-jan-2026-v0.18.0"
     assert metadata["target_version"] == "Official Ascend Jan 2026"
+    assert (
+        metadata["target_contract_id"]
+        == "official-ascend-jan-2026-v0.18.0-sharegpt-online-qwen25-14b-910b2"
+    )
+    assert metadata["target_contract_version"] == "1.3.5"
     assert metadata["workload_config_contract"] == "explicit-effective/v1"
 
 

--- a/tests/test_official_targets.py
+++ b/tests/test_official_targets.py
@@ -15,6 +15,7 @@ from vllm_hust_benchmark.official_targets import (
     generated_outputs,
     render_active_targets,
 )
+from vllm_hust_benchmark.official_targets import _target_contract_metadata
 from vllm_hust_benchmark.same_spec import PREFIX_REPETITION_DEFAULT_NUM_PREFIXES
 from vllm_hust_benchmark.workload_config_contract import (
     _official_defaults_for_scenario,
@@ -36,6 +37,54 @@ def test_registry_matches_schema() -> None:
         )
     )
     jsonschema.Draft202012Validator(schema).validate(registry)
+
+
+def test_registry_generation_is_distinct_from_target_contract_version() -> None:
+    registry = build_registry(REPO_ROOT)
+    assert registry["registry_generation"]["version"] == registry["registry_version"]
+    assert (
+        registry["registry_generation"]["source_set_sha256"]
+        == registry["source_set_sha256"]
+    )
+    assert {target["target_version"] for target in registry["targets"]} == {"1.3.5"}
+
+
+def test_one_target_update_inherits_unchanged_contracts() -> None:
+    history = {
+        "versions": [
+            {
+                "version": "1.3.5",
+                "effective_from": "2026-08-16",
+                "target_contracts": {
+                    "default": {
+                        "version": "1.3.5",
+                        "effective_from": "2026-08-16",
+                        "supersedes": [],
+                    }
+                },
+            },
+            {
+                "version": "1.3.6",
+                "effective_from": "2026-08-17",
+                "target_contracts": {
+                    "changed-target": {
+                        "version": "1.3.6",
+                        "effective_from": "2026-08-17",
+                        "supersedes": ["1.3.5"],
+                    }
+                },
+            },
+        ]
+    }
+
+    unchanged = _target_contract_metadata(history, "unchanged-target")
+    changed = _target_contract_metadata(history, "changed-target")
+    assert unchanged["version"] == "1.3.5"
+    assert unchanged["effective_from"] == "2026-08-16"
+    assert unchanged["supersedes"] == []
+    assert changed["version"] == "1.3.6"
+    assert changed["effective_from"] == "2026-08-17"
+    assert changed["supersedes"] == ["1.3.5"]
 
 
 def test_public_target_matrix_is_exact() -> None:

--- a/tests/test_workload_config_contract.py
+++ b/tests/test_workload_config_contract.py
@@ -402,6 +402,27 @@ def test_contract_rejects_mismatched_target_version() -> None:
     )
 
 
+def test_canonical_target_contract_round_trip_resolves_exact_version() -> None:
+    entry = official_random_online_entry()
+    entry["metadata"].update(
+        {
+            "submitted_at": TARGET_ID_REQUIRED_AFTER,
+            "target_id": "official-ascend-jan-2026-v0.18.0",
+            "target_version": "Official Ascend Jan 2026",
+            "target_contract_id": (
+                "official-ascend-jan-2026-v0.18.0-random-online-qwen25-14b-910b2"
+            ),
+            "target_contract_version": "1.3.5",
+        }
+    )
+
+    assert validate_explicit_workload_config(entry) == []
+
+    entry["metadata"]["target_contract_version"] = "1.3.4"
+    errors = validate_explicit_workload_config(entry)
+    assert any("target_contract_version" in error for error in errors)
+
+
 def test_contract_skips_target_id_requirement_before_activation() -> None:
     """Official entries submitted before TARGET_ID_REQUIRED_AFTER are not
     required to record ``metadata.target_id``."""


### PR DESCRIPTION
## Summary

  Separate registry generation metadata from per-target contract versions.

  This change:

  - Adds canonical `target_contract_id` and `target_contract_version` metadata;
  - Preserves the existing contract version for targets that are not changed in a later registry generation;
  - Ensures a one-target update does not incorrectly mark unchanged targets as superseded;
  - Updates the official target registry schema, generated registry data, checksum, exporter, and workload contract validation;
  - Adds regression coverage for registry generation and canonical target contract round trips.

  This prevents historical benchmark submissions from being associated with an incorrect target contract version after an unrelated
  target is updated.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - `PYTHONPATH=src pytest -q tests/test_leaderboard_export.py tests/test_official_targets.py tests/
  test_workload_config_contract.py tests/test_validate_snapshot_consistency.py`
    - `44 passed`
  - Full test suite:
    - `1497 passed, 11 skipped`
  - Generated official target registry and checksum validation passed.
  - Pre-commit checks passed for the changed files.
  - `git diff --check` passed.

  No hardware benchmark, deployment, publication, or HF synchronization was executed.

  ## Risks

  - The registry schema and metadata are extended with canonical target contract fields; consumers that strictly assume the
  previous schema may need to accept the additive fields.
  - Existing historical target metadata is preserved, so no public benchmark result rows are rewritten by this change.
  - No hardware, runtime, deployment, or performance behavior is changed.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed. Official target registry documentation was updated.
  - [x] I noted the tests I ran, or clearly stated what I could not run.