### PR TITLE
fix(runtime): support official v0.23 benchmark images

### DIFF
--- a/docker/Dockerfile.vllm-ascend-v023-bench
+++ b/docker/Dockerfile.vllm-ascend-v023-bench
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=quay.io/ascend/vllm-ascend:v0.23.0-openeuler
+FROM ${BASE_IMAGE}
+
+# Preserve the engine, CANN, torch-npu, and packaged custom operators from the
+# selected runtime image. Add only the versioned clients required by official
+# HF-backed and prefix-caching benchmark contracts.
+RUN python -m pip install --no-cache-dir \
+    "datasets==3.3.0" \
+    "xxhash==3.6.0"

--- a/docker/Dockerfile.vllm-v018-on-ascend-v023
+++ b/docker/Dockerfile.vllm-v018-on-ascend-v023
@@ -1,0 +1,40 @@
+FROM codex/vllm-ascend-strict-baseline:0.18.0-xxhash3.6.0-datasets3.3.0 AS v018-python
+
+FROM quay.io/ascend/vllm-ascend:v0.23.0-openeuler
+
+ARG VLLM_CORE_COMMIT
+ARG VLLM_ASCEND_COMMIT
+
+LABEL org.opencontainers.image.description="vLLM v0.18 source rebuilt against the official Ascend v0.23 runtime"
+LABEL org.opencontainers.image.vllm-core-commit="${VLLM_CORE_COMMIT}"
+LABEL org.opencontainers.image.vllm-ascend-commit="${VLLM_ASCEND_COMMIT}"
+
+COPY vllm-core /opt/vllm-v018
+COPY vllm-ascend /opt/vllm-ascend-v018
+COPY driver-build-libs/libascend_hal.so /usr/local/Ascend/driver/lib64/driver/libascend_hal.so
+COPY --from=v018-python /usr/local/python3.11.14 /usr/local/python3.11.14
+
+# CANN 9.1 renamed this runtime enum. Keep the v0.18 Triton implementation
+# unchanged apart from the required SDK spelling update, and fail if the
+# expected old spelling is not present exactly once.
+RUN test "$(grep -c 'RT_LIMIT_TYPE_SIMT_WARP_STACK_SIZE' /usr/local/python3.11.14/lib/python3.11/site-packages/triton/backends/ascend/npu_utils.cpp)" = 1 && \
+    sed -i 's/RT_LIMIT_TYPE_SIMT_WARP_STACK_SIZE/RT_LIMIT_TYPE_SIMT_DVG_WARP_STACK_SIZE/' /usr/local/python3.11.14/lib/python3.11/site-packages/triton/backends/ascend/npu_utils.cpp
+
+ENV VLLM_VERSION_OVERRIDE=0.18.0 \
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.18.0 \
+    VLLM_TARGET_DEVICE=empty \
+    COMPILE_CUSTOM_KERNELS=1 \
+    SOC_VERSION=ascend910b2 \
+    Torch_DIR=/usr/local/python3.11.14/lib/python3.11/site-packages/torch/share/cmake/Torch \
+    PATH=/usr/local/python3.11.14/bin:${PATH}
+
+RUN TORCH_DEVICE_BACKEND_AUTOLOAD=0 /usr/local/python3.11.14/bin/python -m pip install --no-build-isolation --no-deps /opt/vllm-v018 && \
+    /usr/local/python3.11.14/bin/python -m pip install --no-build-isolation --no-deps /opt/vllm-ascend-v018 && \
+    /usr/local/python3.11.14/bin/python -c "import importlib.metadata as m, sys; assert sys.version_info[:2] == (3, 11); assert m.version('vllm') == '0.18.0'; assert m.version('vllm-ascend') == '0.18.0'; assert m.version('torch').startswith('2.9.0'); assert m.version('torch-npu').startswith('2.9.0')"
+
+# The v0.18 OPAPI wrapper resolves custom symbols from the process-global
+# namespace. CANN 9.1 correctly ships them in the plugin vendor library rather
+# than the system libopapi, so preload the exact rebuilt v0.18 vendor library.
+ENV LD_PRELOAD=/usr/local/python3.11.14/lib/python3.11/site-packages/vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/op_api/lib/libcust_opapi.so
+
+WORKDIR /vllm-workspace

