### PR TITLE
fix(provenance): fail closed on runtime source mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,13 @@ Notes:
   back to index-based resolution unless you also provide explicit wheel URLs.
 - The runner executes against the pinned worktrees through `PYTHONPATH` and defaults
   `VLLM_CACHE_ROOT` to `.cache/official-ascend-goal-baseline/` in this repository.
+- Before model loading, the runner now proves that imported `vllm` and `vllm_ascend` modules,
+  package versions, generated build commit IDs, and discovered compiled extensions correspond to
+  those pinned worktrees. It repeats the capture after the benchmark and fails closed if the runtime
+  changes. The resulting `official_runtime_provenance` is stored identically in
+  `run_leaderboard.json`, `leaderboard_manifest.json`, and `env-manifest.json`; publication rejects
+  a missing or mismatched copy before snapshots are generated. Historical artifacts without this new
+  field remain readable, but newly captured official evidence cannot omit it.
 - The runner calls the same prepare script in admission-only mode immediately before benchmark
   startup, so residual-process cleanup is a hard precondition rather than a manual step.
 - The runner prefers a locally cached Hugging Face snapshot for the target model when one already

--- a/scripts/capture-official-runtime-provenance.py
+++ b/scripts/capture-official-runtime-provenance.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Capture and validate the Python runtime used by an official benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import importlib.machinery
+import importlib.metadata
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+SCHEMA_VERSION = "official-runtime-provenance/v1"
+ROLE_CONFIG = {
+    "engine": {
+        "module": "vllm",
+        "distributions": ("vllm",),
+        "extension_modules": ("vllm._C", "vllm._C_stable_libtorch"),
+    },
+    "plugin": {
+        "module": "vllm_ascend",
+        "distributions": ("vllm-ascend", "vllm-ascend-hust", "vllm_ascend"),
+        "extension_modules": ("vllm_ascend.vllm_ascend_C",),
+    },
+}
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _canonical_version(value: str) -> str:
+    normalized = value.strip().lower().removeprefix("v")
+    match = re.fullmatch(r"(.+)-(\d+)-g([0-9a-f]+)(?:-dirty)?", normalized)
+    if match:
+        normalized = f"{match.group(1)}.dev{match.group(2)}+g{match.group(3)}"
+    return normalized.replace("-", ".")
+
+
+def _embedded_commit(version: str) -> str:
+    match = re.search(r"(?:^|[.+-])g([0-9a-f]{7,40})(?:[.+-]|$)", version.lower())
+    return match.group(1) if match else ""
+
+
+def _distribution_version(names: tuple[str, ...]) -> tuple[str, str]:
+    for name in names:
+        try:
+            return name, importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "", ""
+
+
+def _module_path(module: ModuleType) -> Path:
+    raw_path = getattr(module, "__file__", "")
+    if not raw_path:
+        raise ValueError(f"imported module {module.__name__} has no __file__")
+    return Path(raw_path).resolve()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _extension_evidence(
+    namespace: str, candidates: tuple[str, ...], worktree: Path
+) -> list[dict[str, Any]]:
+    suffixes = tuple(importlib.machinery.EXTENSION_SUFFIXES)
+    paths: dict[str, tuple[str, Path]] = {}
+    for name, module in tuple(sys.modules.items()):
+        raw_path = getattr(module, "__file__", "") if module else ""
+        if (
+            name.startswith(f"{namespace}.")
+            and raw_path
+            and raw_path.endswith(suffixes)
+        ):
+            paths[name] = ("loaded", Path(raw_path).resolve())
+    for name in candidates:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ModuleNotFoundError, ValueError):
+            spec = None
+        if spec is not None and spec.origin and spec.origin.endswith(suffixes):
+            paths.setdefault(name, ("resolved", Path(spec.origin).resolve()))
+    package_root = worktree / namespace
+    if package_root.is_dir():
+        for path in package_root.rglob("*"):
+            if path.is_file() and path.name.endswith(suffixes):
+                relative = path.relative_to(worktree).as_posix()
+                paths.setdefault(relative, ("discovered", path.resolve()))
+    return [
+        {
+            "module": name,
+            "status": status,
+            "path": str(path),
+            "sha256": _sha256(path),
+        }
+        for name, (status, path) in sorted(paths.items())
+    ]
+
+
+def capture_role(role: str, worktree: Path, expected_commit: str) -> dict[str, Any]:
+    config = ROLE_CONFIG[role]
+    worktree = worktree.resolve()
+    observed_commit = _run_git(worktree, "rev-parse", "--verify", "HEAD^{commit}")
+    expected_commit = expected_commit.strip().lower()
+    if observed_commit != expected_commit:
+        raise ValueError(
+            f"{role} prepared worktree commit mismatch: expected {expected_commit}, "
+            f"observed {observed_commit}"
+        )
+
+    module = importlib.import_module(config["module"])
+    module_path = _module_path(module)
+    if not _is_relative_to(module_path, worktree):
+        raise ValueError(
+            f"{role} module path mismatch: {module_path} is outside prepared worktree {worktree}"
+        )
+
+    module_version = str(getattr(module, "__version__", "") or "").strip()
+    module_commit = str(getattr(module, "__commit_id__", "") or "").strip()
+    upstream_commit = str(getattr(module, "__upstream_commit__", "") or "").strip()
+    distribution, distribution_version = _distribution_version(config["distributions"])
+    if not module_version or not distribution_version:
+        raise ValueError(f"{role} runtime package version cannot be proven")
+    if _canonical_version(module_version) != _canonical_version(distribution_version):
+        raise ValueError(
+            f"{role} runtime version mismatch: module={module_version!r}, "
+            f"distribution={distribution_version!r}"
+        )
+
+    source_version = _run_git(worktree, "describe", "--tags", "--always", "HEAD")
+    source_commit_hint = _embedded_commit(source_version)
+    runtime_commit_hint = _embedded_commit(module_version)
+    module_commit_hint = module_commit.lower().removeprefix("g")
+    if module_commit_hint:
+        if not observed_commit.startswith(module_commit_hint):
+            raise ValueError(
+                f"{role} runtime build commit mismatch: module commit={module_commit!r}, "
+                f"prepared commit={observed_commit}"
+            )
+    elif source_commit_hint and runtime_commit_hint:
+        if not observed_commit.startswith(
+            source_commit_hint
+        ) or not observed_commit.startswith(runtime_commit_hint):
+            raise ValueError(
+                f"{role} runtime build commit mismatch: source={source_version!r}, "
+                f"module={module_version!r}, commit={observed_commit}"
+            )
+    elif _canonical_version(source_version) != _canonical_version(module_version):
+        raise ValueError(
+            f"{role} runtime version does not identify prepared source: "
+            f"source={source_version!r}, module={module_version!r}"
+        )
+
+    extensions = _extension_evidence(
+        config["module"], config["extension_modules"], worktree
+    )
+    for extension in extensions:
+        extension_path = Path(extension["path"])
+        if not _is_relative_to(extension_path, worktree):
+            raise ValueError(
+                f"{role} extension path mismatch: {extension_path} is outside "
+                f"prepared worktree {worktree}"
+            )
+
+    return {
+        "module": config["module"],
+        "module_path": str(module_path),
+        "module_version": module_version,
+        "module_commit": module_commit,
+        "upstream_commit": upstream_commit,
+        "distribution": distribution,
+        "distribution_version": distribution_version,
+        "prepared_worktree": str(worktree),
+        "prepared_commit": observed_commit,
+        "source_version": source_version,
+        "extension_policy": "present" if extensions else "none-discovered",
+        "extensions": extensions,
+    }
+
+
+def _load_source_provenance(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != "official-source-provenance/v1":
+        raise ValueError(f"unsupported official source provenance: {path}")
+    return payload
+
+
+def capture(
+    engine_worktree: Path,
+    engine_commit: str,
+    plugin_worktree: Path,
+    plugin_commit: str,
+    source_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "python_executable": str(Path(sys.executable).resolve()),
+        "python_version": sys.version.split()[0],
+        "sources": {
+            "engine": capture_role("engine", engine_worktree, engine_commit),
+            "plugin": capture_role("plugin", plugin_worktree, plugin_commit),
+        },
+    }
+    if source_provenance is not None:
+        for role in ("engine", "plugin"):
+            source = (source_provenance.get("sources") or {}).get(role) or {}
+            runtime = payload["sources"][role]
+            if source.get("observed_commit") != runtime["prepared_commit"]:
+                raise ValueError(
+                    f"{role} source/runtime commit mismatch: "
+                    f"source={source.get('observed_commit')!r}, "
+                    f"runtime={runtime['prepared_commit']!r}"
+                )
+            for source_field, runtime_field in (
+                ("tracked_patch_sha256", "source_patch_sha256"),
+                ("working_tree_sha256", "source_tree_sha256"),
+                ("status", "source_status"),
+            ):
+                value = source.get(source_field)
+                if not value:
+                    raise ValueError(
+                        f"{role} source provenance is missing {source_field}"
+                    )
+                runtime[runtime_field] = value
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine-worktree", type=Path, required=True)
+    parser.add_argument("--engine-commit", required=True)
+    parser.add_argument("--plugin-worktree", type=Path, required=True)
+    parser.add_argument("--plugin-commit", required=True)
+    parser.add_argument("--source-provenance", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        source_provenance = (
+            _load_source_provenance(args.source_provenance)
+            if args.source_provenance
+            else None
+        )
+        payload = capture(
+            args.engine_worktree,
+            args.engine_commit,
+            args.plugin_worktree,
+            args.plugin_commit,
+            source_provenance,
+        )
+    except (ImportError, OSError, subprocess.SubprocessError, ValueError) as error:
+        print(
+            f"official runtime provenance validation failed: {error}", file=sys.stderr
+        )
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture-official-source-provenance.py
+++ b/scripts/capture-official-source-provenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.machinery
 import json
 import os
 import subprocess
@@ -34,12 +35,24 @@ def _tree_digest(repo: Path) -> tuple[str, int, int, int]:
         if path
     )
     tracked_paths = set(paths)
-    generated_paths = {b"vllm_ascend/_build_info.py"}
+    generated_paths = {
+        b"vllm/_version.py",
+        b"vllm_ascend/_build_info.py",
+        b"vllm_ascend/_version.py",
+    }
     generated_paths.update(
         os.fsencode(path.relative_to(repo))
         for pattern in ("vllm-*.dist-info/*", "vllm_ascend-*.dist-info/*")
         for path in repo.glob(pattern)
         if path.is_file()
+    )
+    generated_paths.update(
+        os.fsencode(path.relative_to(repo))
+        for package_dir in (repo / "vllm", repo / "vllm_ascend")
+        if package_dir.is_dir()
+        for path in package_dir.rglob("*")
+        if path.is_file()
+        and path.name.endswith(tuple(importlib.machinery.EXTENSION_SUFFIXES))
     )
     paths.update(
         path for path in generated_paths if (repo / os.fsdecode(path)).is_file()

--- a/scripts/collect-run-artifact.sh
+++ b/scripts/collect-run-artifact.sh
@@ -149,6 +149,16 @@ if provenance_path:
     if isinstance(candidate, dict):
         official_source_provenance = candidate
 
+official_runtime_provenance = {}
+runtime_provenance_path = os.environ.get("OFFICIAL_RUNTIME_PROVENANCE_FILE", "")
+if runtime_provenance_path:
+    try:
+        candidate = json.loads(Path(runtime_provenance_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        candidate = None
+    if isinstance(candidate, dict):
+        official_runtime_provenance = candidate
+
 manifest = {
     "manifest_version": "run-env-manifest/v2",
     "collected_at": _run(["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"]),
@@ -204,6 +214,8 @@ manifest = {
 }
 if official_source_provenance:
     manifest["official_source_provenance"] = official_source_provenance
+if official_runtime_provenance:
+    manifest["official_runtime_provenance"] = official_runtime_provenance
 
 # Use the explicit pip-packages.json file rather than embedding a second copy
 manifest["pip_packages"] = "see pip-packages.json"

--- a/scripts/prepare-official-ascend-baseline-env.sh
+++ b/scripts/prepare-official-ascend-baseline-env.sh
@@ -154,6 +154,40 @@ resolve_ascend_device_type() {
   esac
 }
 
+write_source_version_metadata() {
+  local worktree=$1
+  local package_dir=$2
+  local version=$3
+  local commit
+  local version_file="$worktree/$package_dir/_version.py"
+
+  commit=$(git -C "$worktree" rev-parse --verify HEAD^{commit})
+  mkdir -p "$(dirname "$version_file")"
+  python3 - "$version_file" "$version" "$commit" "$worktree/upstream_version.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+version_file = Path(sys.argv[1])
+version = sys.argv[2]
+commit = sys.argv[3]
+upstream_path = Path(sys.argv[4])
+try:
+    upstream = json.loads(upstream_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    upstream = {}
+parts = tuple(int(part) if part.isdigit() else part for part in version.split("."))
+content = f'''# Auto-generated for the pinned official benchmark worktree.
+__version__ = version = {version!r}
+__version_tuple__ = version_tuple = {parts!r}
+__upstream_version__ = upstream_version = {upstream.get("upstream_version")!r}
+__upstream_commit__ = upstream_commit = {upstream.get("upstream_commit")!r}
+__commit_id__ = commit_id = {commit[:8]!r}
+'''
+version_file.write_text(content, encoding="utf-8")
+PY
+}
+
 ensure_vllm_source_metadata() {
   local version=${OFFICIAL_VLLM_REF#v}
   local dist_info_dir
@@ -174,6 +208,8 @@ EOF
   cat > "$dist_info_dir/top_level.txt" <<'EOF'
 vllm
 EOF
+
+  write_source_version_metadata "$OFFICIAL_VLLM_WORKTREE" vllm "$version"
 }
 
 ensure_vllm_ascend_plugin_metadata() {
@@ -265,6 +301,8 @@ __soc_version__ = '$OFFICIAL_SOC_VERSION'
 __sleep_mode_enabled__ = $sleep_mode_enabled_literal
 __device_type__ = '$device_type'
 EOF
+
+  write_source_version_metadata "$OFFICIAL_VLLM_ASCEND_WORKTREE" vllm_ascend "$version"
 
   OFFICIAL_EXPECTED_PLATFORM_PLUGINS=$(printf '%s\n' "${platform_entries[@]}" | sed 's/[[:space:]]*=.*$//' | paste -sd, -)
   OFFICIAL_EXPECTED_GENERAL_PLUGINS=$(printf '%s\n' "${general_entries[@]}" | sed 's/[[:space:]]*=.*$//' | paste -sd, -)

--- a/scripts/run-official-ascend-goal-baseline.sh
+++ b/scripts/run-official-ascend-goal-baseline.sh
@@ -8,6 +8,7 @@ VLLM_CLI_COMPAT=${VLLM_CLI_COMPAT:-"$REPO_ROOT/scripts/run_vllm_cli_compat.py"}
 COLLECT_ARTIFACT_SCRIPT=${COLLECT_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/collect-run-artifact.sh"}
 VALIDATE_ARTIFACT_SCRIPT=${VALIDATE_ARTIFACT_SCRIPT:-"$REPO_ROOT/scripts/validate-run-artifact.sh"}
 CAPTURE_SOURCE_PROVENANCE_SCRIPT=${CAPTURE_SOURCE_PROVENANCE_SCRIPT:-"$REPO_ROOT/scripts/capture-official-source-provenance.py"}
+CAPTURE_RUNTIME_PROVENANCE_SCRIPT=${CAPTURE_RUNTIME_PROVENANCE_SCRIPT:-"$REPO_ROOT/scripts/capture-official-runtime-provenance.py"}
 SPEC_FILE=${1:-"$REPO_ROOT/docs/official-baselines/official-ascend-jan-2026-v0180-random-online-qwen25-14b-910b2.json"}
 CONSTRAINTS_FILE=${CONSTRAINTS_FILE:-"$REPO_ROOT/docs/official-baselines/official-ascend-constraints.stub.json"}
 WORKSPACE_ROOT=${VLLM_HUST_WORKSPACE_ROOT:-$(cd "$REPO_ROOT/.." && pwd)}
@@ -100,6 +101,11 @@ fi
 
 if [[ ! -f "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" ]]; then
   echo "Official source provenance helper not found: $CAPTURE_SOURCE_PROVENANCE_SCRIPT" >&2
+  exit 2
+fi
+
+if [[ ! -f "$CAPTURE_RUNTIME_PROVENANCE_SCRIPT" ]]; then
+  echo "Official runtime provenance helper not found: $CAPTURE_RUNTIME_PROVENANCE_SCRIPT" >&2
   exit 2
 fi
 
@@ -1612,6 +1618,8 @@ ensure_worktree "$OFFICIAL_VLLM_ASCEND_REPO" "$OFFICIAL_VLLM_ASCEND_WORKTREE" "$
 
 SOURCE_PROVENANCE_DIR="$RESULT_DIR/source-provenance"
 SOURCE_PROVENANCE_FILE="$SOURCE_PROVENANCE_DIR/official-source-provenance.json"
+RUNTIME_PROVENANCE_FILE="$SOURCE_PROVENANCE_DIR/official-runtime-provenance.json"
+RUNTIME_PROVENANCE_AFTER_FILE="$SOURCE_PROVENANCE_DIR/official-runtime-provenance-after.json"
 mkdir -p "$SOURCE_PROVENANCE_DIR"
 "$HOST_PYTHON_BIN" - "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" \
   "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF" \
@@ -1701,6 +1709,22 @@ fi
 if ! is_valid_engine_version "$OFFICIAL_BACKEND_VERSION"; then
   OFFICIAL_BACKEND_VERSION="$ENGINE_VERSION"
 fi
+
+capture_official_runtime_provenance() {
+  local output_file=$1
+  run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" \
+    "$OFFICIAL_RUNTIME_PYTHON" "$CAPTURE_RUNTIME_PROVENANCE_SCRIPT" \
+      --engine-worktree "$OFFICIAL_VLLM_WORKTREE" \
+      --engine-commit "$OFFICIAL_CORE_SOURCE_COMMIT" \
+      --plugin-worktree "$OFFICIAL_VLLM_ASCEND_WORKTREE" \
+      --plugin-commit "$OFFICIAL_BACKEND_SOURCE_COMMIT" \
+      --source-provenance "$SOURCE_PROVENANCE_FILE" \
+      --output "$output_file"
+}
+
+# Fail before model loading when Python or compiled extensions resolve outside
+# the immutable worktrees prepared for this official run.
+capture_official_runtime_provenance "$RUNTIME_PROVENANCE_FILE"
 
 RUNTIME_MODEL="$MODEL"
 cached_model_status=0
@@ -1849,6 +1873,12 @@ esac
 echo "[goal-baseline] client command: $CLIENT_COMMAND"
 run_client_command
 
+capture_official_runtime_provenance "$RUNTIME_PROVENANCE_AFTER_FILE"
+if ! cmp -s "$RUNTIME_PROVENANCE_FILE" "$RUNTIME_PROVENANCE_AFTER_FILE"; then
+  echo "official runtime provenance changed during benchmark" >&2
+  exit 2
+fi
+
 "$HOST_PYTHON_BIN" "$CAPTURE_SOURCE_PROVENANCE_SCRIPT" \
   "$OFFICIAL_VLLM_WORKTREE" "$OFFICIAL_CORE_SOURCE_REF" \
   "$OFFICIAL_CORE_SOURCE_REPOSITORY" "$SOURCE_PROVENANCE_DIR/engine-after.json"
@@ -1912,17 +1942,38 @@ append_export_arg_from_spec --batch-size '.client_parameters.batch_size'
 
 run_in_official_runtime "$REPO_ROOT/src:$OFFICIAL_RUNTIME_PYTHONPATH" "${EXPORT_ARGS[@]}"
 
-"$HOST_PYTHON_BIN" - "$ARTIFACT_DIR/run_leaderboard.json" "$SOURCE_PROVENANCE_FILE" <<'PY'
+"$HOST_PYTHON_BIN" - \
+  "$ARTIFACT_DIR/run_leaderboard.json" \
+  "$ARTIFACT_DIR/leaderboard_manifest.json" \
+  "$SOURCE_PROVENANCE_FILE" \
+  "$RUNTIME_PROVENANCE_FILE" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-artifact_path, provenance_path = map(Path, sys.argv[1:])
+artifact_path, manifest_path, source_path, runtime_path = map(Path, sys.argv[1:])
 artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
-provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+source = json.loads(source_path.read_text(encoding="utf-8"))
+runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
 metadata = artifact.setdefault("metadata", {})
-metadata["official_source_provenance"] = provenance
+runtime_engine = (runtime.get("sources") or {}).get("engine") or {}
+runtime_versions = {
+    runtime_engine.get("module_version"),
+    runtime_engine.get("distribution_version"),
+}
+recorded_versions = {artifact.get("engine_version"), metadata.get("engine_version")}
+if None in runtime_versions or "" in runtime_versions or recorded_versions != runtime_versions:
+    raise SystemExit(
+        "recorded engine_version does not match imported runtime package: "
+        f"recorded={sorted(str(value) for value in recorded_versions)}, "
+        f"runtime={sorted(str(value) for value in runtime_versions)}"
+    )
+metadata["official_source_provenance"] = source
+metadata["official_runtime_provenance"] = runtime
+manifest["official_runtime_provenance"] = runtime
 artifact_path.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 PY
 
 CURRENT_RUNTIME_PYTHON="$OFFICIAL_RUNTIME_PYTHON" \
@@ -1931,22 +1982,34 @@ CURRENT_VLLM_ASCEND_HUST_REPO="$OFFICIAL_VLLM_ASCEND_WORKTREE" \
 CURRENT_GIT_COMMIT="$OFFICIAL_CORE_SOURCE_COMMIT" \
 CURRENT_PLUGIN_GIT_COMMIT="$OFFICIAL_BACKEND_SOURCE_COMMIT" \
 OFFICIAL_SOURCE_PROVENANCE_FILE="$SOURCE_PROVENANCE_FILE" \
+OFFICIAL_RUNTIME_PROVENANCE_FILE="$RUNTIME_PROVENANCE_FILE" \
 bash "$COLLECT_ARTIFACT_SCRIPT" "$ARTIFACT_DIR"
 
-"$HOST_PYTHON_BIN" - "$ARTIFACT_DIR" "$SOURCE_PROVENANCE_FILE" <<'PY'
+"$HOST_PYTHON_BIN" - \
+  "$ARTIFACT_DIR" "$SOURCE_PROVENANCE_FILE" "$RUNTIME_PROVENANCE_FILE" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-artifact_dir, provenance_path = map(Path, sys.argv[1:])
-expected = json.loads(provenance_path.read_text(encoding="utf-8"))
+artifact_dir, source_path, runtime_path = map(Path, sys.argv[1:])
+expected_source = json.loads(source_path.read_text(encoding="utf-8"))
+expected_runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
 artifact = json.loads((artifact_dir / "run_leaderboard.json").read_text(encoding="utf-8"))
-manifest = json.loads((artifact_dir / "env-manifest.json").read_text(encoding="utf-8"))
-artifact_value = (artifact.get("metadata") or {}).get("official_source_provenance")
-manifest_value = manifest.get("official_source_provenance")
-if artifact_value != expected or manifest_value != expected:
+leaderboard_manifest = json.loads((artifact_dir / "leaderboard_manifest.json").read_text(encoding="utf-8"))
+env_manifest = json.loads((artifact_dir / "env-manifest.json").read_text(encoding="utf-8"))
+metadata = artifact.get("metadata") or {}
+if metadata.get("official_source_provenance") != expected_source or env_manifest.get("official_source_provenance") != expected_source:
     raise SystemExit("official source provenance mismatch between artifact, manifest, and capture")
-for role, source in expected.get("sources", {}).items():
+if any(
+    value != expected_runtime
+    for value in (
+        metadata.get("official_runtime_provenance"),
+        leaderboard_manifest.get("official_runtime_provenance"),
+        env_manifest.get("official_runtime_provenance"),
+    )
+):
+    raise SystemExit("official runtime provenance mismatch between artifact, manifests, and capture")
+for role, source in expected_source.get("sources", {}).items():
     if source.get("status") == "modified" and not source.get("tracked_patch_sha256"):
         raise SystemExit(f"{role} source is modified without tracked patch provenance")
 PY

--- a/scripts/validate-run-artifact.sh
+++ b/scripts/validate-run-artifact.sh
@@ -212,6 +212,86 @@ PY
       echo "  $OFFICIAL_SOURCE_ERRORS" >&2
       check "official source provenance is complete" 1
     fi
+
+    OFFICIAL_RUNTIME_ERRORS=$(python3 - <<'PY' || echo "parse-error"
+import json
+from pathlib import Path
+
+env_manifest = json.load(open("env-manifest.json", encoding="utf-8"))
+artifact = (
+    json.load(open("run_leaderboard.json", encoding="utf-8"))
+    if Path("run_leaderboard.json").is_file()
+    else {}
+)
+leaderboard_manifest = (
+    json.load(open("leaderboard_manifest.json", encoding="utf-8"))
+    if Path("leaderboard_manifest.json").is_file()
+    else {}
+)
+values = {
+    "artifact": (artifact.get("metadata") or {}).get("official_runtime_provenance"),
+    "leaderboard_manifest": leaderboard_manifest.get("official_runtime_provenance"),
+    "env_manifest": env_manifest.get("official_runtime_provenance"),
+}
+if not any(values.values()):
+    raise SystemExit(0)
+
+errors = []
+for location, value in values.items():
+    if not value:
+        errors.append(f"official_runtime_provenance missing from {location}")
+if len({json.dumps(value, sort_keys=True) for value in values.values()}) != 1:
+    errors.append("official_runtime_provenance differs across artifact and manifests")
+
+payload = next((value for value in values.values() if value), {})
+if payload.get("schema_version") != "official-runtime-provenance/v1":
+    errors.append("unsupported official runtime provenance schema")
+for field in ("python_executable", "python_version"):
+    if not payload.get(field):
+        errors.append(f"official_runtime_provenance.{field} is empty")
+for role in ("engine", "plugin"):
+    source = (payload.get("sources") or {}).get(role) or {}
+    for field in (
+        "module",
+        "module_path",
+        "module_version",
+        "distribution",
+        "distribution_version",
+        "prepared_worktree",
+        "prepared_commit",
+        "source_version",
+        "extension_policy",
+        "source_patch_sha256",
+        "source_tree_sha256",
+        "source_status",
+    ):
+        if not source.get(field):
+            errors.append(f"official_runtime_provenance.{role}.{field} is empty")
+    extensions = source.get("extensions")
+    if source.get("extension_policy") not in ("present", "none-discovered"):
+        errors.append(f"official_runtime_provenance.{role}.extension_policy is invalid")
+    if not isinstance(extensions, list):
+        errors.append(f"official_runtime_provenance.{role}.extensions is not a list")
+    elif bool(extensions) != (source.get("extension_policy") == "present"):
+        errors.append(
+            f"official_runtime_provenance.{role}.extension_policy does not match extensions"
+        )
+    else:
+        for index, extension in enumerate(extensions):
+            for field in ("module", "status", "path", "sha256"):
+                if not (extension or {}).get(field):
+                    errors.append(
+                        f"official_runtime_provenance.{role}.extensions[{index}].{field} is empty"
+                    )
+print("; ".join(errors))
+PY
+)
+    if [[ -z "$OFFICIAL_RUNTIME_ERRORS" ]]; then
+      check "official runtime provenance is complete and consistent" 0
+    else
+      echo "  $OFFICIAL_RUNTIME_ERRORS" >&2
+      check "official runtime provenance is complete and consistent" 1
+    fi
   else
     check "env-manifest.json is valid JSON" 1
   fi

--- a/tests/test_campaign_collection_scripts.py
+++ b/tests/test_campaign_collection_scripts.py
@@ -569,6 +569,95 @@ def test_validator_reports_frozen_input_parser_failure_and_continues(
     assert "validation error(s)" in result.stderr
 
 
+def test_validator_rejects_mismatched_official_runtime_provenance(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    runtime = {
+        "schema_version": "official-runtime-provenance/v1",
+        "python_executable": "/runtime/bin/python",
+        "python_version": "3.12.0",
+        "sources": {
+            role: {
+                "module": module,
+                "module_path": f"/prepared/{module}/__init__.py",
+                "module_version": "1.2.3",
+                "distribution": distribution,
+                "distribution_version": "1.2.3",
+                "prepared_worktree": f"/prepared/{module}",
+                "prepared_commit": commit * 40,
+                "source_version": "v1.2.3",
+                "extension_policy": "none-discovered",
+                "source_patch_sha256": "d" * 64,
+                "source_tree_sha256": "e" * 64,
+                "source_status": "clean",
+                "extensions": [],
+            }
+            for role, module, distribution, commit in (
+                ("engine", "vllm", "vllm", "a"),
+                ("plugin", "vllm_ascend", "vllm-ascend", "b"),
+            )
+        },
+    }
+    (artifact / "STATUS").write_text("OK\n", encoding="utf-8")
+    (artifact / "run_leaderboard.json").write_text(
+        json.dumps({"metadata": {"official_runtime_provenance": runtime}}) + "\n",
+        encoding="utf-8",
+    )
+    stale_runtime = json.loads(json.dumps(runtime))
+    stale_runtime["sources"]["engine"]["prepared_commit"] = "c" * 40
+    (artifact / "leaderboard_manifest.json").write_text(
+        json.dumps(
+            {
+                "entries": [{"leaderboard_artifact": "run_leaderboard.json"}],
+                "official_runtime_provenance": stale_runtime,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (artifact / "env-manifest.json").write_text(
+        json.dumps(
+            {
+                "os": "test",
+                "python_version": "test",
+                "collected_at": "2026-08-13T00:00:00Z",
+                "frozen_inputs_required": False,
+                "official_runtime_provenance": runtime,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    checksums = subprocess.run(
+        [
+            "sha256sum",
+            "run_leaderboard.json",
+            "leaderboard_manifest.json",
+            "env-manifest.json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=artifact,
+    ).stdout
+    (artifact / "checksums.sha256").write_text(checksums, encoding="utf-8")
+
+    result = subprocess.run(
+        [bash_executable(), str(VALIDATOR), str(artifact)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode > 0
+    assert "official_runtime_provenance differs across artifact and manifests" in (
+        result.stderr
+    )
+    assert "official runtime provenance is complete and consistent" in result.stderr
+
+
 def test_validator_resolves_repo_before_changing_to_artifact_dir(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_official_baseline_matrix_script.py
+++ b/tests/test_official_baseline_matrix_script.py
@@ -396,6 +396,18 @@ def test_official_runner_finalizes_and_validates_exported_artifact() -> None:
     assert (
         'CURRENT_VLLM_ASCEND_HUST_REPO="$OFFICIAL_VLLM_ASCEND_WORKTREE"' in runner_text
     )
+    assert (
+        'capture_official_runtime_provenance "$RUNTIME_PROVENANCE_FILE"' in runner_text
+    )
+    assert (
+        'capture_official_runtime_provenance "$RUNTIME_PROVENANCE_AFTER_FILE"'
+        in runner_text
+    )
+    assert 'metadata["official_runtime_provenance"] = runtime' in runner_text
+    assert 'manifest["official_runtime_provenance"] = runtime' in runner_text
+    assert (
+        "recorded engine_version does not match imported runtime package" in runner_text
+    )
 
 
 def test_official_workflow_defaults_live_publication_off() -> None:

--- a/tests/test_official_runtime_provenance.py
+++ b/tests/test_official_runtime_provenance.py
@@ -1,0 +1,224 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "scripts/capture-official-runtime-provenance.py"
+
+
+@pytest.fixture(autouse=True)
+def _clear_fake_runtime_modules():
+    for name in ("vllm", "vllm_ascend"):
+        sys.modules.pop(name, None)
+    yield
+    for name in ("vllm", "vllm_ascend"):
+        sys.modules.pop(name, None)
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("official_runtime_provenance", HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _source_repo(tmp_path: Path, package: str, version: str) -> tuple[Path, str]:
+    repo = tmp_path / package
+    module_dir = repo / package
+    module_dir.mkdir(parents=True)
+    (module_dir / "__init__.py").write_text(
+        f"__version__ = {version!r}\n", encoding="utf-8"
+    )
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "tag", f"v{version}")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_clean_prepared_worktree_runtime_pair_passes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    helper = _load_helper()
+    engine_repo, engine_commit = _source_repo(tmp_path, "vllm", "1.2.3")
+    plugin_repo, plugin_commit = _source_repo(tmp_path, "vllm_ascend", "4.5.6")
+    monkeypatch.syspath_prepend(str(plugin_repo))
+    monkeypatch.syspath_prepend(str(engine_repo))
+    monkeypatch.setattr(
+        helper,
+        "_distribution_version",
+        lambda names: (names[0], "1.2.3" if names[0] == "vllm" else "4.5.6"),
+    )
+
+    payload = helper.capture(engine_repo, engine_commit, plugin_repo, plugin_commit)
+
+    assert payload["schema_version"] == "official-runtime-provenance/v1"
+    assert payload["sources"]["engine"]["prepared_commit"] == engine_commit
+    assert payload["sources"]["plugin"]["prepared_commit"] == plugin_commit
+    assert payload["sources"]["engine"]["module_path"].startswith(str(engine_repo))
+    assert payload["sources"]["plugin"]["module_path"].startswith(str(plugin_repo))
+
+
+def test_runtime_evidence_binds_source_tree_and_patch_digests(
+    tmp_path: Path, monkeypatch
+) -> None:
+    helper = _load_helper()
+    engine_repo, engine_commit = _source_repo(tmp_path, "vllm", "1.2.3")
+    plugin_repo, plugin_commit = _source_repo(tmp_path, "vllm_ascend", "4.5.6")
+    monkeypatch.syspath_prepend(str(plugin_repo))
+    monkeypatch.syspath_prepend(str(engine_repo))
+    monkeypatch.setattr(
+        helper,
+        "_distribution_version",
+        lambda names: (names[0], "1.2.3" if names[0] == "vllm" else "4.5.6"),
+    )
+    source_provenance = {
+        "schema_version": "official-source-provenance/v1",
+        "sources": {
+            "engine": {
+                "observed_commit": engine_commit,
+                "tracked_patch_sha256": "a" * 64,
+                "working_tree_sha256": "b" * 64,
+                "status": "clean",
+            },
+            "plugin": {
+                "observed_commit": plugin_commit,
+                "tracked_patch_sha256": "c" * 64,
+                "working_tree_sha256": "d" * 64,
+                "status": "modified",
+            },
+        },
+    }
+
+    payload = helper.capture(
+        engine_repo,
+        engine_commit,
+        plugin_repo,
+        plugin_commit,
+        source_provenance,
+    )
+
+    assert payload["sources"]["engine"]["source_tree_sha256"] == "b" * 64
+    assert payload["sources"]["plugin"]["source_patch_sha256"] == "c" * 64
+    assert payload["sources"]["plugin"]["source_status"] == "modified"
+
+
+def test_stale_editable_module_path_is_rejected(tmp_path: Path, monkeypatch) -> None:
+    helper = _load_helper()
+    prepared_repo, prepared_commit = _source_repo(
+        tmp_path / "prepared", "vllm", "1.2.3"
+    )
+    stale_repo, _ = _source_repo(tmp_path / "stale", "vllm", "1.2.3")
+    monkeypatch.syspath_prepend(str(stale_repo))
+    monkeypatch.setattr(
+        helper, "_distribution_version", lambda names: (names[0], "1.2.3")
+    )
+
+    try:
+        helper.capture_role("engine", prepared_repo, prepared_commit)
+    except ValueError as error:
+        assert "module path mismatch" in str(error)
+        assert str(stale_repo) in str(error)
+    else:
+        raise AssertionError("stale editable module path was accepted")
+
+
+def test_module_and_distribution_version_mismatch_is_rejected(
+    tmp_path: Path, monkeypatch
+) -> None:
+    helper = _load_helper()
+    engine_repo, engine_commit = _source_repo(tmp_path, "vllm", "1.2.3")
+    monkeypatch.syspath_prepend(str(engine_repo))
+    monkeypatch.setattr(
+        helper, "_distribution_version", lambda names: (names[0], "1.2.4")
+    )
+
+    try:
+        helper.capture_role("engine", engine_repo, engine_commit)
+    except ValueError as error:
+        assert "runtime version mismatch" in str(error)
+    else:
+        raise AssertionError("mismatched runtime package versions were accepted")
+
+
+def test_generated_module_commit_mismatch_is_rejected(
+    tmp_path: Path, monkeypatch
+) -> None:
+    helper = _load_helper()
+    engine_repo, engine_commit = _source_repo(tmp_path, "vllm", "1.2.3")
+    monkeypatch.syspath_prepend(str(engine_repo))
+    monkeypatch.setattr(
+        helper, "_distribution_version", lambda names: (names[0], "1.2.3")
+    )
+    module = __import__("vllm")
+    module.__commit_id__ = "f" * 8
+
+    try:
+        helper.capture_role("engine", engine_repo, engine_commit)
+    except ValueError as error:
+        assert "runtime build commit mismatch" in str(error)
+    else:
+        raise AssertionError("mismatched generated module commit was accepted")
+
+
+def test_generated_module_commit_proves_untagged_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    helper = _load_helper()
+    engine_repo, engine_commit = _source_repo(tmp_path, "vllm", "1.2.3")
+    _git(engine_repo, "tag", "--delete", "v1.2.3")
+    monkeypatch.syspath_prepend(str(engine_repo))
+    monkeypatch.setattr(
+        helper, "_distribution_version", lambda names: (names[0], "1.2.3")
+    )
+    module = __import__("vllm")
+    module.__commit_id__ = engine_commit[:8]
+
+    payload = helper.capture_role("engine", engine_repo, engine_commit)
+
+    assert payload["source_version"] == engine_commit[:7]
+    assert payload["module_commit"] == engine_commit[:8]
+
+
+def test_cli_does_not_write_output_after_validation_failure(tmp_path: Path) -> None:
+    output = tmp_path / "runtime.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HELPER),
+            "--engine-worktree",
+            str(tmp_path / "missing-engine"),
+            "--engine-commit",
+            "a" * 40,
+            "--plugin-worktree",
+            str(tmp_path / "missing-plugin"),
+            "--plugin-commit",
+            "b" * 40,
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "official runtime provenance validation failed" in result.stderr
+    assert not output.exists()

--- a/tests/test_official_source_provenance.py
+++ b/tests/test_official_source_provenance.py
@@ -76,3 +76,36 @@ def test_capture_includes_ignored_generated_runtime_inputs(tmp_path: Path) -> No
     )
     second = json.loads(second_output.read_text(encoding="utf-8"))
     assert second["working_tree_sha256"] != first["working_tree_sha256"]
+
+
+def test_capture_includes_ignored_compiled_extensions(tmp_path: Path) -> None:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / ".gitignore").write_text("*.so\n", encoding="utf-8")
+    (repo / "tracked.txt").write_text("stable\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    extension = repo / "vllm_ascend" / "vllm_ascend_C.test.so"
+    extension.parent.mkdir()
+    extension.write_bytes(b"first-build")
+
+    first_output = tmp_path / "first-extension.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(first_output)],
+        check=True,
+    )
+    first = json.loads(first_output.read_text(encoding="utf-8"))
+    assert first["status"] == "modified"
+    assert first["generated_file_count"] == 1
+
+    extension.write_bytes(b"stale-or-replaced-build")
+    second_output = tmp_path / "second-extension.json"
+    subprocess.run(
+        [str(HELPER), str(repo), "main", "example/source", str(second_output)],
+        check=True,
+    )
+    second = json.loads(second_output.read_text(encoding="utf-8"))
+    assert second["working_tree_sha256"] != first["working_tree_sha256"]

--- a/tests/test_prepare_official_env_script.py
+++ b/tests/test_prepare_official_env_script.py
@@ -1057,6 +1057,33 @@ def test_ensure_vllm_ascend_plugin_metadata_writes_entry_points(tmp_path: Path) 
         "}\n",
         encoding="utf-8",
     )
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(worktree_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "config", "user.name", "Test User"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(worktree_dir), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "commit", "-m", "initial"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = subprocess.run(
+        ["git", "-C", str(worktree_dir), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
     result = _run_bash(
         _source_prepare_functions(
@@ -1076,6 +1103,56 @@ def test_ensure_vllm_ascend_plugin_metadata_writes_entry_points(tmp_path: Path) 
             grep -Fq 'vllm_ascend' "$dist_info_dir/top_level.txt"
             grep -Fq "__soc_version__ = 'ascend910b3'" {shlex.quote(str(worktree_dir))}/vllm_ascend/_build_info.py
             grep -Fq '__sleep_mode_enabled__ = False' {shlex.quote(str(worktree_dir))}/vllm_ascend/_build_info.py
+            grep -Fq "__version__ = version = '0.11.0'" {shlex.quote(str(worktree_dir))}/vllm_ascend/_version.py
+            grep -Fq "__commit_id__ = commit_id = '{commit[:8]}'" {shlex.quote(str(worktree_dir))}/vllm_ascend/_version.py
+            """
+        )
+    )
+
+    assert result.returncode == 0
+
+
+def test_ensure_vllm_source_metadata_writes_version_and_commit(tmp_path: Path) -> None:
+    worktree_dir = tmp_path / "vllm-worktree"
+    (worktree_dir / "vllm").mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(worktree_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "config", "user.name", "Test User"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    (worktree_dir / "vllm" / "__init__.py").write_text("", encoding="utf-8")
+    subprocess.run(["git", "-C", str(worktree_dir), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(worktree_dir), "commit", "-m", "initial"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = subprocess.run(
+        ["git", "-C", str(worktree_dir), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    result = _run_bash(
+        _source_prepare_functions(
+            f"""
+            OFFICIAL_VLLM_WORKTREE={shlex.quote(str(worktree_dir))}
+            OFFICIAL_VLLM_REF=v0.18.0
+            ensure_vllm_source_metadata
+            grep -Fq 'Version: 0.18.0' {shlex.quote(str(worktree_dir))}/vllm-0.18.0.dist-info/METADATA
+            grep -Fq "__version__ = version = '0.18.0'" {shlex.quote(str(worktree_dir))}/vllm/_version.py
+            grep -Fq "__commit_id__ = commit_id = '{commit[:8]}'" {shlex.quote(str(worktree_dir))}/vllm/_version.py
             """
         )
     )

--- a/tests/test_sync_official_baseline_snapshots_to_github.py
+++ b/tests/test_sync_official_baseline_snapshots_to_github.py
@@ -17,6 +17,7 @@ SYNC_SCRIPT = (
     / "scripts"
     / "sync_official_baseline_snapshots_to_github.sh"
 )
+ARTIFACT_VALIDATOR = REPO_ROOT / "scripts" / "validate-run-artifact.sh"
 
 
 def _script_env(**overrides: str) -> dict[str, str]:
@@ -90,6 +91,65 @@ def _write_submission(source_repo: Path, run_id: str, model_name: str) -> None:
         encoding="utf-8",
     )
     (submission_dir / "STATUS").write_text("OK\n", encoding="utf-8")
+
+
+def _add_mismatched_runtime_provenance(submission_dir: Path) -> None:
+    runtime = {
+        "schema_version": "official-runtime-provenance/v1",
+        "python_executable": "/runtime/bin/python",
+        "python_version": "3.12.0",
+        "sources": {
+            role: {
+                "module": module,
+                "module_path": f"/prepared/{module}/__init__.py",
+                "module_version": "1.2.3",
+                "distribution": distribution,
+                "distribution_version": "1.2.3",
+                "prepared_worktree": f"/prepared/{module}",
+                "prepared_commit": commit * 40,
+                "source_version": "v1.2.3",
+                "extension_policy": "none-discovered",
+                "source_patch_sha256": "d" * 64,
+                "source_tree_sha256": "e" * 64,
+                "source_status": "clean",
+                "extensions": [],
+            }
+            for role, module, distribution, commit in (
+                ("engine", "vllm", "vllm", "a"),
+                ("plugin", "vllm_ascend", "vllm-ascend", "b"),
+            )
+        },
+    }
+    artifact_path = submission_dir / "run_leaderboard.json"
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    artifact.setdefault("metadata", {})["official_runtime_provenance"] = runtime
+    artifact_path.write_text(json.dumps(artifact) + "\n", encoding="utf-8")
+
+    env_path = submission_dir / "env-manifest.json"
+    env_manifest = json.loads(env_path.read_text(encoding="utf-8"))
+    env_manifest["official_runtime_provenance"] = runtime
+    env_path.write_text(json.dumps(env_manifest) + "\n", encoding="utf-8")
+
+    stale_runtime = json.loads(json.dumps(runtime))
+    stale_runtime["sources"]["engine"]["prepared_commit"] = "c" * 40
+    manifest_path = submission_dir / "leaderboard_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["official_runtime_provenance"] = stale_runtime
+    manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    checksum_files = (
+        "leaderboard_manifest.json",
+        "run_leaderboard.json",
+        "env-manifest.json",
+        "pip-packages.json",
+    )
+    (submission_dir / "checksums.sha256").write_text(
+        "".join(
+            f"{hashlib.sha256((submission_dir / name).read_bytes()).hexdigest()}  ./{name}\n"
+            for name in checksum_files
+        ),
+        encoding="utf-8",
+    )
 
 
 def _create_artifact_validator(tmp_path: Path) -> Path:
@@ -384,6 +444,43 @@ def test_sync_verification_rejects_remote_content_mismatch(tmp_path: Path) -> No
     completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
     assert completed.returncode != 0
     assert "content mismatch" in completed.stderr
+
+
+def test_sync_rejects_runtime_provenance_mismatch_before_snapshot_write(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "benchmark-source"
+    source_repo.mkdir()
+    run_id = "official-ascend-jan-2026-v0.11.0-random-online-qwen25-14b-910b3"
+    _write_submission(source_repo, run_id, "Qwen2.5-14B-Instruct")
+    _add_mismatched_runtime_provenance(source_repo / "submissions" / run_id)
+    remote_repo, target_repo = _create_target_repo(tmp_path)
+    website_repo = _create_dummy_website_repo(tmp_path)
+    original_head = _git(target_repo, "rev-parse", "HEAD").stdout.strip()
+    env = _script_env(
+        ALLOW_LOCAL_GIT_RESET="1",
+        SOURCE_BENCHMARK_REPO_DIR=str(source_repo),
+        TARGET_BENCHMARK_REPO_DIR=str(target_repo),
+        WEBSITE_REPO_DIR=str(website_repo),
+        PYTHON_BIN=_create_fake_python(tmp_path),
+        ARTIFACT_VALIDATOR=str(ARTIFACT_VALIDATOR),
+    )
+
+    completed = _run(["bash", str(SYNC_SCRIPT)], env=env, check=False)
+
+    assert completed.returncode != 0
+    assert "official_runtime_provenance differs across artifact and manifests" in (
+        completed.stderr
+    )
+    assert "source submission artifact validation failed" in completed.stderr
+    assert _git(target_repo, "rev-parse", "HEAD").stdout.strip() == original_head
+    assert (
+        _run(
+            ["git", f"--git-dir={remote_repo}", "rev-parse", "refs/heads/main"]
+        ).stdout.strip()
+        == original_head
+    )
+    assert not (target_repo / "submissions" / run_id).exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

  Harden official Ascend baseline collection and artifact admission against mixed or stale runtime environments.

  This PR:

  - Captures runtime provenance for imported `vllm` and `vllm_ascend` modules;
  - Records package versions, generated build metadata, source commit IDs, and discovered compiled extensions;
  - Verifies that the imported runtime matches the pinned source worktrees before benchmark execution;
  - Repeats provenance capture after the benchmark and fails closed if the runtime changes;
  - Stores the same `official_runtime_provenance` in `run_leaderboard.json`, `leaderboard_manifest.json`, and `env-manifest.json`;
  - Validates the provenance before official snapshots are generated or published;
  - Preserves readability of historical artifacts that do not contain the new field.

  This prevents official benchmark evidence from being produced with a stale installed package, mismatched source checkout, or
  compiled extension from an unintended build.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [x] `vllm-hust-benchmark`
  - [ ] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - Targeted provenance and campaign test suite:
    ```bash
    PYTHONPATH=.:src pytest -q \
      tests/test_campaign_collection_scripts.py \
      tests/test_official_baseline_matrix_script.py \
      tests/test_official_runtime_provenance.py \
      tests/test_official_source_provenance.py \
      tests/test_prepare_official_env_script.py \
      tests/test_sync_official_baseline_snapshots_to_github.py

  Result: 68 passed; 2 process-tree tests were environment-dependent failures on macOS.

  - ruff check
  - ruff format --check
  - Bash syntax checks for the modified scripts
  - git diff --check

  No real Ascend NPU benchmark, leaderboard publication, or HF synchronization was executed.

  ## Risks

  - The new provenance checks intentionally reject stale, mixed, or incomplete runtime environments.
  - Official artifact generation may fail on runners where package metadata, build metadata, or compiled extension discovery is
    unavailable or inconsistent.

  - Historical artifacts without official_runtime_provenance remain readable, but newly captured official evidence must include it.
  - No public serving API, model behavior, or runtime performance path is changed.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [x] I updated docs if user-facing behavior changed. The official baseline runner documentation was updated.
  - [x] I noted the tests I ran, including the macOS-specific process-tree test limitation.