### PR TITLE
ci: verify post-cleanup benchmark protection

### DIFF
--- a/tests/test_website_contract.py
+++ b/tests/test_website_contract.py
@@ -1,5 +1,7 @@
 """Contract tests for website fixture consumption.
 
+CI canary: verify the current main branch protection test job.
+
 These tests verify that:
 1. Each fixture category produces the expected trend_status classification
 2. The website can stably distinguish all six fixture categories


### PR DESCRIPTION
## Summary

  Create a no-op canary change to verify that the `Protect main` Ruleset
  applies to `main` and requires the retained `tests` job after legacy
  benchmark CI cleanup.

  This PR is intentionally not a product change and should not be merged.

  ## Repository Scope

  - [x] `vllm-hust-benchmark`

  ## Validation

  - Confirm the required `tests` check runs and passes.
  - Confirm current correctness checks complete.
  - Confirm no retired Merge Gate, 112, HF publication, or website dispatch check is reported.

  ## Risks

  No benchmark data, baseline branch, publication, or external validation service is changed.