--- a/scripts/run-current-ascend-same-spec.sh
+++ b/scripts/run-current-ascend-same-spec.sh
@@ -33,6 +33,10 @@ CURRENT_RUNTIME_CWD=${CURRENT_RUNTIME_CWD:-"/data/shared_datasets/vllm-hust-benc
 CURRENT_VLLM_HUST_REPO=${CURRENT_VLLM_HUST_REPO:-"$WORKSPACE_ROOT/vllm-hust"}
 CURRENT_VLLM_ASCEND_HUST_REPO=${CURRENT_VLLM_ASCEND_HUST_REPO:-"$WORKSPACE_ROOT/vllm-ascend-hust"}
 CURRENT_RUNTIME_PYTHONPATH=${CURRENT_RUNTIME_PYTHONPATH:-}
+CURRENT_RUNTIME_SOURCE_MODE=${CURRENT_RUNTIME_SOURCE_MODE:-worktree}
+CURRENT_RUNTIME_EXPECT_CUSTOM_OP_VENDOR=${CURRENT_RUNTIME_EXPECT_CUSTOM_OP_VENDOR:-0}
+CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME=${CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME:-custom_transformer}
+export CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME
 CURRENT_ENV_PREFIX=${CURRENT_ENV_PREFIX:-"/root/miniconda3/envs/vllm-hust-dev"}
 CURRENT_RUNTIME_PYTHON=${CURRENT_RUNTIME_PYTHON:-"$CURRENT_ENV_PREFIX/bin/python"}
 CURRENT_VLLM_CACHE_ROOT=${CURRENT_VLLM_CACHE_ROOT:-"/data/shared_datasets/vllm-hust-benchmark/current-ascend-same-spec-cache"}
@@ -100,16 +104,29 @@ NPU_OOM_EXIT_CODE=87
 SERVER_PID=""
 RUNNER_LOCK_FD=""
 
-if [[ "$CURRENT_USE_MANAGED_SERVER" == "1" ]]; then
-  CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_HUST_REPO"
-else
-  CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_ASCEND_HUST_REPO:$CURRENT_VLLM_HUST_REPO"
-fi
-if [[ -n "$CURRENT_RUNTIME_PYTHONPATH" ]]; then
-  CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH:$CURRENT_RUNTIME_PYTHONPATH"
-else
-  CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH"
-fi
+case "$CURRENT_RUNTIME_SOURCE_MODE" in
+  worktree)
+    if [[ "$CURRENT_USE_MANAGED_SERVER" == "1" ]]; then
+      CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_HUST_REPO"
+    else
+      CURRENT_RUNTIME_SOURCE_PYTHONPATH="$CURRENT_VLLM_ASCEND_HUST_REPO:$CURRENT_VLLM_HUST_REPO"
+    fi
+    if [[ -n "$CURRENT_RUNTIME_PYTHONPATH" ]]; then
+      CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH:$CURRENT_RUNTIME_PYTHONPATH"
+    else
+      CURRENT_RUNTIME_PYTHONPATH="$CURRENT_RUNTIME_SOURCE_PYTHONPATH"
+    fi
+    ;;
+  image-native)
+    # Release images may contain generated custom-operator payloads that are
+    # deliberately absent from a Git source checkout. Do not shadow those
+    # installed packages with raw worktrees.
+    ;;
+  *)
+    echo "Unsupported CURRENT_RUNTIME_SOURCE_MODE: $CURRENT_RUNTIME_SOURCE_MODE" >&2
+    exit 2
+    ;;
+esac
 
 if [[ ! -x "$CURRENT_RUNTIME_PYTHON" ]]; then
   echo "CURRENT_RUNTIME_PYTHON is not executable: $CURRENT_RUNTIME_PYTHON" >&2
@@ -494,6 +511,42 @@ run_in_current_runtime() {
     PYTHONPATH="$pythonpath_prefix${PYTHONPATH:+:$PYTHONPATH}" \
       "$@"
   )
+}
+
+validate_runtime_packaging() {
+  if [[ "$CURRENT_RUNTIME_EXPECT_CUSTOM_OP_VENDOR" != "1" ]]; then
+    return 0
+  fi
+
+  run_in_current_runtime "$CURRENT_RUNTIME_PYTHONPATH" \
+    "$CURRENT_RUNTIME_PYTHON" - <<'PY'
+from importlib.util import find_spec
+import os
+from pathlib import Path
+
+spec = find_spec("vllm_ascend")
+if spec is None or not spec.submodule_search_locations:
+    raise SystemExit("vllm_ascend package is unavailable in the selected runtime")
+
+package_root = Path(next(iter(spec.submodule_search_locations))).resolve()
+vendor_root = (
+    package_root
+    / "_cann_ops_custom"
+    / "vendors"
+    / os.environ["CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME"]
+)
+required = (
+    vendor_root / "op_api" / "lib" / "libcust_opapi.so",
+    vendor_root / "op_proto" / "inc" / "add_rms_norm_bias_proto.h",
+)
+missing = [str(path) for path in required if not path.is_file()]
+if missing:
+    raise SystemExit(
+        "selected runtime shadows or omits packaged Ascend custom operators: "
+        + ", ".join(missing)
+    )
+print(f"[same-spec-current] verified packaged Ascend custom operators: {vendor_root}")
+PY
 }
 
 run_server_command() {
@@ -1072,6 +1125,8 @@ kill_server() {
 }
 
 trap kill_server EXIT
+
+validate_runtime_packaging
 
 mkdir -p "$RESULT_DIR"
 mkdir -p "$CURRENT_VLLM_CACHE_ROOT"

--- a/scripts/run_vllm_cli_compat.py
+++ b/scripts/run_vllm_cli_compat.py
@@ -65,11 +65,7 @@ def install_offline_graph_guard() -> None:
 
     from vllm import LLM
 
-    original_from_engine_args = LLM.from_engine_args
-
-    @classmethod
-    def guarded_from_engine_args(_cls, engine_args):
-        llm = original_from_engine_args(engine_args)
+    def record_proof(llm: object) -> None:
         proof = offline_graph_proof(llm)
         require_offline_graph(proof)
         output_path = Path(proof_file)
@@ -78,9 +74,26 @@ def install_offline_graph_guard() -> None:
             json.dumps(proof, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        return llm
 
-    LLM.from_engine_args = guarded_from_engine_args
+    if hasattr(LLM, "from_engine_args"):
+        original_from_engine_args = LLM.from_engine_args
+
+        @classmethod
+        def guarded_from_engine_args(_cls, engine_args):
+            llm = original_from_engine_args(engine_args)
+            record_proof(llm)
+            return llm
+
+        LLM.from_engine_args = guarded_from_engine_args
+        return
+
+    original_init = LLM.__init__
+
+    def guarded_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        record_proof(self)
+
+    LLM.__init__ = guarded_init
 
 
 def run_single_benchmark(argv: list[str]) -> int | None:

--- a/tests/test_current_same_spec_script.py
+++ b/tests/test_current_same_spec_script.py
@@ -131,6 +131,42 @@ def test_current_same_spec_runner_defaults_to_one_start_attempt() -> None:
     assert "SERVER_START_RETRIES=${SERVER_START_RETRIES:-1}" in script
 
 
+def test_current_same_spec_runner_supports_image_native_runtime() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+
+    assert (
+        "CURRENT_RUNTIME_SOURCE_MODE=${CURRENT_RUNTIME_SOURCE_MODE:-worktree}" in script
+    )
+    assert "image-native)" in script
+    assert "Do not shadow those" in script
+    image_native_block = script[script.index("  image-native)") :]
+    image_native_block = image_native_block[: image_native_block.index("  *)")]
+    assert "CURRENT_RUNTIME_SOURCE_PYTHONPATH=" not in image_native_block
+    assert "CURRENT_VLLM_ASCEND_HUST_REPO:" not in image_native_block
+
+
+def test_current_same_spec_runner_can_require_packaged_ascend_custom_ops() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    validator = _function_text(script, "validate_runtime_packaging")
+
+    assert "CURRENT_RUNTIME_EXPECT_CUSTOM_OP_VENDOR" in validator
+    assert 'find_spec("vllm_ascend")' in validator
+    assert '"libcust_opapi.so"' in validator
+    assert '"add_rms_norm_bias_proto.h"' in validator
+    assert "shadows or omits packaged Ascend custom operators" in validator
+    assert script.index("validate_runtime_packaging\n") < script.index(
+        'mkdir -p "$RESULT_DIR"'
+    )
+
+
+def test_current_same_spec_runner_accepts_versioned_custom_op_vendor_name() -> None:
+    script = RUNNER.read_text(encoding="utf-8")
+    validator = _function_text(script, "validate_runtime_packaging")
+
+    assert "CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME" in script
+    assert "CURRENT_RUNTIME_CUSTOM_OP_VENDOR_NAME" in validator
+
+
 def test_current_same_spec_runner_requires_offline_graph_proof() -> None:
     script = RUNNER.read_text(encoding="utf-8")
 

--- a/tests/test_v023_benchmark_image.py
+++ b/tests/test_v023_benchmark_image.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+def test_v023_benchmark_image_only_adds_frozen_benchmark_clients() -> None:
+    root = Path(__file__).resolve().parents[1]
+    dockerfile = (root / "docker" / "Dockerfile.vllm-ascend-v023-bench").read_text(
+        encoding="utf-8"
+    )
+
+    assert "quay.io/ascend/vllm-ascend:v0.23.0-openeuler" in dockerfile
+    assert '"datasets==3.3.0"' in dockerfile
+    assert '"xxhash==3.6.0"' in dockerfile
+    assert "pip install --no-cache-dir" in dockerfile
+    assert "vllm-ascend" not in dockerfile.split("RUN", maxsplit=1)[1]
+    assert "torch-npu" not in dockerfile.split("RUN", maxsplit=1)[1]
+
+
+def test_v018_runtime_is_rebuilt_on_the_official_v023_container() -> None:
+    root = Path(__file__).resolve().parents[1]
+    dockerfile = (root / "docker" / "Dockerfile.vllm-v018-on-ascend-v023").read_text(
+        encoding="utf-8"
+    )
+
+    assert "FROM quay.io/ascend/vllm-ascend:v0.23.0-openeuler" in dockerfile
+    assert "COPY --from=v018-python /usr/local/python3.11.14" in dockerfile
+    assert "pip install --no-build-isolation --no-deps /opt/vllm-v018" in dockerfile
+    assert (
+        "pip install --no-build-isolation --no-deps /opt/vllm-ascend-v018" in dockerfile
+    )
+    assert "RT_LIMIT_TYPE_SIMT_DVG_WARP_STACK_SIZE" in dockerfile
+    assert "LD_PRELOAD=" in dockerfile
+    assert "libcust_opapi.so" in dockerfile

--- a/tests/test_vllm_cli_compat.py
+++ b/tests/test_vllm_cli_compat.py
@@ -1,8 +1,13 @@
+import inspect
 from types import SimpleNamespace
 
 import pytest
 
-from scripts.run_vllm_cli_compat import offline_graph_proof, require_offline_graph
+from scripts.run_vllm_cli_compat import (
+    install_offline_graph_guard,
+    offline_graph_proof,
+    require_offline_graph,
+)
 
 
 def _fake_llm(*, enforce_eager: bool, mode: str, cudagraph_mode: str) -> object:
@@ -52,3 +57,11 @@ def test_offline_graph_proof_rejects_eager_or_disabled_graph(
 
     with pytest.raises(RuntimeError, match="eager/non-graph"):
         require_offline_graph(proof)
+
+
+def test_offline_graph_guard_supports_pre_from_engine_args_llm_api() -> None:
+    source = inspect.getsource(install_offline_graph_guard)
+
+    assert 'hasattr(LLM, "from_engine_args")' in source
+    assert "original_init = LLM.__init__" in source
+    assert "record_proof(self)" in source


### PR DESCRIPTION
## Summary

Make the corrected Ascend v0.23-container benchmark path reproducible in the benchmark repository.

- Add a versioned benchmark-client layer for the official v0.23 Ascend image, pinning `datasets==3.3.0` and `xxhash==3.6.0`.
- Add the reproducible vLLM v0.18 rebuild on the official v0.23 container/CANN stack.
- Support image-native runtime packages without shadowing packaged custom-operator assets with raw source worktrees.
- Fail before measurement when required packaged Ascend custom operators are missing.
- Support both legacy and current offline `LLM` construction APIs while preserving graph-mode proof.

## Root cause

The previous harness overlaid source worktrees on release images and could hide generated custom-op packages. It also treated optional benchmark clients as implicit, which caused HF-backed workloads and prefix hashing to fail only after engine startup.

## Validation

- 32 targeted tests passed.
- Ruff checks and formatting checks passed for changed tests.
- Bash syntax validation passed.
- Diff whitespace validation passed.
- Both runtime images were built and used for real 910B2 measurements.
